### PR TITLE
Completely special-case the `scalar` call method

### DIFF
--- a/pkg/promclient/iterators.go
+++ b/pkg/promclient/iterators.go
@@ -52,6 +52,8 @@ type SeriesIterator struct {
 // the given timestamp.
 func (s *SeriesIterator) Seek(t int64) bool {
 	switch valueTyped := s.V.(type) {
+	case *model.Scalar: // From a vector
+		return int64(valueTyped.Timestamp) >= t
 	case *model.Sample: // From a vector
 		return int64(valueTyped.Timestamp) >= t
 	case *model.SampleStream: // from a Matrix
@@ -75,6 +77,8 @@ func (s *SeriesIterator) Seek(t int64) bool {
 // At returns the current timestamp/value pair.
 func (s *SeriesIterator) At() (t int64, v float64) {
 	switch valueTyped := s.V.(type) {
+	case *model.Scalar:
+		return int64(valueTyped.Timestamp), float64(valueTyped.Value)
 	case *model.Sample: // From a vector
 		return int64(valueTyped.Timestamp), float64(valueTyped.Value)
 	case *model.SampleStream: // from a Matrix
@@ -89,6 +93,12 @@ func (s *SeriesIterator) At() (t int64, v float64) {
 // Next advances the iterator by one.
 func (s *SeriesIterator) Next() bool {
 	switch valueTyped := s.V.(type) {
+	case *model.Scalar:
+		if s.offset < 0 {
+			s.offset = 0
+			return true
+		}
+		return false
 	case *model.Sample: // From a vector
 		if s.offset < 0 {
 			s.offset = 0


### PR DESCRIPTION
Unlike the other `Call` methods that simply return VectorSelectors -- scalar actually mutates the types which has caused pains. This simply uses the sub-query to fetch data and set it as the VectorSelector of the `scalar` func -- which allows it to handle type setting etc.

Fixes #234