### PR TITLE
Add truncate option to time filters

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -70,6 +70,7 @@ promxy:
       relative_time_range:
         start: -3h
         end: -1h
+        truncate: false
 
       # absolute_time_range defines an absolute time range that this server group contains.
       # this is completely optional and start/end are both optional as well
@@ -78,6 +79,7 @@ promxy:
       absolute_time_range:
         start: '2009-10-10T23:00:00Z'
         end: '2009-10-11T23:00:00Z'
+        truncate: true
 
     # as many additional server groups as you have
     - static_configs:

--- a/pkg/promclient/timefilter.go
+++ b/pkg/promclient/timefilter.go
@@ -13,6 +13,7 @@ import (
 type AbsoluteTimeFilter struct {
 	API
 	Start, End time.Time
+	Truncate   bool
 }
 
 // Query performs a query for the given time.
@@ -30,6 +31,15 @@ func (tf *AbsoluteTimeFilter) QueryRange(ctx context.Context, query string, r v1
 		return nil, nil, nil
 	}
 
+	if tf.Truncate {
+		if r.Start.Before(tf.Start) {
+			r.Start = tf.Start
+		}
+		if r.End.After(tf.End) {
+			r.End = tf.End
+		}
+	}
+
 	return tf.API.QueryRange(ctx, query, r)
 }
 
@@ -38,6 +48,16 @@ func (tf *AbsoluteTimeFilter) Series(ctx context.Context, matches []string, star
 	if (!tf.Start.IsZero() && endTime.Before(tf.Start)) || (!tf.End.IsZero() && startTime.After(tf.End)) {
 		return nil, nil, nil
 	}
+
+	if tf.Truncate {
+		if startTime.Before(tf.Start) {
+			startTime = tf.Start
+		}
+		if endTime.After(tf.End) {
+			endTime = tf.End
+		}
+	}
+
 	return tf.API.Series(ctx, matches, startTime, endTime)
 }
 
@@ -47,6 +67,15 @@ func (tf *AbsoluteTimeFilter) GetValue(ctx context.Context, start, end time.Time
 		return nil, nil, nil
 	}
 
+	if tf.Truncate {
+		if start.Before(tf.Start) {
+			start = tf.Start
+		}
+		if end.After(tf.End) {
+			end = tf.End
+		}
+	}
+
 	return tf.API.GetValue(ctx, start, end, matchers)
 }
 
@@ -54,6 +83,7 @@ func (tf *AbsoluteTimeFilter) GetValue(ctx context.Context, start, end time.Time
 type RelativeTimeFilter struct {
 	API
 	Start, End *time.Duration
+	Truncate   bool
 }
 
 func (tf *RelativeTimeFilter) window() (time.Time, time.Time) {
@@ -87,6 +117,15 @@ func (tf *RelativeTimeFilter) QueryRange(ctx context.Context, query string, r v1
 		return nil, nil, nil
 	}
 
+	if tf.Truncate {
+		if r.Start.Before(tfStart) {
+			r.Start = tfStart
+		}
+		if r.End.After(tfEnd) {
+			r.End = tfEnd
+		}
+	}
+
 	return tf.API.QueryRange(ctx, query, r)
 }
 
@@ -96,6 +135,16 @@ func (tf *RelativeTimeFilter) Series(ctx context.Context, matches []string, star
 	if (!tfStart.IsZero() && endTime.Before(tfStart)) || (!tfEnd.IsZero() && startTime.After(tfEnd)) {
 		return nil, nil, nil
 	}
+
+	if tf.Truncate {
+		if startTime.Before(tfStart) {
+			startTime = tfStart
+		}
+		if endTime.After(tfEnd) {
+			endTime = tfEnd
+		}
+	}
+
 	return tf.API.Series(ctx, matches, startTime, endTime)
 }
 
@@ -104,6 +153,15 @@ func (tf *RelativeTimeFilter) GetValue(ctx context.Context, start, end time.Time
 	tfStart, tfEnd := tf.window()
 	if (!tfStart.IsZero() && end.Before(tfStart)) || (!tfEnd.IsZero() && start.After(tfEnd)) {
 		return nil, nil, nil
+	}
+
+	if tf.Truncate {
+		if start.Before(tfStart) {
+			start = tfStart
+		}
+		if end.After(tfEnd) {
+			end = tfEnd
+		}
 	}
 
 	return tf.API.GetValue(ctx, start, end, matchers)

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -161,8 +161,9 @@ type HTTPClientConfig struct {
 // RelativeTimeRangeConfig configures durations relative from "now" to define
 // a servergroup's time range
 type RelativeTimeRangeConfig struct {
-	Start *time.Duration `yaml:"start"`
-	End   *time.Duration `yaml:"end"`
+	Start    *time.Duration `yaml:"start"`
+	End      *time.Duration `yaml:"end"`
+	Truncate bool           `yaml:"truncate"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -184,8 +185,9 @@ func (tr *RelativeTimeRangeConfig) validate() error {
 
 // AbsoluteTimeRangeConfig contains absolute times to define a servergroup's time range
 type AbsoluteTimeRangeConfig struct {
-	Start time.Time `yaml:"start"`
-	End   time.Time `yaml:"end"`
+	Start    time.Time `yaml:"start"`
+	End      time.Time `yaml:"end"`
+	Truncate bool      `yaml:"truncate"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -178,17 +178,19 @@ SYNC_LOOP:
 					// Optionally add time range layers
 					if s.Cfg.AbsoluteTimeRangeConfig != nil {
 						apiClient = &promclient.AbsoluteTimeFilter{
-							API:   apiClient,
-							Start: s.Cfg.AbsoluteTimeRangeConfig.Start,
-							End:   s.Cfg.AbsoluteTimeRangeConfig.End,
+							API:      apiClient,
+							Start:    s.Cfg.AbsoluteTimeRangeConfig.Start,
+							End:      s.Cfg.AbsoluteTimeRangeConfig.End,
+							Truncate: s.Cfg.AbsoluteTimeRangeConfig.Truncate,
 						}
 					}
 
 					if s.Cfg.RelativeTimeRangeConfig != nil {
 						apiClient = &promclient.RelativeTimeFilter{
-							API:   apiClient,
-							Start: s.Cfg.RelativeTimeRangeConfig.Start,
-							End:   s.Cfg.RelativeTimeRangeConfig.End,
+							API:      apiClient,
+							Start:    s.Cfg.RelativeTimeRangeConfig.Start,
+							End:      s.Cfg.RelativeTimeRangeConfig.End,
+							Truncate: s.Cfg.RelativeTimeRangeConfig.Truncate,
 						}
 					}
 


### PR DESCRIPTION
This allows for configuring the filters to actually truncate the time
they send to downstream APIs

Fixes #422