### PR TITLE
Create new go-kit log wrapper that honors log levels

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -26,7 +26,6 @@ import (
 	"crypto/md5"
 
 	kitlog "github.com/go-kit/kit/log"
-	kitloglogrus "github.com/go-kit/kit/log/logrus"
 	"github.com/jessevdk/go-flags"
 	"github.com/julienschmidt/httprouter"
 	"github.com/prometheus/client_golang/prometheus"
@@ -163,11 +162,11 @@ func main() {
 
 	// Above level 6, the k8s client would log bearer tokens in clear-text.
 	glog.ClampLevel(6)
-	glog.SetLogger(kitloglogrus.NewLogrusLogger(logrus.WithField("component", "k8s_client_runtime").Logger))
+	glog.SetLogger(logging.NewLogger(logrus.WithField("component", "k8s_client_runtime").Logger))
 
 	// Above level 6, the k8s client would log bearer tokens in clear-text.
 	klog.ClampLevel(6)
-	klog.SetLogger(kitloglogrus.NewLogrusLogger(logrus.WithField("component", "k8s_client_runtime").Logger))
+	klog.SetLogger(logging.NewLogger(logrus.WithField("component", "k8s_client_runtime").Logger))
 
 	// Create base context for this daemon
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/logging/logrus_logger.go
+++ b/pkg/logging/logrus_logger.go
@@ -1,0 +1,68 @@
+// A logrus adapter to the go-kit log.Logger interface.
+package logging
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/sirupsen/logrus"
+)
+
+type Logger struct {
+	field logrus.FieldLogger
+}
+
+type Option func(*Logger)
+
+var errMissingValue = errors.New("(MISSING)")
+
+// NewLogger returns a Go kit log.Logger that sends log events to a logrus.Logger.
+func NewLogger(logger logrus.FieldLogger, options ...Option) log.Logger {
+	l := &Logger{
+		field: logger,
+	}
+
+	for _, optFunc := range options {
+		optFunc(l)
+	}
+
+	return l
+}
+
+func (l Logger) Log(keyvals ...interface{}) error {
+	fields := logrus.Fields{}
+
+	var lvl level.Value
+
+	for i := 0; i < len(keyvals); i += 2 {
+		if i+1 < len(keyvals) {
+			if keyvals[i] == level.Key() {
+				tmpLevel, ok := keyvals[i+1].(level.Value)
+				if ok {
+					lvl = tmpLevel
+				}
+			} else {
+				fields[fmt.Sprint(keyvals[i])] = keyvals[i+1]
+			}
+		} else {
+			fields[fmt.Sprint(keyvals[i])] = errMissingValue
+		}
+	}
+
+	switch lvl {
+	case level.InfoValue():
+		l.field.WithFields(fields).Info()
+	case level.ErrorValue():
+		l.field.WithFields(fields).Error()
+	case level.DebugValue():
+		l.field.WithFields(fields).Debug()
+	case level.WarnValue():
+		l.field.WithFields(fields).Warn()
+	default:
+		l.field.WithFields(fields).Print()
+	}
+
+	return nil
+}

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -16,8 +16,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/sirupsen/logrus"
 
-	kitloglogrus "github.com/go-kit/kit/log/logrus"
-
+	"github.com/jacksontj/promxy/pkg/logging"
 	"github.com/jacksontj/promxy/pkg/promhttputil"
 	"github.com/jacksontj/promxy/pkg/remote"
 
@@ -115,7 +114,7 @@ func (p *ProxyStorage) ApplyConfig(c *proxyconfig.Config) error {
 			newState.remoteStorage = oldState.remoteStorage
 		} else {
 			// TODO: configure path?
-			remote := remote.NewStorage(kitloglogrus.NewLogrusLogger(logrus.WithField("component", "k8s_client_runtime").Logger), func() (int64, error) { return 0, nil }, 1*time.Second)
+			remote := remote.NewStorage(logging.NewLogger(logrus.WithField("component", "remote_write").Logger), func() (int64, error) { return 0, nil }, 1*time.Second)
 			if err := remote.ApplyConfig(&c.PromConfig); err != nil {
 				return err
 			}


### PR DESCRIPTION
The upstream log wrapper doesn't actually honor the log levels, which is confusing. This creates our own logger wrapper that does honor the levels

Fixes #295