### PR TITLE
Handle scalar() function return type

### DIFF
--- a/pkg/promclient/iterators.go
+++ b/pkg/promclient/iterators.go
@@ -52,8 +52,6 @@ type SeriesIterator struct {
 // the given timestamp.
 func (s *SeriesIterator) Seek(t int64) bool {
 	switch valueTyped := s.V.(type) {
-	case *model.Scalar: // From a vector
-		return int64(valueTyped.Timestamp) >= t
 	case *model.Sample: // From a vector
 		return int64(valueTyped.Timestamp) >= t
 	case *model.SampleStream: // from a Matrix
@@ -77,8 +75,6 @@ func (s *SeriesIterator) Seek(t int64) bool {
 // At returns the current timestamp/value pair.
 func (s *SeriesIterator) At() (t int64, v float64) {
 	switch valueTyped := s.V.(type) {
-	case *model.Scalar:
-		return int64(valueTyped.Timestamp), float64(valueTyped.Value)
 	case *model.Sample: // From a vector
 		return int64(valueTyped.Timestamp), float64(valueTyped.Value)
 	case *model.SampleStream: // from a Matrix
@@ -93,12 +89,6 @@ func (s *SeriesIterator) At() (t int64, v float64) {
 // Next advances the iterator by one.
 func (s *SeriesIterator) Next() bool {
 	switch valueTyped := s.V.(type) {
-	case *model.Scalar:
-		if s.offset < 0 {
-			s.offset = 0
-			return true
-		}
-		return false
 	case *model.Sample: // From a vector
 		if s.offset < 0 {
 			s.offset = 0
@@ -113,7 +103,6 @@ func (s *SeriesIterator) Next() bool {
 		return false
 	default:
 		msg := fmt.Sprintf("Unknown data type %v", reflect.TypeOf(s.V))
-		fmt.Println(msg)
 		panic(msg)
 	}
 }
@@ -127,7 +116,7 @@ func (s *SeriesIterator) Err() error {
 func (s *SeriesIterator) Labels() labels.Labels {
 	switch valueTyped := s.V.(type) {
 	case *model.Scalar:
-		return nil
+		panic("Unknown metric() scalar?")
 	case *model.Sample: // From a vector
 		ret := make(labels.Labels, 0, len(valueTyped.Metric))
 		for k, v := range valueTyped.Metric {

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -376,6 +376,13 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 		if err != nil {
 			return nil, errors.Cause(err)
 		}
+
+		// the "scalar()" function can return a scalar, if so we need to make sure we return
+		// the correct type
+		if scalarResult, ok := result.(*model.Scalar); ok {
+			return &promql.NumberLiteral{float64(scalarResult.Value)}, nil
+		}
+
 		iterators := promclient.IteratorsForValue(result)
 		series := make([]storage.Series, len(iterators))
 		for i, iterator := range iterators {


### PR DESCRIPTION
The scalar function call can return a scalar -- which we need to handle
(otherwise we return it as a vector-- which isn't right).

Fixes #219