### PR TITLE
Add default evaluation interval

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -107,6 +107,7 @@ func reloadConfig(rls ...proxyconfig.Reloadable) error {
 	if failed {
 		return fmt.Errorf("One or more errors occurred while applying new configuration")
 	}
+	promql.SetDefaultEvaluationInterval(time.Duration(cfg.PromConfig.GlobalConfig.EvaluationInterval))
 	reloadTime.Set(float64(time.Now().Unix()))
 	return nil
 }


### PR DESCRIPTION
subqueries require a default evaluation interval to be set, otherwise it
is 0 -- which fails

Fixes #209