### PR TITLE
Added goroutine to monitor and cancel memory intensive queries

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -82,3 +82,4 @@ promxy:
       # meaning if this servergroup returns and error and others don't the overall
       # query can still succeed
       ignore_error: true
+  max_memory: 15000

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,9 +11,14 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+//DefaultMemory defines the maximum memory consumption
+const DefaultMemory = 25000
+
 // DefaultPromxyConfig is the default promxy config that the config file
 // is loaded into
-var DefaultPromxyConfig = PromxyConfig{}
+var DefaultPromxyConfig = PromxyConfig{
+	MaxMemory: DefaultMemory,
+}
 
 // ConfigFromFile loads a config file at path
 func ConfigFromFile(path string) (*Config, error) {
@@ -50,4 +55,5 @@ type Config struct {
 type PromxyConfig struct {
 	// Config for each of the server groups promxy is configured to aggregate
 	ServerGroups []*servergroup.Config `yaml:"server_groups"`
+	MaxMemory    int                   `yaml:"max_memory"`
 }

--- a/pkg/promclient/memory_monitor.go
+++ b/pkg/promclient/memory_monitor.go
@@ -1,0 +1,131 @@
+package promclient
+
+import (
+	"context"
+	"runtime"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/api"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/sirupsen/logrus"
+)
+
+// ConvertErr converts the errors that the prometheus API client returns
+// into errors that the prometheus API server actually handles and returns proper
+// error codes for
+func ConvertErr(err error, memExceeded bool) error {
+	// If error is caused by memory exceeds
+	if memExceeded {
+		return errors.New("Memory Consumption Limit Exceeded")
+	}
+	// If all else fails, return the original error
+	return err
+}
+
+// MemMonitorAPI sets up a memory monitor for a given api operation
+type MemMonitorAPI struct {
+	API
+	MaxMem int
+}
+
+// Starts a memory monitoring goroutine that oversees the memory usage of the process during a query
+// Cancels all queries when the memory threshold is exceeded
+// Takes in the parent's context cancel function used for stopping the query
+func (m *MemMonitorAPI) Monitor(ctx context.Context, parentContextCancel func(), memExceeded *bool) {
+	var memAlloc uint64
+	d := 5 * time.Second
+	MaxMem := uint64(m.MaxMem)
+	for x := range time.Tick(d) {
+		select {
+		case <-ctx.Done():
+			logrus.Debugf("Memory Consumed = %v MiB  %v\n", memAlloc, x)
+			return
+		default:
+			var mem runtime.MemStats
+			runtime.ReadMemStats(&mem)
+			memAlloc := mem.Sys / 1024 / 1024
+
+			if memAlloc > MaxMem {
+				*memExceeded = true
+				parentContextCancel()
+				logrus.Debugf("Memory Consumed = %v MiB  %v\n", memAlloc, x)
+				return
+			}
+		}
+	}
+}
+
+// LabelNames returns all the unique label names present in the block in sorted order.
+func (m *MemMonitorAPI) LabelNames(ctx context.Context) ([]string, api.Warnings, error) {
+	childContext, childContextCancel := context.WithCancel(ctx)
+	defer childContextCancel()
+
+	memExceeded := false
+	go m.Monitor(childContext, childContextCancel, &memExceeded)
+
+	v, w, err := m.API.LabelNames(childContext)
+	return v, w, ConvertErr(err, memExceeded)
+}
+
+// LabelValues performs a query for the values of the given label.
+func (m *MemMonitorAPI) LabelValues(ctx context.Context, label string) (model.LabelValues, api.Warnings, error) {
+	childContext, childContextCancel := context.WithCancel(ctx)
+	defer childContextCancel()
+
+	memExceeded := false
+	go m.Monitor(childContext, childContextCancel, &memExceeded)
+
+	v, w, err := m.API.LabelValues(childContext, label)
+	return v, w, ConvertErr(err, memExceeded)
+}
+
+// Query performs a query for the given time.
+func (m *MemMonitorAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, api.Warnings, error) {
+	childContext, childContextCancel := context.WithCancel(ctx)
+	defer childContextCancel()
+
+	memExceeded := false
+	go m.Monitor(childContext, childContextCancel, &memExceeded)
+
+	v, w, err := m.API.Query(childContext, query, ts)
+	return v, w, ConvertErr(err, memExceeded)
+}
+
+// QueryRange performs a query for the given range.
+func (m *MemMonitorAPI) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, api.Warnings, error) {
+	childContext, childContextCancel := context.WithCancel(ctx)
+	defer childContextCancel()
+
+	memExceeded := false
+	go m.Monitor(childContext, childContextCancel, &memExceeded)
+
+	v, w, err := m.API.QueryRange(childContext, query, r)
+	return v, w, ConvertErr(err, memExceeded)
+}
+
+// Series finds series by label matchers.
+func (m *MemMonitorAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, api.Warnings, error) {
+	childContext, childContextCancel := context.WithCancel(ctx)
+	defer childContextCancel()
+
+	memExceeded := false
+	go m.Monitor(childContext, childContextCancel, &memExceeded)
+
+	v, w, err := m.API.Series(childContext, matches, startTime, endTime)
+	return v, w, ConvertErr(err, memExceeded)
+}
+
+// GetValue loads the raw data for a given set of matchers in the time range
+func (m *MemMonitorAPI) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (model.Value, api.Warnings, error) {
+	childContext, childContextCancel := context.WithCancel(ctx)
+	defer childContextCancel()
+
+	memExceeded := false
+	go m.Monitor(childContext, childContextCancel, &memExceeded)
+
+	v, w, err := m.API.GetValue(childContext, start, end, matchers)
+	return v, w, ConvertErr(err, memExceeded)
+}

--- a/pkg/promclient/memory_monitor.go
+++ b/pkg/promclient/memory_monitor.go
@@ -31,9 +31,10 @@ type MemMonitorAPI struct {
 	MaxMem int
 }
 
-// Starts a memory monitoring goroutine that oversees the memory usage of the process during a query
+// Monitor starts a memory monitoring goroutine that oversees the memory usage of the process during a query
 // Cancels all queries when the memory threshold is exceeded
 // Takes in the parent's context cancel function used for stopping the query
+// TODO: Figure out a way to determine which query is eating up most of the memory and only cancel that
 func (m *MemMonitorAPI) Monitor(ctx context.Context, parentContextCancel func(), memExceeded *bool) {
 	var memAlloc uint64
 	d := 5 * time.Second

--- a/pkg/promclient/multi_api.go
+++ b/pkg/promclient/multi_api.go
@@ -32,7 +32,6 @@ func NormalizePromError(err error) error {
 		ErrorType promhttputil.ErrorType `json:"errorType,omitempty"`
 		Error     string                 `json:"error,omitempty"`
 	}
-
 	if typedErr, ok := err.(*v1.Error); ok {
 		res := &result{}
 		// The prometheus client does a terrible job of handling and returning errors
@@ -120,6 +119,7 @@ func (m *MultiAPI) LabelValues(ctx context.Context, label string) (model.LabelVa
 	}
 
 	resultChans := make([]chan chanResult, len(m.apis))
+
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	for i, api := range m.apis {
@@ -151,7 +151,8 @@ func (m *MultiAPI) LabelValues(ctx context.Context, label string) (model.LabelVa
 	for i := 0; i < len(m.apis); i++ {
 		select {
 		case <-ctx.Done():
-			return nil, warnings.Warnings(), ctx.Err()
+			err := ctx.Err()
+			return nil, warnings.Warnings(), err
 
 		case ret := <-resultChans[i]:
 			warnings.AddWarnings(ret.warnings)
@@ -181,7 +182,6 @@ func (m *MultiAPI) LabelValues(ctx context.Context, label string) (model.LabelVa
 	}
 
 	sort.Sort(model.LabelValues(result))
-
 	return result, warnings.Warnings(), nil
 }
 
@@ -198,6 +198,7 @@ func (m *MultiAPI) LabelNames(ctx context.Context) ([]string, api.Warnings, erro
 	}
 
 	resultChans := make([]chan chanResult, len(m.apis))
+
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	for i, api := range m.apis {
@@ -229,7 +230,8 @@ func (m *MultiAPI) LabelNames(ctx context.Context) ([]string, api.Warnings, erro
 	for i := 0; i < len(m.apis); i++ {
 		select {
 		case <-ctx.Done():
-			return nil, warnings.Warnings(), ctx.Err()
+			err := ctx.Err()
+			return nil, warnings.Warnings(), err
 
 		case ret := <-resultChans[i]:
 			warnings.AddWarnings(ret.warnings)
@@ -279,6 +281,7 @@ func (m *MultiAPI) Query(ctx context.Context, query string, ts time.Time) (model
 	}
 
 	resultChans := make([]chan chanResult, len(m.apis))
+
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	for i, api := range m.apis {
@@ -310,7 +313,8 @@ func (m *MultiAPI) Query(ctx context.Context, query string, ts time.Time) (model
 	for i := 0; i < len(m.apis); i++ {
 		select {
 		case <-ctx.Done():
-			return nil, warnings.Warnings(), ctx.Err()
+			err := ctx.Err()
+			return nil, warnings.Warnings(), err
 
 		case ret := <-resultChans[i]:
 			warnings.AddWarnings(ret.warnings)
@@ -359,6 +363,7 @@ func (m *MultiAPI) QueryRange(ctx context.Context, query string, r v1.Range) (mo
 	}
 
 	resultChans := make([]chan chanResult, len(m.apis))
+
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	for i, api := range m.apis {
@@ -390,7 +395,8 @@ func (m *MultiAPI) QueryRange(ctx context.Context, query string, r v1.Range) (mo
 	for i := 0; i < len(m.apis); i++ {
 		select {
 		case <-ctx.Done():
-			return nil, warnings.Warnings(), ctx.Err()
+			err := ctx.Err()
+			return nil, warnings.Warnings(), err
 
 		case ret := <-resultChans[i]:
 			warnings.AddWarnings(ret.warnings)
@@ -439,6 +445,7 @@ func (m *MultiAPI) Series(ctx context.Context, matches []string, startTime time.
 	}
 
 	resultChans := make([]chan chanResult, len(m.apis))
+
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	for i, api := range m.apis {
@@ -470,7 +477,8 @@ func (m *MultiAPI) Series(ctx context.Context, matches []string, startTime time.
 	for i := 0; i < len(m.apis); i++ {
 		select {
 		case <-ctx.Done():
-			return nil, warnings.Warnings(), ctx.Err()
+			err := ctx.Err()
+			return nil, warnings.Warnings(), err
 
 		case ret := <-resultChans[i]:
 			warnings.AddWarnings(ret.warnings)
@@ -515,6 +523,7 @@ func (m *MultiAPI) GetValue(ctx context.Context, start, end time.Time, matchers 
 	}
 
 	resultChans := make([]chan chanResult, len(m.apis))
+
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	// Scatter out all the queries
@@ -547,7 +556,8 @@ func (m *MultiAPI) GetValue(ctx context.Context, start, end time.Time, matchers 
 	for i := 0; i < len(m.apis); i++ {
 		select {
 		case <-ctx.Done():
-			return nil, warnings.Warnings(), ctx.Err()
+			err := ctx.Err()
+			return nil, warnings.Warnings(), err
 
 		case ret := <-resultChans[i]:
 			warnings.AddWarnings(ret.warnings)

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -58,7 +58,8 @@ func (p *proxyStorageState) Cancel(n *proxyStorageState) {
 
 // NewProxyStorage creates a new ProxyStorage
 func NewProxyStorage() (*ProxyStorage, error) {
-	return &ProxyStorage{}, nil
+	ps := ProxyStorage{}
+	return &ps, nil
 }
 
 // ProxyStorage implements prometheus' Storage interface
@@ -87,7 +88,7 @@ func (p *ProxyStorage) ApplyConfig(c *proxyconfig.Config) error {
 		cfg: &c.PromxyConfig,
 	}
 	for i, sgCfg := range c.ServerGroups {
-		tmp := servergroup.New()
+		tmp := servergroup.New(c.MaxMemory)
 		if err := tmp.ApplyConfig(sgCfg); err != nil {
 			failed = true
 			logrus.Errorf("Error applying config to server group: %s", err)

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -41,13 +41,14 @@ func init() {
 }
 
 // New creates a new servergroup
-func New() *ServerGroup {
+func New(MaxMemory int) *ServerGroup {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	// Create the targetSet (which will maintain all of the updating etc. in the background)
 	sg := &ServerGroup{
 		ctx:       ctx,
 		ctxCancel: ctxCancel,
 		Ready:     make(chan struct{}),
+		Memory:    MaxMemory,
 	}
 
 	logCfg := &promlog.Config{
@@ -89,6 +90,8 @@ type ServerGroup struct {
 	OriginalURLs []string
 
 	state atomic.Value
+
+	Memory int
 }
 
 // Cancel stops backround processes (e.g. discovery manager)
@@ -200,7 +203,7 @@ SYNC_LOOP:
 					if logrus.GetLevel() >= logrus.DebugLevel {
 						apiClient = &promclient.DebugAPI{apiClient, u.String()}
 					}
-
+					apiClient = &promclient.MemMonitorAPI{apiClient, s.Memory}
 					apiClients = append(apiClients, apiClient)
 				}
 			}


### PR DESCRIPTION
Added monitorMemory function which creates a new goroutine to monitor the memory usage. It would invoke cancel (context cancel that was passed in as a parameter) to immediately stop the query from running and prevent promxy from running out of memory. E.g of query that causes promxy to run out of memory: `{__name__=~".*a.*"}`

TODO:
- Separate the error message from cancelled context (currently displays error: context canceled)
- Allow a flag to be passed in to define maximum memory usage (currently hardcoded to 5G)
- Investigate memory retention (`ps aux | grep promxy` reveals that the memory usage by promxy even when idle remains at where it was cancelled, not sure if premature context cancel is causing this retention or this is in general the expected behaviour)