### PR TITLE
Ignore errors with LabelNames

### DIFF
--- a/pkg/promclient/ignore_error.go
+++ b/pkg/promclient/ignore_error.go
@@ -16,6 +16,12 @@ type IgnoreErrorAPI struct {
 	API
 }
 
+// LabelNames returns all the unique label names present in the block in sorted order.
+func (n *IgnoreErrorAPI) LabelNames(ctx context.Context) ([]string, v1.Warnings, error) {
+	v, w, _ := n.API.LabelNames(ctx)
+	return v, w, nil
+}
+
 // LabelValues performs a query for the values of the given label.
 func (n *IgnoreErrorAPI) LabelValues(ctx context.Context, label string) (model.LabelValues, v1.Warnings, error) {
 	v, w, _ := n.API.LabelValues(ctx, label)


### PR DESCRIPTION
Hello,

If I am not mistaken there is a missing method to swallow errors from LabelNames.

Without this fix I had this kind of errors in Grafana when doing queries using labels API with a failed server group. 

`{"status":"error","errorType":"execution","error":"Get \"http://promxy-data:8082/api/v1/labels?end=9223309901257974\u0026start=-9223309901257974\": dial tcp: lookup promxy-data on 172.20.0.10:53: no such host"}`