### PR TITLE
allow overriding the remote read path

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -42,6 +42,8 @@ promxy:
       anti_affinity: 10s
       # Controls whether to use remote_read or the prom HTTP API for fetching remote raw data
       remote_read: true
+      # configures the path to send remote read requests to. The default is "api/v1/read"
+      remote_read_path: api/v1/read
       # path_prefix defines a prefix to prepend to all queries to hosts in this servergroup
       path_prefix: /example/prefix
       # query_params adds the following map of query parameters to downstream requests.
@@ -56,10 +58,10 @@ promxy:
         dial_timeout: 1s
         tls_config:
           insecure_skip_verify: true
-      
+
       # relative_time_range defines a relative-to-now time range that this server group contains.
       # this is completely optional and start/end are both optional as well
-      # an example is if this servergroup only has the most recent 3h of data 
+      # an example is if this servergroup only has the most recent 3h of data
       # the "start" would be -3h and the end would be left out
       relative_time_range:
         start: -3h

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -13,8 +13,9 @@ import (
 var (
 	// DefaultConfig is the Default base promxy configuration
 	DefaultConfig = Config{
-		AntiAffinity: time.Second * 10,
-		Scheme:       "http",
+		AntiAffinity:   time.Second * 10,
+		Scheme:         "http",
+		RemoteReadPath: "api/v1/read",
 		HTTPConfig: HTTPClientConfig{
 			DialTimeout: time.Millisecond * 2000, // Default dial timeout of 200ms
 		},
@@ -43,6 +44,8 @@ type Config struct {
 	// from the same memory-balooning problems that the HTTP+JSON API originally had.
 	// It has **less** of a problem (its 2x memory instead of 14x) so it is a viable option.
 	RemoteRead bool `yaml:"remote_read"`
+	// RemoteReadPath sets the remote read path for the hosts in this servergroup
+	RemoteReadPath string `yaml:"remote_read_path"`
 	// HTTP client config for promxy to use when connecting to the various server_groups
 	// this is the same config as prometheus
 	HTTPConfig HTTPClientConfig `yaml:"http_client"`

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -156,7 +156,7 @@ SYNC_LOOP:
 					apiClient = &promclient.PromAPIV1{v1.NewAPI(client)}
 
 					if s.Cfg.RemoteRead {
-						u.Path = path.Join(u.Path, "api/v1/read")
+						u.Path = path.Join(u.Path, s.Cfg.RemoteReadPath)
 						cfg := &remote.ClientConfig{
 							URL: &config_util.URL{u},
 							// TODO: from context?


### PR DESCRIPTION
m3 uses a different path than the one that was hardcoded into promxy (ref: https://m3db.github.io/m3/coordinator/api/remote/#remote-read), so this allows setting the path in the config by server group.

This seems like it would potentially make `path_prefix` removable. I didn't attempt to remove for the sake of backwards compatibility.