### PR TITLE
Workaround for __name__ grouping in avg()

### DIFF
--- a/pkg/proxystorage/util.go
+++ b/pkg/proxystorage/util.go
@@ -115,3 +115,9 @@ func CloneExpr(expr promql.Expr) (newExpr promql.Expr) {
 	newExpr, _ = promql.ParseExpr(expr.String())
 	return
 }
+
+// PreserveLabel wraps the input expression with a label replace in order to preserve the metadata through binary expressions
+func PreserveLabel(expr promql.Expr, srcLabel string, dstLabel string) (relabelExpress promql.Expr) {
+	relabelExpress, _ = promql.ParseExpr(fmt.Sprintf("label_replace(%s,`%s`,`$1`,`%s`,`(.*)`)", expr.String(), dstLabel, srcLabel))
+	return relabelExpress
+}

--- a/test/testdata/issue_274.test
+++ b/test/testdata/issue_274.test
@@ -1,0 +1,18 @@
+# Test for https://github.com/jacksontj/promxy/issues/274
+load 5m
+    metric_1{a="1"} 1
+    metric_10{a="10"} 10
+    metric_1000{a="1000"} 1000
+    metric_10000{a="10000"} 10000
+
+eval instant at 5m avg({__name__=~"metric_.*"}) by (a)
+    {a="1"} 1
+    {a="10"} 10
+    {a="1000"} 1000
+    {a="10000"} 10000
+
+eval instant at 5m avg({__name__=~"metric_.*"}) by (__name__)
+    metric_1{} 1
+    metric_10{} 10
+    metric_1000{} 1000
+    metric_10000{} 10000


### PR DESCRIPTION
Right now promql's BinaryExpr strips the __name__ label -- which breaks
the avg() optimizations in the NodeReplacer. This patch implements a
relabel workaround (which is nasty, but works) to relabel `__name__` ->
`__name` and then back.

Fixes #274

Special thanks to @john-delivuk for the debugging help!


TODO:
- [x] Investigate mechanism without string() and parse