### PR TITLE
Fix bug where NodeReplacer wouldn't replace a single aggregate

### DIFF
--- a/proxystorage/util.go
+++ b/proxystorage/util.go
@@ -59,13 +59,13 @@ func (o *OffsetRemover) Visit(node promql.Node, _ []promql.Node) (promql.Visitor
 // Use given func to determine if something is in there or notret := &promql.VectorSelector{Offset: offset}
 type BooleanFinder struct {
 	Func  func(promql.Node) bool
-	Found bool
+	Found int
 }
 
 func (f *BooleanFinder) Visit(node promql.Node, _ []promql.Node) (promql.Visitor, error) {
 	if f.Func(node) {
-		f.Found = true
-		return nil, nil
+		f.Found++
+		return f, nil
 	}
 	return f, nil
 }


### PR DESCRIPTION
NodeReplacer needs to ensure that there aren't children that are
AggregateExpr, but the Walk call includes the parent node. To handle
this case we change aggFinder to get a count of aggregates that it
finds, and allow 1 if the base node is an aggregate.