### PR TITLE
Don't mutate target entry from discoveryManager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ test:
 release:
 	./build.bash github.com/jacksontj/promxy/cmd/promxy $(BUILD)
 	./build.bash github.com/jacksontj/promxy/cmd/remote_write_exporter $(BUILD)
+
+testlocal-build:
+	docker build -t 127.0.0.1:32000/promxy:latest .
+	docker push 127.0.0.1:32000/promxy:latest

--- a/deploy/k8s/promxy.yaml
+++ b/deploy/k8s/promxy.yaml
@@ -22,18 +22,9 @@ data:
     ##
     promxy:
       server_groups:
-        - static_configs:
-            - targets:
-              - localhost:9090
-          labels:
-            sg: localhost_9090
-          anti_affinity: 10s
-        - static_configs:
-            - targets:
-              - localhost:9091
-          labels:
-            sg: localhost_9091
-          anti_affinity: 10s
+      - kubernetes_sd_configs:
+        - role: pod
+
 kind: ConfigMap
 metadata:
   name: promxy-config
@@ -61,23 +52,17 @@ spec:
       - args:
         - "--config=/etc/promxy/config.yaml"
         - "--web.enable-lifecycle"
+        - "--log-level=trace"
+        env:
+          - name: ROLE
+            value: "1"
         command:
         - "/bin/promxy"
-        image: quay.io/jacksontj/promxy:latest
+        image: 127.0.0.1:32000/promxy:latest
         imagePullPolicy: Always
-        livenessProbe:
-          httpGet:
-            path: "/-/healthy"
-            port: 8082
-          initialDelaySeconds: 3
         name: promxy
         ports:
         - containerPort: 8082
-        readinessProbe:
-          httpGet:
-            path: "/-/ready"
-            port: 8082
-          initialDelaySeconds: 3
         volumeMounts:
         - mountPath: "/etc/promxy/"
           name: promxy-config

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -184,14 +184,15 @@ SYNC_LOOP:
 					}
 
 					// We remove all private labels after we set the target entry
-					for name := range target {
-						if strings.HasPrefix(string(name), model.ReservedLabelPrefix) {
-							delete(target, name)
+					modelLabelSet := make(model.LabelSet, len(lset))
+					for _, lbl := range lset {
+						if !strings.HasPrefix(string(lbl.Name), model.ReservedLabelPrefix) {
+							modelLabelSet[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
 						}
 					}
 
 					// Add labels
-					apiClient = &promclient.AddLabelClient{apiClient, target.Merge(s.Cfg.Labels)}
+					apiClient = &promclient.AddLabelClient{apiClient, modelLabelSet.Merge(s.Cfg.Labels)}
 
 					// If debug logging is enabled, wrap the client with a debugAPI client
 					// Since these are called in the reverse order of what we add, we want


### PR DESCRIPTION
This was while debugging #198, in doing so I added debug logging and then found that some of the responses from the discoveryManager were returning without an `Address` label which is invalid -- so I added an error check for that. After doing so I dug into *why* we were getting them, and it turns out *some* of the discovery clients (e.g. k8s) cache their targets -- so if we mutate them then the changes persist across reloads.