### PR TITLE
Adding in PerserveName to handoff the name label and fix the result

### DIFF
--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -297,25 +297,25 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 		// Convert avg into sum() / count()
 		case promql.ItemAvg:
 			// Replace with sum() / count()
-			return &promql.BinaryExpr{
+			return PreserveNameLabel(&promql.BinaryExpr{
 				Op: promql.ItemDIV,
-				LHS: &promql.AggregateExpr{
+				LHS: PreserveNameLabel(&promql.AggregateExpr{
 					Op:       promql.ItemSum,
 					Expr:     CloneExpr(n.Expr),
 					Param:    n.Param,
 					Grouping: n.Grouping,
 					Without:  n.Without,
-				},
+				}, "__name__", "__name"),
 
-				RHS: &promql.AggregateExpr{
+				RHS: PreserveNameLabel(&promql.AggregateExpr{
 					Op:       promql.ItemCount,
 					Expr:     CloneExpr(n.Expr),
 					Param:    n.Param,
 					Grouping: n.Grouping,
 					Without:  n.Without,
-				},
+				}, "__name__", "__name"),
 				VectorMatching: &promql.VectorMatching{Card: promql.CardOneToOne},
-			}, nil
+			}, "__name", "__name__"), nil
 
 		// For count we simply need to change this to a sum over the data we get back
 		case promql.ItemCount:

--- a/pkg/proxystorage/util.go
+++ b/pkg/proxystorage/util.go
@@ -115,3 +115,9 @@ func CloneExpr(expr promql.Expr) (newExpr promql.Expr) {
 	newExpr, _ = promql.ParseExpr(expr.String())
 	return
 }
+
+// PreserveNameLabel wraps the input expression with a label replace in order to preserve the metadata through binary expressions
+func PreserveNameLabel(expr promql.Expr, srcLabel string, dstLabel string) (relabelExpr promql.Expr) {
+	relabelExpr, _ = promql.ParseExpr(fmt.Sprintf("label_replace(%s,`%s`,`$1`,`%s`,`(.*)`)", expr.String(), dstLabel, srcLabel))
+	return relabelExpr
+}


### PR DESCRIPTION
A bit crude but a functional work around for issue #274. Right now it does leave the temp `__name` label, looking for the best way to strip that.