### PR TITLE
Add QueryParams (query_params) option to add params to downstream queries

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -44,6 +44,11 @@ promxy:
       remote_read: true
       # path_prefix defines a prefix to prepend to all queries to hosts in this servergroup
       path_prefix: /example/prefix
+      # query_params adds the following map of query parameters to downstream requests.
+      # The initial use-case for this is to add `nocache=1` to VictoriaMetrics downstreams
+	    # (see https://github.com/jacksontj/promxy/issues/202)
+      query_params:
+        nocache: 1
       # options for promxy's HTTP client when talking to hosts in server_groups
       http_client:
         # dial_timeout controls how long promxy will wait for a connection to the downstream

--- a/pkg/promclient/client_wrap.go
+++ b/pkg/promclient/client_wrap.go
@@ -1,0 +1,31 @@
+package promclient
+
+import (
+	"net/url"
+
+	"github.com/prometheus/client_golang/api"
+)
+
+// NewClientArgsWrap returns a client that will add the given args
+func NewClientArgsWrap(api api.Client, args map[string]string) *ClientArgsWrap {
+	return &ClientArgsWrap{api, args}
+}
+
+// ClientArgsWrap wraps the prom API client to add query params to any given urls
+type ClientArgsWrap struct {
+	api.Client
+
+	args map[string]string
+}
+
+func (c *ClientArgsWrap) URL(ep string, args map[string]string) *url.URL {
+	u := c.Client.URL(ep, args)
+
+	q := u.Query()
+	for k, v := range c.args {
+		q.Set(k, v)
+	}
+	u.RawQuery = q.Encode()
+
+	return u
+}

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -83,6 +83,10 @@ type Config struct {
 	Hosts sd_config.ServiceDiscoveryConfig `yaml:",inline"`
 	// PathPrefix to prepend to all queries to hosts in this servergroup
 	PathPrefix string `yaml:"path_prefix"`
+	// QueryParams are a map of query params to add to all HTTP calls made to this downstream
+	// the main use-case for this is to add `nocache=1` to VictoriaMetrics downstreams
+	// (see https://github.com/jacksontj/promxy/issues/202)
+	QueryParams map[string]string `yaml:"query_params"`
 	// TODO cache this as a model.Time after unmarshal
 	// AntiAffinity defines how large of a gap in the timeseries will cause promxy
 	// to merge series from 2 hosts in a server_group. This required for a couple reasons

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -148,6 +148,10 @@ SYNC_LOOP:
 						panic(err) // TODO: shouldn't be possible? If this happens I guess we log and skip?
 					}
 
+					if len(s.Cfg.QueryParams) > 0 {
+						client = promclient.NewClientArgsWrap(client, s.Cfg.QueryParams)
+					}
+
 					var apiClient promclient.API
 					apiClient = &promclient.PromAPIV1{v1.NewAPI(client)}
 


### PR DESCRIPTION
This enables users to configure query params to send to a given downstream ServerGroup. The initial case here is to solve #202 to allow the user to specify `nocache=1`

Fixes #202