### PR TITLE
Add more explicit logging RE recording rules

### DIFF
--- a/proxystorage/proxy.go
+++ b/proxystorage/proxy.go
@@ -120,6 +120,7 @@ func (a *appenderStub) Commit() error { return nil }
 func (a *appenderStub) Rollback() error { return nil }
 
 func (p *ProxyStorage) Appender() (storage.Appender, error) {
+	logrus.Warning("Promxy cannot *write* metrics but is being asked to. This is likely due to a RecordingRule")
 	return &appenderStub{}, nil
 }
 


### PR DESCRIPTION
Promxy doesn't currently support storing recording rules, because
prometheus has no remote write API -- meaning promxy has no place to put
the metrics. This used to log (before the 2.x upgrade)-- but that was
dropped and this is confusing again.

This patch adds 2 layers of logging. (1) in main it checks for recording
rules on start (where it will fatal log) and on reload (error log) (2)
the ProxyStorage.Appender() now also logs a warning. This will remain in
place until #79 (the long term plan) is figured out and executed

Fixes #74