### PR TITLE
Add HTTPClientConfig to the Remote Storage client's configuration to support TLS settings for Remote Read

### DIFF
--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -161,7 +161,7 @@ SYNC_LOOP:
 							URL: &config_util.URL{u},
 							// TODO: from context?
 							HTTPClientConfig: s.Cfg.HTTPConfig.HTTPConfig,
-							Timeout: model.Duration(time.Minute * 2),
+							Timeout:          model.Duration(time.Minute * 2),
 						}
 						remoteStorageClient, err := remote.NewClient(1, cfg)
 						if err != nil {

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -160,6 +160,7 @@ SYNC_LOOP:
 						cfg := &remote.ClientConfig{
 							URL: &config_util.URL{u},
 							// TODO: from context?
+							HTTPClientConfig: s.Cfg.HTTPConfig.HTTPConfig,
 							Timeout: model.Duration(time.Minute * 2),
 						}
 						remoteStorageClient, err := remote.NewClient(1, cfg)


### PR DESCRIPTION
Co-authored-by: Dana Pruitt <dpruitt@vmware.com>
Co-authored-by: Jeremy Alvis <jalvis@vmware.com>

Closes #373