### PR TITLE
Properly re-run aggregates for subqueries

### DIFF
--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -255,7 +255,8 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 		}
 		switch subNodeTyped := subNode.(type) {
 		case *promql.AggregateExpr:
-			n.Expr = promql.NewRawMatrixFromVector(subNodeTyped.Expr.(*promql.VectorSelector))
+			subNodeTyped.Expr = promql.NewRawMatrixFromVector(subNodeTyped.Expr.(*promql.VectorSelector))
+			n.Expr = subNodeTyped
 		case *promql.MatrixSelector:
 			n.Expr = promql.NewRawMatrixFromMatrix(subNodeTyped)
 		case *promql.VectorSelector:


### PR DESCRIPTION
Previously we were replacing the returned Expr from an AggregateExpr to
a MatrixSelector -- meaning it wasn't aggregated. This was causing some
interesting promql failures (as a `sum` would have a bunch of labels --
even though there was no `by` clause). This simpy wraps the resultant
Selector within the AggregateExpr to be a Raw selector and still keep
the aggregateExpr wrapping.

Fixes #273