### PR TITLE
Support matchers that are only the added promxy labels

### DIFF
--- a/pkg/promclient/labelfilter.go
+++ b/pkg/promclient/labelfilter.go
@@ -66,5 +66,17 @@ func FilterMatchers(ls model.LabelSet, matchers []*labels.Matcher) ([]*labels.Ma
 			filteredMatchers = append(filteredMatchers, matcher)
 		}
 	}
+
+	// Prometheus doesn't support empty matchers (https://github.com/prometheus/prometheus/issues/2162)
+	// so if we filter out all matchers we want to replace the empty matcher
+	// with a matcher that does the same
+	if len(filteredMatchers) == 0 {
+		filteredMatchers = append(filteredMatchers, &labels.Matcher{
+			Type:  labels.MatchRegexp,
+			Name:  labels.MetricName,
+			Value: ".+",
+		})
+	}
+
 	return filteredMatchers, true
 }


### PR DESCRIPTION
Promxy supports adding labels and filtering by them, if a query included
only matchers on these added labels the matchers would end up being
empty -- but downstream prometheus doesn't support empty matchers. This
simply replaces empty matchers with `{__name__=".+"}` (which effectively
matches all).

Fixes #251