### PR TITLE
Add DisableLookback to NodeReplacer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -528,7 +528,7 @@
 
 [[projects]]
   branch = "release-2.10_fork_promxy"
-  digest = "1:25f481c8d37eeb821e6565a5943cf0443db5dd186e7c5f6e092df385f60169e2"
+  digest = "1:f7c9a940ce6e6ce179416c766b8f0e37942f87bc23432ea438fa6cc836972911"
   name = "github.com/prometheus/prometheus"
   packages = [
     "config",
@@ -577,7 +577,7 @@
     "web/ui",
   ]
   pruneopts = "NUT"
-  revision = "8291a73c3f83a63171b4b1452f091d0bb671f5c2"
+  revision = "7ba2818c13c88799dc2b4e7f53a6f9ca17e390b3"
   source = "github.com/jacksontj/prometheus"
 
 [[projects]]

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -235,7 +235,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 
 			if s.Interval > 0 {
 				result, warnings, err = state.client.QueryRange(ctx, n.String(), v1.Range{
-					Start: s.Start.Add(-offset - promql.LookbackDelta),
+					Start: s.Start.Add(-offset),
 					End:   s.End.Add(-offset),
 					Step:  s.Interval,
 				})
@@ -276,7 +276,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 
 			if s.Interval > 0 {
 				result, warnings, err = state.client.QueryRange(ctx, n.String(), v1.Range{
-					Start: s.Start.Add(-offset - promql.LookbackDelta),
+					Start: s.Start.Add(-offset),
 					End:   s.End.Add(-offset),
 					Step:  s.Interval,
 				})
@@ -295,7 +295,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 			// First we must fetch the data into a vectorselector
 			if s.Interval > 0 {
 				result, warnings, err = state.client.QueryRange(ctx, n.String(), v1.Range{
-					Start: s.Start.Add(-offset - promql.LookbackDelta),
+					Start: s.Start.Add(-offset),
 					End:   s.End.Add(-offset),
 					Step:  s.Interval,
 				})
@@ -365,7 +365,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 		var err error
 		if s.Interval > 0 {
 			result, warnings, err = state.client.QueryRange(ctx, n.String(), v1.Range{
-				Start: s.Start.Add(-offset - promql.LookbackDelta),
+				Start: s.Start.Add(-offset),
 				End:   s.End.Add(-offset),
 				Step:  s.Interval,
 			})
@@ -406,7 +406,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 		var err error
 		if s.Interval > 0 {
 			result, warnings, err = state.client.QueryRange(ctx, n.String(), v1.Range{
-				Start: s.Start.Add(-offset - promql.LookbackDelta),
+				Start: s.Start.Add(-offset),
 				End:   s.End.Add(-offset),
 				Step:  s.Interval,
 			})

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -400,6 +400,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 		if n.HasSeries() {
 			return nil, nil
 		}
+		removeOffset()
 
 		var result model.Value
 		var warnings api.Warnings
@@ -423,6 +424,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 		for i, iterator := range iterators {
 			series[i] = &proxyquerier.Series{iterator}
 		}
+		n.Offset = offset
 		n.SetSeries(series, promhttputil.WarningsConvert(warnings))
 		n.DisableLookback = true
 

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -314,7 +314,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 				series[i] = &proxyquerier.Series{iterator}
 			}
 
-			ret := &promql.VectorSelector{Offset: offset}
+			ret := &promql.VectorSelector{Offset: offset, DisableLookback: true}
 			ret.SetSeries(series, promhttputil.WarningsConvert(warnings))
 
 			// Replace with sum(count_values()) BY (label)
@@ -348,7 +348,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 				series[i] = &proxyquerier.Series{iterator}
 			}
 
-			ret := &promql.VectorSelector{Offset: offset}
+			ret := &promql.VectorSelector{Offset: offset, DisableLookback: true}
 			ret.SetSeries(series, promhttputil.WarningsConvert(warnings))
 			n.Expr = ret
 			return n, nil
@@ -389,7 +389,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 			series[i] = &proxyquerier.Series{iterator}
 		}
 
-		ret := &promql.VectorSelector{Offset: offset}
+		ret := &promql.VectorSelector{Offset: offset, DisableLookback: true}
 		ret.SetSeries(series, promhttputil.WarningsConvert(warnings))
 		return ret, nil
 
@@ -424,6 +424,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 			series[i] = &proxyquerier.Series{iterator}
 		}
 		n.SetSeries(series, promhttputil.WarningsConvert(warnings))
+		n.DisableLookback = true
 
 	// If we hit this someone is asking for a matrix directly, if so then we don't
 	// have anyway to ask for less-- since this is exactly what they are asking for

--- a/vendor/github.com/prometheus/prometheus/promql/ast.go
+++ b/vendor/github.com/prometheus/prometheus/promql/ast.go
@@ -161,9 +161,10 @@ type UnaryExpr struct {
 
 // VectorSelector represents a Vector selection.
 type VectorSelector struct {
-	Name          string
-	Offset        time.Duration
-	LabelMatchers []*labels.Matcher
+	Name            string
+	Offset          time.Duration
+	LabelMatchers   []*labels.Matcher
+	DisableLookback bool
 
 	// The unexpanded seriesSet populated at query preparation time.
 	unexpandedSeriesSet storage.SeriesSet

--- a/vendor/github.com/prometheus/prometheus/promql/engine.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine.go
@@ -1256,7 +1256,7 @@ func (ev *evaluator) vectorSelectorSingle(it *storage.BufferedSeriesIterator, no
 
 	if !ok || t > refTime {
 		t, v, ok = it.PeekBack(1)
-		if !ok || t < refTime-durationMilliseconds(LookbackDelta) {
+		if !ok || t < refTime-durationMilliseconds(LookbackDelta) || node.DisableLookback {
 			return 0, 0, false
 		}
 	}


### PR DESCRIPTION
In NodeReplacer we are sub-tasking the queries to remote prom APIs; if we do this we should not do our own LookbackDelta on top of it -- as it was already done remotely.

Prior to this if the remote returned a result with gaps we'd fill them as long as there was a point within LookbackDelta.