### PR TITLE
Add workaround to upstream boundary time issue

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -548,7 +548,7 @@
 
 [[projects]]
   branch = "release-2.10_fork_promxy"
-  digest = "1:a5b6e8d26f3bf9e4831da81621a52f7f1a57d01f6894d9176c8d9400b81df85e"
+  digest = "1:af616e485ce6fadbf64233a7bd4f2012801b1cda27316ef74657f591bcbdcc8f"
   name = "github.com/prometheus/prometheus"
   packages = [
     "config",
@@ -597,7 +597,7 @@
     "web/ui",
   ]
   pruneopts = "NUT"
-  revision = "ce3f0b004d19550b0e72c1b1cf2c22df4a07dee6"
+  revision = "a1adb11ceba7fa0c55008e6dbd33559bd55d4e41"
   source = "github.com/jacksontj/prometheus"
 
 [[projects]]

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,11 +11,16 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+var DefaultPromxyConfig = PromxyConfig{
+	BoundaryTimeWorkaround: true,
+}
+
 // ConfigFromFile loads a config file at path
 func ConfigFromFile(path string) (*Config, error) {
 	// load the config file
 	cfg := &Config{
-		PromConfig: config.DefaultConfig,
+		PromConfig:   config.DefaultConfig,
+		PromxyConfig: DefaultPromxyConfig,
 	}
 	configBytes, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -45,4 +50,9 @@ type Config struct {
 type PromxyConfig struct {
 	// Config for each of the server groups promxy is configured to aggregate
 	ServerGroups []*servergroup.Config `yaml:"server_groups"`
+
+	// BoundaryTimeWorkaround enables a workaround to prometheus' internal boundary
+	// times being un-supported serverside. Newer versions of prometheus (2.11+)
+	// don't need this workaround enabled as it was worked around server-side.
+	BoundaryTimeWorkaround bool `yaml:"boundary_time_workaround"`
 }

--- a/pkg/promclient/multi_api.go
+++ b/pkg/promclient/multi_api.go
@@ -3,6 +3,7 @@ package promclient
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"strings"
 	"time"
 
@@ -257,6 +258,8 @@ func (m *MultiAPI) LabelNames(ctx context.Context) ([]string, api.Warnings, erro
 	for k := range result {
 		stringResult = append(stringResult, k)
 	}
+
+	sort.Strings(stringResult)
 
 	return stringResult, warnings.Warnings(), nil
 }

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -3,6 +3,7 @@ package proxystorage
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"sync/atomic"
 	"time"
@@ -136,9 +137,33 @@ func (p *ProxyStorage) ApplyConfig(c *proxyconfig.Config) error {
 	return nil
 }
 
+// Stdlib's time parser can only handle 4 digit years. As a workaround until
+// that is fixed we want to at least support our own boundary times.
+// Context: https://github.com/prometheus/client_golang/issues/614
+// Upstream issue: https://github.com/golang/go/issues/20555
+// Promxy issue for context: https://github.com/jacksontj/promxy/issues/186
+var (
+	minTime = timestamp.FromTime(time.Unix(math.MinInt64/1000+62135596801, 0))
+	maxTime = timestamp.FromTime(time.Unix(math.MaxInt64/1000-62135596801, 999999999))
+
+	workaroundMinTime = timestamp.FromTime(time.Unix(0, 0))            // "1970-01-01T00:00:00.0Z"
+	workaroundMaxTime = timestamp.FromTime(time.Unix(253402300799, 0)) // "9999-12-31T23:59:59.999999999Z"
+)
+
 // Querier returns a new Querier on the storage.
 func (p *ProxyStorage) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 	state := p.GetState()
+
+	if state.cfg.BoundaryTimeWorkaround {
+		if mint == minTime {
+			mint = workaroundMinTime
+		}
+
+		if maxt == maxTime {
+			maxt = workaroundMaxTime
+		}
+	}
+
 	return &proxyquerier.ProxyQuerier{
 		ctx,
 		timestamp.Time(mint),

--- a/vendor/github.com/prometheus/prometheus/discovery/kubernetes/pod.go
+++ b/vendor/github.com/prometheus/prometheus/discovery/kubernetes/pod.go
@@ -141,6 +141,7 @@ const (
 	podContainerPortNameLabel     = metaLabelPrefix + "pod_container_port_name"
 	podContainerPortNumberLabel   = metaLabelPrefix + "pod_container_port_number"
 	podContainerPortProtocolLabel = metaLabelPrefix + "pod_container_port_protocol"
+	podContainerIsInit            = metaLabelPrefix + "pod_container_init"
 	podReadyLabel                 = metaLabelPrefix + "pod_ready"
 	podPhaseLabel                 = metaLabelPrefix + "pod_phase"
 	podLabelPrefix                = metaLabelPrefix + "pod_label_"
@@ -213,7 +214,10 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 	tg.Labels = podLabels(pod)
 	tg.Labels[namespaceLabel] = lv(pod.Namespace)
 
-	for _, c := range pod.Spec.Containers {
+	containers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
+	for i, c := range containers {
+		is_init := i >= len(pod.Spec.Containers)
+
 		// If no ports are defined for the container, create an anonymous
 		// target per container.
 		if len(c.Ports) == 0 {
@@ -222,6 +226,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 			tg.Targets = append(tg.Targets, model.LabelSet{
 				model.AddressLabel:    lv(pod.Status.PodIP),
 				podContainerNameLabel: lv(c.Name),
+				podContainerIsInit:    lv(strconv.FormatBool(is_init)),
 			})
 			continue
 		}
@@ -236,6 +241,7 @@ func (p *Pod) buildPod(pod *apiv1.Pod) *targetgroup.Group {
 				podContainerPortNumberLabel:   lv(ports),
 				podContainerPortNameLabel:     lv(port.Name),
 				podContainerPortProtocolLabel: lv(string(port.Protocol)),
+				podContainerIsInit:            lv(strconv.FormatBool(is_init)),
 			})
 		}
 	}

--- a/vendor/github.com/prometheus/prometheus/storage/remote/max_gauge.go
+++ b/vendor/github.com/prometheus/prometheus/storage/remote/max_gauge.go
@@ -35,5 +35,7 @@ func (m *maxGauge) Set(value float64) {
 }
 
 func (m *maxGauge) Get() float64 {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
 	return m.value
 }

--- a/vendor/github.com/prometheus/prometheus/template/template.go
+++ b/vendor/github.com/prometheus/prometheus/template/template.go
@@ -243,6 +243,9 @@ func NewTemplateExpander(
 				}
 				return fmt.Sprintf("%.4g%ss", v, prefix)
 			},
+			"humanizePercentage": func(v float64) string {
+				return fmt.Sprintf("%.4g%%", v*100)
+			},
 			"humanizeTimestamp": func(v float64) string {
 				if math.IsNaN(v) || math.IsInf(v, 0) {
 					return fmt.Sprintf("%.4g", v)

--- a/vendor/github.com/prometheus/prometheus/util/treecache/treecache.go
+++ b/vendor/github.com/prometheus/prometheus/util/treecache/treecache.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -68,6 +69,7 @@ type ZookeeperTreeCache struct {
 	prefix string
 	events chan ZookeeperTreeCacheEvent
 	stop   chan struct{}
+	wg     *sync.WaitGroup
 	head   *zookeeperTreeCacheNode
 
 	logger log.Logger
@@ -94,14 +96,17 @@ func NewZookeeperTreeCache(conn *zk.Conn, path string, events chan ZookeeperTree
 		prefix: path,
 		events: events,
 		stop:   make(chan struct{}),
+		wg:     &sync.WaitGroup{},
 
 		logger: logger,
 	}
 	tc.head = &zookeeperTreeCacheNode{
 		events:   make(chan zk.Event),
 		children: map[string]*zookeeperTreeCacheNode{},
-		stopped:  true,
+		done:     make(chan struct{}, 1),
+		stopped:  true, // Set head's stop to be true so that recursiveDelete will not stop the head node.
 	}
+	tc.wg.Add(1)
 	go tc.loop(path)
 	return tc
 }
@@ -109,9 +114,23 @@ func NewZookeeperTreeCache(conn *zk.Conn, path string, events chan ZookeeperTree
 // Stop stops the tree cache.
 func (tc *ZookeeperTreeCache) Stop() {
 	tc.stop <- struct{}{}
+	go func() {
+		// Drain tc.head.events so that go routines can make progress and exit.
+		for range tc.head.events {
+		}
+	}()
+	go func() {
+		tc.wg.Wait()
+		// Close the tc.head.events after all members of the wait group have exited.
+		// This makes the go routine above exit.
+		close(tc.head.events)
+		close(tc.events)
+	}()
 }
 
 func (tc *ZookeeperTreeCache) loop(path string) {
+	defer tc.wg.Done()
+
 	failureMode := false
 	retryChan := make(chan struct{})
 
@@ -185,6 +204,8 @@ func (tc *ZookeeperTreeCache) loop(path string) {
 				failureMode = false
 			}
 		case <-tc.stop:
+			// Stop head as well.
+			tc.head.done <- struct{}{}
 			tc.recursiveStop(tc.head)
 			return
 		}
@@ -243,6 +264,7 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 		}
 	}
 
+	tc.wg.Add(1)
 	go func() {
 		numWatchers.Inc()
 		// Pass up zookeeper events, until the node is deleted.
@@ -254,6 +276,7 @@ func (tc *ZookeeperTreeCache) recursiveNodeUpdate(path string, node *zookeeperTr
 		case <-node.done:
 		}
 		numWatchers.Dec()
+		tc.wg.Done()
 	}()
 	return nil
 }

--- a/vendor/github.com/prometheus/prometheus/web/api/v1/api.go
+++ b/vendor/github.com/prometheus/prometheus/web/api/v1/api.go
@@ -441,6 +441,9 @@ func (api *API) labelValues(r *http.Request) apiFuncResult {
 var (
 	minTime = time.Unix(math.MinInt64/1000+62135596801, 0)
 	maxTime = time.Unix(math.MaxInt64/1000-62135596801, 999999999)
+
+	minTimeFormatted = minTime.Format(time.RFC3339Nano)
+	maxTimeFormatted = maxTime.Format(time.RFC3339Nano)
 )
 
 func (api *API) series(r *http.Request) apiFuncResult {
@@ -1161,6 +1164,17 @@ func parseTime(s string) (time.Time, error) {
 	}
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
 		return t, nil
+	}
+
+	// Stdlib's time parser can only handle 4 digit years. As a workaround until
+	// that is fixed we want to at least support our own boundary times.
+	// Context: https://github.com/prometheus/client_golang/issues/614
+	// Upstream issue: https://github.com/golang/go/issues/20555
+	switch s {
+	case minTimeFormatted:
+		return minTime, nil
+	case maxTimeFormatted:
+		return maxTime, nil
 	}
 	return time.Time{}, errors.Errorf("cannot parse %q to a valid timestamp", s)
 }


### PR DESCRIPTION
Workaround/Fixes for #186

This PR includes:
- prom-side fix -- meaning if promxy is the downstream we'll have the prom-serverside workaround
- Promxy-side workaround -- we special case the min/max time from prom and send a min/max time that prometheus can actually parse