### PR TITLE
Add locking around promql Visitors

### DIFF
--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -189,7 +189,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 	aggFinder := &BooleanFinder{Func: isAgg}
 	offsetFinder := &OffsetFinder{}
 
-	visitor := &MultiVisitor{[]promql.Visitor{aggFinder, offsetFinder}}
+	visitor := NewMultiVisitor([]promql.Visitor{aggFinder, offsetFinder})
 
 	if _, err := promql.Walk(ctx, visitor, s, node, nil, nil); err != nil {
 		return nil, err


### PR DESCRIPTION
Since the visitors are potentially run in parallel (due to the parallelism added in promql.Walk) we need to ensure we lock the structs to avoid data races