### PR TITLE
Update travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: go
 
 go:
   - "1.x"
+
+# have an empty install to avoid travis doing a go get
+install: []


### PR DESCRIPTION
since comitting vendor and removing the `install` script in the travis config travis is now running `go get` on each test run-- which is unnecessary