### PR TITLE
Correct series Select handling with upstream changes

### DIFF
--- a/pkg/proxyquerier/querier.go
+++ b/pkg/proxyquerier/querier.go
@@ -47,7 +47,7 @@ func (h *ProxyQuerier) Select(_ bool, hints *storage.SelectHints, matchers ...*l
 	// data call (query/query_range) and a metadata call (series). For now
 	// the working workaround is to switch based on the hints.
 	// https://github.com/prometheus/prometheus/issues/4057
-	if hints == nil {
+	if hints == nil || hints.Func == "series" {
 		matcherString, err := promhttputil.MatcherToString(matchers)
 		if err != nil {
 			return NewSeriesSet(nil, nil, err)


### PR DESCRIPTION
In prometheus 2.24 dep upgrade prometheus changed how it signaled to
queriers whether the request was for data or just the series.
So with that upgrade we started *always* fetching all the data
regardless of the query (in this case a series call would fetch all data
for those series in the time range requested). As with before we're
working around this by introspecting (cortex does the same --
https://github.com/cortexproject/cortex/pull/3461).

Fixes #415