### PR TITLE
change docker base image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /go/src/github.com/jacksontj/promxy
 RUN cd /go/src/github.com/jacksontj/promxy/cmd/promxy && CGO_ENABLED=0 go build
 RUN cd /go/src/github.com/jacksontj/promxy/cmd/remote_write_exporter && CGO_ENABLED=0 go build
 
-FROM scratch
+FROM alpine:3.11.6
 MAINTAINER Thomas Jackson <jacksontj.89@gmail.com>
 EXPOSE     8082
 


### PR DESCRIPTION
The scratch base image is too hard for debugging because it don't have /bin/sh so that you can't run `docker exec`.

Since the alpine base image is small enough, it won't be a problem that promxy image size become larger.

Signed-off-by: Wing924 <weihe924stephen@gmail.com>