### PR TITLE
Don't log Fatal when http server exits

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -363,7 +363,10 @@ func main() {
 	go func() {
 		logrus.Infof("promxy starting")
 		if err := srv.ListenAndServe(); err != nil {
-			log.Fatalf("Error listening: %v", err)
+			if err == http.ErrServerClosed {
+				return
+			}
+			log.Errorf("Error listening: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
Otherwise we exit before letting the server do its graceful shutdown.