### PR TITLE
run as nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/jacksontj/promxy/cmd/promxy/promxy /bin/promxy
 COPY --from=builder /go/src/github.com/jacksontj/promxy/cmd/remote_write_exporter/remote_write_exporter /bin/remote_write_exporter
 
+USER       nobody
+
 ENTRYPOINT [ "/bin/promxy" ]
 


### PR DESCRIPTION
Let's run promxy as `nobody` user by default.
Current is run as `root`, which have security issue.