### PR TITLE
Add timerange options to servergroups

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -51,6 +51,23 @@ promxy:
         dial_timeout: 1s
         tls_config:
           insecure_skip_verify: true
+      
+      # relative_time_range defines a relative-to-now time range that this server group contains.
+      # this is completely optional and start/end are both optional as well
+      # an example is if this servergroup only has the most recent 3h of data 
+      # the "start" would be -3h and the end would be left out
+      relative_time_range:
+        start: -3h
+        end: -1h
+
+      # absolute_time_range defines an absolute time range that this server group contains.
+      # this is completely optional and start/end are both optional as well
+      # and example is if the servergroup has been deprecated and is no longer receiving data
+      # you could set the specific times that it has data for.
+      absolute_time_range:
+        start: 2009-10-10 23:00:00 +0000 UTC m=+0.000000001
+        end: 2009-11-10 23:00:00 +0000 UTC m=+0.000000001
+
     # as many additional server groups as you have
     - static_configs:
         - targets:

--- a/promclient/recover.go
+++ b/promclient/recover.go
@@ -1,0 +1,64 @@
+package promclient
+
+import (
+	"context"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// recoverAPI simply recovers all panics and returns them as errors
+// this is used for testing
+type recoverAPI struct{ API }
+
+// LabelValues performs a query for the values of the given label.
+func (api *recoverAPI) LabelValues(ctx context.Context, label string) (v model.LabelValues, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	return api.API.LabelValues(ctx, label)
+}
+
+// Query performs a query for the given time.
+func (api *recoverAPI) Query(ctx context.Context, query string, ts time.Time) (v model.Value, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	return api.API.Query(ctx, query, ts)
+}
+
+// QueryRange performs a query for the given range.
+func (api *recoverAPI) QueryRange(ctx context.Context, query string, r v1.Range) (v model.Value, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	return api.API.QueryRange(ctx, query, r)
+}
+
+// Series finds series by label matchers.
+func (api *recoverAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) (v []model.LabelSet, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	return api.API.Series(ctx, matches, startTime, endTime)
+}
+
+// GetValue loads the raw data for a given set of matchers in the time range
+func (api *recoverAPI) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (v model.Value, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	return api.API.GetValue(ctx, start, end, matchers)
+}

--- a/promclient/timefilter.go
+++ b/promclient/timefilter.go
@@ -1,0 +1,110 @@
+package promclient
+
+import (
+	"context"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// AbsoluteTimeFilter will filter queries out (return nil,nil) for all queries outside the given times
+type AbsoluteTimeFilter struct {
+	API
+	Start, End time.Time
+}
+
+// Query performs a query for the given time.
+func (tf *AbsoluteTimeFilter) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
+	if (!tf.Start.IsZero() && ts.Before(tf.Start)) || (!tf.End.IsZero() && ts.After(tf.End)) {
+		return nil, nil
+	}
+
+	return tf.API.Query(ctx, query, ts)
+}
+
+// QueryRange performs a query for the given range.
+func (tf *AbsoluteTimeFilter) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, error) {
+	if (!tf.Start.IsZero() && r.End.Before(tf.Start)) || (!tf.End.IsZero() && r.Start.After(tf.End)) {
+		return nil, nil
+	}
+
+	return tf.API.QueryRange(ctx, query, r)
+}
+
+// Series finds series by label matchers.
+func (tf *AbsoluteTimeFilter) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
+	if (!tf.Start.IsZero() && endTime.Before(tf.Start)) || (!tf.End.IsZero() && startTime.After(tf.End)) {
+		return nil, nil
+	}
+	return tf.API.Series(ctx, matches, startTime, endTime)
+}
+
+// GetValue loads the raw data for a given set of matchers in the time range
+func (tf *AbsoluteTimeFilter) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (model.Value, error) {
+	if (!tf.Start.IsZero() && end.Before(tf.Start)) || (!tf.End.IsZero() && start.After(tf.End)) {
+		return nil, nil
+	}
+
+	return tf.API.GetValue(ctx, start, end, matchers)
+}
+
+// RelativeTimeFilter will filter queries out (return nil,nil) for all queries outside the given durations relative to time.Now()
+type RelativeTimeFilter struct {
+	API
+	Start, End *time.Duration
+}
+
+func (tf *RelativeTimeFilter) window() (time.Time, time.Time) {
+	now := time.Now()
+
+	var start, end time.Time
+	if tf.Start != nil {
+		start = now.Add(*tf.Start)
+	}
+	if tf.End != nil {
+		end = now.Add(*tf.End)
+	}
+
+	return start, end
+}
+
+// Query performs a query for the given time.
+func (tf *RelativeTimeFilter) Query(ctx context.Context, query string, ts time.Time) (model.Value, error) {
+	tfStart, tfEnd := tf.window()
+	if (!tfStart.IsZero() && ts.Before(tfStart)) || (!tfEnd.IsZero() && ts.After(tfEnd)) {
+		return nil, nil
+	}
+
+	return tf.API.Query(ctx, query, ts)
+}
+
+// QueryRange performs a query for the given range.
+func (tf *RelativeTimeFilter) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, error) {
+	tfStart, tfEnd := tf.window()
+	if (!tfStart.IsZero() && r.End.Before(tfStart)) || (!tfEnd.IsZero() && r.Start.After(tfEnd)) {
+		return nil, nil
+	}
+
+	return tf.API.QueryRange(ctx, query, r)
+}
+
+// Series finds series by label matchers.
+func (tf *RelativeTimeFilter) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, error) {
+	tfStart, tfEnd := tf.window()
+	if (!tfStart.IsZero() && endTime.Before(tfStart)) || (!tfEnd.IsZero() && startTime.After(tfEnd)) {
+		return nil, nil
+	}
+	return tf.API.Series(ctx, matches, startTime, endTime)
+}
+
+// GetValue loads the raw data for a given set of matchers in the time range
+func (tf *RelativeTimeFilter) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (model.Value, error) {
+	tfStart, tfEnd := tf.window()
+	if (!tfStart.IsZero() && end.Before(tfStart)) || (!tfEnd.IsZero() && start.After(tfEnd)) {
+		return nil, nil
+	}
+
+	return tf.API.GetValue(ctx, start, end, matchers)
+}

--- a/promclient/timefilter_test.go
+++ b/promclient/timefilter_test.go
@@ -1,0 +1,147 @@
+package promclient
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+type timeFilterTestCase struct {
+	validTimes   []time.Time
+	invalidTimes []time.Time
+
+	validRanges   []v1.Range
+	invalidRanges []v1.Range
+}
+
+func timefilterTest(t *testing.T, api API, testCase timeFilterTestCase) {
+	for i, validTime := range testCase.validTimes {
+		t.Run(fmt.Sprintf("validTime_%d", i), func(t *testing.T) {
+			t.Run("query", func(t *testing.T) {
+				if _, err := api.Query(context.TODO(), "", validTime); err == nil {
+					t.Fatalf("Missing call to API")
+				}
+			})
+		})
+	}
+	for i, invalidTime := range testCase.invalidTimes {
+		t.Run(fmt.Sprintf("invalidTime_%d", i), func(t *testing.T) {
+			t.Run("query", func(t *testing.T) {
+				if _, err := api.Query(context.TODO(), "", invalidTime); err != nil {
+					t.Fatalf("Unexpected call to API")
+				}
+			})
+		})
+	}
+
+	for i, r := range testCase.validRanges {
+		t.Run(fmt.Sprintf("validRange_%d", i), func(t *testing.T) {
+			t.Run("query_range", func(t *testing.T) {
+				if _, err := api.QueryRange(context.TODO(), "", v1.Range{Start: r.Start, End: r.End}); err == nil {
+					t.Fatalf("Missing call to API")
+				}
+			})
+			t.Run("series", func(t *testing.T) {
+				if _, err := api.Series(context.TODO(), nil, r.Start, r.End); err == nil {
+					t.Fatalf("Missing call to API")
+				}
+			})
+			t.Run("getvalue", func(t *testing.T) {
+				if _, err := api.GetValue(context.TODO(), r.Start, r.End, nil); err == nil {
+					t.Fatalf("Missing call to API")
+				}
+			})
+		})
+	}
+	for i, r := range testCase.invalidRanges {
+		t.Run(fmt.Sprintf("invalidRange_%d", i), func(t *testing.T) {
+			t.Run("query_range", func(t *testing.T) {
+				if _, err := api.QueryRange(context.TODO(), "", v1.Range{Start: r.Start, End: r.End}); err != nil {
+					t.Fatalf("Unexpected call to API")
+				}
+			})
+			t.Run("series", func(t *testing.T) {
+				if _, err := api.Series(context.TODO(), nil, r.Start, r.End); err != nil {
+					t.Fatalf("Unexpected call to API")
+				}
+			})
+			t.Run("getvalue", func(t *testing.T) {
+				if _, err := api.GetValue(context.TODO(), r.Start, r.End, nil); err != nil {
+					t.Fatalf("Unexpected call to API")
+				}
+			})
+		})
+	}
+}
+
+func TestAbsoluteTimeFilter(t *testing.T) {
+	now := time.Now()
+
+	start := now.Add(time.Hour * -2)
+	end := now.Add(time.Hour * -1)
+
+	api := &AbsoluteTimeFilter{
+		API:   &recoverAPI{nil},
+		Start: start,
+		End:   end,
+	}
+	timefilterTest(t, api, timeFilterTestCase{
+		validTimes: []time.Time{
+			start,
+			end,
+			start.Add(time.Minute),
+		},
+		invalidTimes: []time.Time{
+			now,
+			start.Add(time.Minute * -1),
+		},
+		validRanges: []v1.Range{
+			{Start: start, End: end},
+			{Start: start.Add(time.Hour * -1), End: end},
+			{Start: start, End: end.Add(time.Hour)},
+		},
+		invalidRanges: []v1.Range{
+			{Start: now, End: now},
+			{Start: start.Add(time.Hour * -10), End: end.Add(time.Hour * -9)},
+		},
+	})
+}
+
+func TestRelativeTimeFilter(t *testing.T) {
+	now := time.Now()
+
+	startOffset := time.Hour * -2
+	endOffset := time.Hour * -1
+
+	start := now.Add(startOffset)
+	end := now.Add(endOffset)
+
+	api := &RelativeTimeFilter{
+		API:   &recoverAPI{nil},
+		Start: &startOffset,
+		End:   &endOffset,
+	}
+	timefilterTest(t, api, timeFilterTestCase{
+		validTimes: []time.Time{
+			start.Add(time.Minute),
+			end,
+		},
+		invalidTimes: []time.Time{
+			now,
+			start.Add(time.Minute * -1),
+		},
+		validRanges: []v1.Range{
+			{Start: start, End: end},
+			{Start: start.Add(time.Hour * -1), End: end},
+			{Start: start, End: end.Add(time.Hour)},
+		},
+		invalidRanges: []v1.Range{
+			{Start: now, End: now},
+			{Start: start.Add(time.Hour * -10), End: end.Add(time.Hour * -9)},
+		},
+	})
+
+}

--- a/servergroup/servergroup.go
+++ b/servergroup/servergroup.go
@@ -2,6 +2,7 @@ package servergroup
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -140,6 +141,25 @@ func (s *ServerGroup) Sync() {
 						apiClient = &promclient.PromAPIRemoteRead{promAPIClient, remoteStorageClient}
 					} else {
 						apiClient = promAPIClient
+					}
+
+					// Optionally add time range layers
+					if s.Cfg.AbsoluteTimeRangeConfig != nil {
+						fmt.Println("absolute")
+						apiClient = &promclient.AbsoluteTimeFilter{
+							API:   apiClient,
+							Start: s.Cfg.AbsoluteTimeRangeConfig.Start,
+							End:   s.Cfg.AbsoluteTimeRangeConfig.End,
+						}
+					}
+
+					if s.Cfg.RelativeTimeRangeConfig != nil {
+						fmt.Println("relative")
+						apiClient = &promclient.RelativeTimeFilter{
+							API:   apiClient,
+							Start: s.Cfg.RelativeTimeRangeConfig.Start,
+							End:   s.Cfg.RelativeTimeRangeConfig.End,
+						}
 					}
 
 					// We remove all private labels after we set the target entry


### PR DESCRIPTION
This adds 2 optional config flags to a servergroup; relative_time_range and absolute_time_range. Both of these provide a way to scope the timerange of a given servergroup such that if a query is outside the time window promxy will not query the given servergroup.

Implements #88