### PR TITLE
Add targetgroup labels to individual targets

### DIFF
--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -107,11 +107,18 @@ func (s *ServerGroup) Sync() {
 		for _, targetGroupList := range targetGroupMap {
 			for _, targetGroup := range targetGroupList {
 				for _, target := range targetGroup.Targets {
-					lbls := make([]labels.Label, 0, len(target))
+					lbls := make([]labels.Label, 0, len(target)+len(targetGroup.Labels))
 
 					for ln, lv := range target {
 						lbls = append(lbls, labels.Label{Name: string(ln), Value: string(lv)})
 					}
+
+					for ln, lv := range targetGroup.Labels {
+						if _, ok := target[ln]; !ok {
+							lbls = append(lbls, labels.Label{Name: string(ln), Value: string(lv)})
+						}
+					}
+
 					lset := labels.New(lbls...)
 
 					lset = relabel.Process(lset, s.Cfg.RelabelConfigs...)


### PR DESCRIPTION
Prom's discovery system has labels both at the target and targetgroup level, previously we were only looking at the target level ones.

Fixes #198