### PR TITLE
Fix HTTP metrics for API handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ imports:
 
 .PHONY: test
 test:
-	GO111MODULE=on $(GO) test -mod=vendor -v ./...
+	GO111MODULE=on $(GO) test -mod=vendor -tags netgo,builtinassets -v ./...
 
 .PHONY: release
 release:

--- a/test/promql_test.go
+++ b/test/promql_test.go
@@ -70,7 +70,7 @@ promxy:
           insecure_skip_verify: true
     - static_configs:
         - targets:
-          - localhost:8084
+          - localhost:8085
       labels:
         az: b
       http_client:
@@ -92,7 +92,7 @@ promxy:
           insecure_skip_verify: true
     - static_configs:
         - targets:
-          - localhost:8084
+          - localhost:8085
       labels:
         az: b
       remote_read: true
@@ -241,7 +241,7 @@ func TestEvaluations(t *testing.T) {
 
 				// Create API for the storage engine
 				srv, stopChan := startAPIForTest(test.Storage(), ":8083")
-				srv2, stopChan2 := startAPIForTest(test.Storage(), ":8084")
+				srv2, stopChan2 := startAPIForTest(test.Storage(), ":8085")
 
 				ps := getProxyStorage(psConfig)
 				lStorage := &LayeredStorage{ps, test.Storage()}

--- a/test/promql_test.go
+++ b/test/promql_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -166,7 +167,9 @@ func startAPIForTest(s storage.Storage, listen string) (*http.Server, chan struc
 	go func() {
 		defer close(stopChan)
 		close(startChan)
-		srv.ListenAndServe()
+		if err := srv.ListenAndServe(); err != nil {
+			fmt.Println("Error listening to", listen, err)
+		}
 	}()
 
 	<-startChan


### PR DESCRIPTION
Previously it was creating another "router" object which was causing the
API endpoints to not have the prometheus_http metrics.