### PR TITLE
Add LookbackDelta to web handler

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -342,6 +342,7 @@ func main() {
 		ScrapeManager: scrapeManager,
 		RuleManager:   ruleManager,
 		Notifier:      notifierManager,
+		LookbackDelta: opts.QueryLookbackDelta,
 
 		RemoteReadConcurrencyLimit: opts.RemoteReadMaxConcurrency,
 


### PR DESCRIPTION
Without this option we have a 0s LookbackDelta which causes the /federate endpoint to query upstreams with a 1s lookback (which is too short).

Fixes #397