### PR TITLE
Handle status codes from prometheus returns

### DIFF
--- a/proxyquerier/querier.go
+++ b/proxyquerier/querier.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jacksontj/promxy/config"
 	"github.com/jacksontj/promxy/promclient"
 	"github.com/jacksontj/promxy/servergroup"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/timestamp"
@@ -47,7 +48,7 @@ func (h *ProxyQuerier) Select(selectParams *storage.SelectParams, matchers ...*l
 		result, err = h.ServerGroups.GetValue(h.Ctx, timestamp.Time(selectParams.Start), timestamp.Time(selectParams.End), matchers)
 	}
 	if err != nil {
-		return nil, err
+		return nil, errors.Cause(err)
 	}
 
 	iterators := promclient.IteratorsForValue(result)
@@ -72,7 +73,7 @@ func (h *ProxyQuerier) LabelValues(name string) ([]string, error) {
 
 	result, err := h.ServerGroups.GetValuesForLabelName(h.Ctx, "/api/v1/label/"+string(name)+"/values")
 	if err != nil {
-		return nil, err
+		return nil, errors.Cause(err)
 	}
 
 	ret := make([]string, len(result))

--- a/proxystorage/proxy.go
+++ b/proxystorage/proxy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jacksontj/promxy/promclient"
 	"github.com/jacksontj/promxy/proxyquerier"
 	"github.com/jacksontj/promxy/servergroup"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/prometheus/prometheus/promql"
@@ -230,7 +231,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 
 			result, err = serverGroups.GetData(ctx, urlBase, values)
 			if err != nil {
-				return nil, err
+				return nil, errors.Cause(err)
 			}
 
 		// Convert avg into sum() / count()
@@ -275,7 +276,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 
 			result, err = serverGroups.GetData(ctx, urlBase, values)
 			if err != nil {
-				return nil, err
+				return nil, errors.Cause(err)
 			}
 			// TODO: have a reverse method in promql/lex.go
 			n.Op = 41 // SUM
@@ -327,7 +328,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 
 		result, err := serverGroups.GetData(ctx, urlBase, values)
 		if err != nil {
-			return nil, err
+			return nil, errors.Cause(err)
 		}
 		iterators := promclient.IteratorsForValue(result)
 		series := make([]storage.Series, len(iterators))

--- a/servergroup/servergroup.go
+++ b/servergroup/servergroup.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jacksontj/promxy/promclient"
 	"github.com/jacksontj/promxy/promhttputil"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	config_util "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
@@ -369,7 +370,7 @@ func (s *ServerGroup) RemoteRead(ctx context.Context, start, end time.Time, matc
 	}
 
 	if errCount != 0 && errCount == len(state.Targets) {
-		return nil, fmt.Errorf("Unable to fetch from downstream servers, lastError: %s", lastError.Error())
+		return nil, errors.Wrap(lastError, "Unable to fetch from downstream servers")
 	}
 
 	return result, nil
@@ -459,7 +460,7 @@ func (s *ServerGroup) GetData(ctx context.Context, path string, inValues url.Val
 	}
 
 	if errCount != 0 && errCount == len(state.Targets) {
-		return nil, fmt.Errorf("Unable to fetch from downstream servers, lastError: %s", lastError.Error())
+		return nil, errors.Wrap(lastError, "Unable to fetch from downstream servers")
 	}
 
 	return result, nil
@@ -520,7 +521,7 @@ func (s *ServerGroup) GetValuesForLabelName(ctx context.Context, path string) ([
 
 	// If we got only errors, lets return that
 	if errCount == len(state.Targets) {
-		return nil, fmt.Errorf("Unable to fetch from downstream servers, lastError: %s", lastError.Error())
+		return nil, errors.Wrap(lastError, "Unable to fetch from downstream servers")
 	}
 
 	return result, nil
@@ -607,7 +608,7 @@ func (s *ServerGroup) GetSeries(ctx context.Context, start, end time.Time, match
 	}
 
 	if errCount != 0 && errCount == len(state.Targets) {
-		return nil, fmt.Errorf("Unable to fetch from downstream servers, lastError: %s", lastError.Error())
+		return nil, errors.Wrap(lastError, "Unable to fetch from downstream servers")
 	}
 
 	return result, nil

--- a/servergroup/servergroups.go
+++ b/servergroup/servergroups.go
@@ -2,12 +2,12 @@ package servergroup
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"time"
 
 	"github.com/jacksontj/promxy/promclient"
 	"github.com/jacksontj/promxy/promhttputil"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
@@ -59,7 +59,7 @@ func (s ServerGroups) GetValue(ctx context.Context, start, end time.Time, matche
 
 	// If we got only errors, lets return that
 	if errCount == len(s) {
-		return nil, fmt.Errorf("Unable to fetch from downstream servers, lastError: %s", lastError.Error())
+		return nil, errors.Wrap(lastError, "Unable to fetch from downstream servers")
 	}
 
 	return result, nil
@@ -109,7 +109,7 @@ func (s ServerGroups) GetData(ctx context.Context, path string, values url.Value
 
 	// If we got only errors, lets return that
 	if errCount == len(s) {
-		return nil, fmt.Errorf("Unable to fetch from downstream servers, lastError: %s", lastError.Error())
+		return nil, errors.Wrap(lastError, "Unable to fetch from downstream servers")
 	}
 
 	return result, nil
@@ -158,7 +158,7 @@ func (s ServerGroups) GetValuesForLabelName(ctx context.Context, path string) ([
 
 	// If we got only errors, lets return that
 	if errCount == len(s) {
-		return nil, fmt.Errorf("Unable to fetch from downstream servers, lastError: %s", lastError.Error())
+		return nil, errors.Wrap(lastError, "Unable to fetch from downstream servers")
 	}
 
 	return result, nil
@@ -208,7 +208,7 @@ func (s ServerGroups) GetSeries(ctx context.Context, start, end time.Time, match
 
 	// If we got only errors, lets return that
 	if errCount == len(s) {
-		return nil, fmt.Errorf("Unable to fetch from downstream servers, lastError: %s", lastError.Error())
+		return nil, errors.Wrap(lastError, "Unable to fetch from downstream servers")
 	}
 
 	return result, nil


### PR DESCRIPTION
The various status codes have different meaning, so we'll convert those
into the errors that the prom API is expecting so that promxy will
return similar status codes

Fixes #101