### PR TITLE
Correctly pass down warnings/errors to SeriesSet

### DIFF
--- a/pkg/proxyquerier/series_set.go
+++ b/pkg/proxyquerier/series_set.go
@@ -7,7 +7,9 @@ import (
 // NewSeriesSet returns a SeriesSet for the given series
 func NewSeriesSet(series []storage.Series, warnings storage.Warnings, err error) *SeriesSet {
 	return &SeriesSet{
-		series: series,
+		series:   series,
+		warnings: warnings,
+		err:      err,
 	}
 }
 


### PR DESCRIPTION
When the errors/warnings were moved to this SeriesSet apparently we
weren't setting it through to the struct properly. This meant that
errors/warnings were being ignored!

Fixes #402