### PR TITLE
Revert "Use DisableLookback feature in NodeReplacer"

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -537,7 +537,7 @@
 
 [[projects]]
   branch = "release-2.10_fork_promxy"
-  digest = "1:9dcdd7af04713621d3ec2664afd6946a4aedaede43ff6245f026c3f41ee14d99"
+  digest = "1:fee035f8c85b78e2442e452972e1bd7d1f3fc1a61873927b3476e4333ef9b58a"
   name = "github.com/prometheus/prometheus"
   packages = [
     "config",
@@ -586,7 +586,7 @@
     "web/ui",
   ]
   pruneopts = "T"
-  revision = "5e7b325121b893703f982d554d70debb6d2f6e0c"
+  revision = "c784807932c2a1f98ecd1ff54ea1893a4d3213cc"
   source = "github.com/jacksontj/prometheus"
 
 [[projects]]

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -507,6 +507,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 		var warnings api.Warnings
 		var err error
 		if s.Interval > 0 {
+			n.LookbackDelta = s.Interval - time.Duration(1)
 			result, warnings, err = state.client.QueryRange(ctx, n.String(), v1.Range{
 				Start: s.Start.Add(-offset),
 				End:   s.End.Add(-offset),

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -410,7 +410,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 				series[i] = &proxyquerier.Series{iterator}
 			}
 
-			ret := &promql.VectorSelector{Offset: offset, DisableLookback: true}
+			ret := &promql.VectorSelector{Offset: offset}
 			ret.SetSeries(series, promhttputil.WarningsConvert(warnings))
 
 			// Replace with sum(count_values()) BY (label)
@@ -445,7 +445,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 				series[i] = &proxyquerier.Series{iterator}
 			}
 
-			ret := &promql.VectorSelector{Offset: offset, DisableLookback: true}
+			ret := &promql.VectorSelector{Offset: offset}
 			ret.SetSeries(series, promhttputil.WarningsConvert(warnings))
 			n.Expr = ret
 
@@ -481,7 +481,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 			series[i] = &proxyquerier.Series{iterator}
 		}
 
-		ret := &promql.VectorSelector{Offset: offset, DisableLookback: true}
+		ret := &promql.VectorSelector{Offset: offset}
 		ret.SetSeries(series, promhttputil.WarningsConvert(warnings))
 
 		// the "scalar()" function is a bit tricky. It can return a scalar or a vector.
@@ -527,7 +527,6 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *promql.EvalStmt, nod
 		}
 		n.Offset = offset
 		n.SetSeries(series, promhttputil.WarningsConvert(warnings))
-		n.DisableLookback = true
 
 	// If we hit this someone is asking for a matrix directly, if so then we don't
 	// have anyway to ask for less-- since this is exactly what they are asking for

--- a/vendor/github.com/prometheus/prometheus/promql/ast.go
+++ b/vendor/github.com/prometheus/prometheus/promql/ast.go
@@ -161,15 +161,23 @@ type UnaryExpr struct {
 
 // VectorSelector represents a Vector selection.
 type VectorSelector struct {
-	Name            string
-	Offset          time.Duration
-	LabelMatchers   []*labels.Matcher
-	DisableLookback bool
+	Name          string
+	Offset        time.Duration
+	LabelMatchers []*labels.Matcher
+	LookbackDelta time.Duration
 
 	// The unexpanded seriesSet populated at query preparation time.
 	unexpandedSeriesSet storage.SeriesSet
 	series              []storage.Series
 	warnings            storage.Warnings
+}
+
+func (m *VectorSelector) GetLookbackDelta() time.Duration {
+	if m.LookbackDelta > 0 {
+		return m.LookbackDelta
+	}
+
+	return LookbackDelta
 }
 
 func (m *VectorSelector) SetSeries(series []storage.Series, w storage.Warnings) {

--- a/vendor/github.com/prometheus/prometheus/promql/engine.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine.go
@@ -1263,7 +1263,7 @@ func (ev *evaluator) vectorSelectorSingle(it *storage.BufferedSeriesIterator, no
 
 	if !ok || t > refTime {
 		t, v, ok = it.PeekBack(1)
-		if !ok || t < refTime-durationMilliseconds(LookbackDelta) || node.DisableLookback {
+		if !ok || t < refTime-durationMilliseconds(node.GetLookbackDelta()) {
 			return 0, 0, false
 		}
 	}


### PR DESCRIPTION
This reverts commit c2454bb3d4081cec103a06c99eedaa67d1d140fe.

in #223 the objective was to avoid querying excessive amounts of
previous data (e.g. double lookback range). This particular change
actually made it so we are now significantly more strict about the
timestamps that we get from the downstream; which is not as desierable
(as any level of caching in the middle causes issues). What this does
mean though is if the result returns an inaccurate timestamp (due to
caching or something else) promql may interpolate the value -- which is
what it does for all other queries of data off of the scrape interval.
So this should be fine -- and was the previous behavior.

Fixes #298