### PR TITLE
Remove inheritance from full wrappers

### DIFF
--- a/pkg/promclient/debug.go
+++ b/pkg/promclient/debug.go
@@ -12,7 +12,7 @@ import (
 
 // DebugAPI simply logs debug lines for the given API with the given prefix
 type DebugAPI struct {
-	API
+	A             API
 	PrefixMessage string
 }
 
@@ -24,7 +24,7 @@ func (d *DebugAPI) LabelNames(ctx context.Context) ([]string, v1.Warnings, error
 	logrus.WithFields(fields).Debug(d.PrefixMessage)
 
 	s := time.Now()
-	v, w, err := d.API.LabelNames(ctx)
+	v, w, err := d.A.LabelNames(ctx)
 	fields["took"] = time.Since(s)
 
 	if logrus.GetLevel() > logrus.DebugLevel {
@@ -48,7 +48,7 @@ func (d *DebugAPI) LabelValues(ctx context.Context, label string) (model.LabelVa
 	logrus.WithFields(fields).Debug(d.PrefixMessage)
 
 	s := time.Now()
-	v, w, err := d.API.LabelValues(ctx, label)
+	v, w, err := d.A.LabelValues(ctx, label)
 	fields["took"] = time.Since(s)
 
 	if logrus.GetLevel() > logrus.DebugLevel {
@@ -73,7 +73,7 @@ func (d *DebugAPI) Query(ctx context.Context, query string, ts time.Time) (model
 	logrus.WithFields(fields).Debug(d.PrefixMessage)
 
 	s := time.Now()
-	v, w, err := d.API.Query(ctx, query, ts)
+	v, w, err := d.A.Query(ctx, query, ts)
 	fields["took"] = time.Since(s)
 
 	if logrus.GetLevel() > logrus.DebugLevel {
@@ -98,7 +98,7 @@ func (d *DebugAPI) QueryRange(ctx context.Context, query string, r v1.Range) (mo
 	logrus.WithFields(fields).Debug(d.PrefixMessage)
 
 	s := time.Now()
-	v, w, err := d.API.QueryRange(ctx, query, r)
+	v, w, err := d.A.QueryRange(ctx, query, r)
 	fields["took"] = time.Since(s)
 
 	if logrus.GetLevel() > logrus.DebugLevel {
@@ -124,7 +124,7 @@ func (d *DebugAPI) Series(ctx context.Context, matches []string, startTime time.
 	logrus.WithFields(fields).Debug(d.PrefixMessage)
 
 	s := time.Now()
-	v, w, err := d.API.Series(ctx, matches, startTime, endTime)
+	v, w, err := d.A.Series(ctx, matches, startTime, endTime)
 	fields["took"] = time.Since(s)
 
 	if logrus.GetLevel() > logrus.DebugLevel {
@@ -150,7 +150,7 @@ func (d *DebugAPI) GetValue(ctx context.Context, start, end time.Time, matchers 
 	logrus.WithFields(fields).Debug(d.PrefixMessage)
 
 	s := time.Now()
-	v, w, err := d.API.GetValue(ctx, start, end, matchers)
+	v, w, err := d.A.GetValue(ctx, start, end, matchers)
 	fields["took"] = time.Since(s)
 
 	if logrus.GetLevel() > logrus.DebugLevel {

--- a/pkg/promclient/ignore_error.go
+++ b/pkg/promclient/ignore_error.go
@@ -13,53 +13,53 @@ import (
 // be used with all the regular error merging logic and effectively have its errors
 // not considered
 type IgnoreErrorAPI struct {
-	API
+	A API
 }
 
 // LabelNames returns all the unique label names present in the block in sorted order.
 func (n *IgnoreErrorAPI) LabelNames(ctx context.Context) ([]string, v1.Warnings, error) {
-	v, w, _ := n.API.LabelNames(ctx)
+	v, w, _ := n.A.LabelNames(ctx)
 	return v, w, nil
 }
 
 // LabelValues performs a query for the values of the given label.
 func (n *IgnoreErrorAPI) LabelValues(ctx context.Context, label string) (model.LabelValues, v1.Warnings, error) {
-	v, w, _ := n.API.LabelValues(ctx, label)
+	v, w, _ := n.A.LabelValues(ctx, label)
 
 	return v, w, nil
 }
 
 // Query performs a query for the given time.
 func (n *IgnoreErrorAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
-	v, w, _ := n.API.Query(ctx, query, ts)
+	v, w, _ := n.A.Query(ctx, query, ts)
 
 	return v, w, nil
 }
 
 // QueryRange performs a query for the given range.
 func (n *IgnoreErrorAPI) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, v1.Warnings, error) {
-	v, w, _ := n.API.QueryRange(ctx, query, r)
+	v, w, _ := n.A.QueryRange(ctx, query, r)
 
 	return v, w, nil
 }
 
 // Series finds series by label matchers.
 func (n *IgnoreErrorAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
-	v, w, _ := n.API.Series(ctx, matches, startTime, endTime)
+	v, w, _ := n.A.Series(ctx, matches, startTime, endTime)
 
 	return v, w, nil
 }
 
 // GetValue loads the raw data for a given set of matchers in the time range
 func (n *IgnoreErrorAPI) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (model.Value, v1.Warnings, error) {
-	v, w, _ := n.API.GetValue(ctx, start, end, matchers)
+	v, w, _ := n.A.GetValue(ctx, start, end, matchers)
 
 	return v, w, nil
 }
 
 // Key returns a labelset used to determine other api clients that are the "same"
 func (n *IgnoreErrorAPI) Key() model.LabelSet {
-	if apiLabels, ok := n.API.(APILabels); ok {
+	if apiLabels, ok := n.A.(APILabels); ok {
 		return apiLabels.Key()
 	}
 	return nil

--- a/pkg/promclient/recover.go
+++ b/pkg/promclient/recover.go
@@ -11,7 +11,17 @@ import (
 
 // recoverAPI simply recovers all panics and returns them as errors
 // this is used for testing
-type recoverAPI struct{ API }
+type recoverAPI struct{ A API }
+
+// LabelNames returns all the unique label names present in the block in sorted order.
+func (api *recoverAPI) LabelNames(ctx context.Context) (v []string, w v1.Warnings, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	return api.A.LabelNames(ctx)
+}
 
 // LabelValues performs a query for the values of the given label.
 func (api *recoverAPI) LabelValues(ctx context.Context, label string) (v model.LabelValues, w v1.Warnings, err error) {
@@ -20,7 +30,7 @@ func (api *recoverAPI) LabelValues(ctx context.Context, label string) (v model.L
 			err = r.(error)
 		}
 	}()
-	return api.API.LabelValues(ctx, label)
+	return api.A.LabelValues(ctx, label)
 }
 
 // Query performs a query for the given time.
@@ -30,7 +40,7 @@ func (api *recoverAPI) Query(ctx context.Context, query string, ts time.Time) (v
 			err = r.(error)
 		}
 	}()
-	return api.API.Query(ctx, query, ts)
+	return api.A.Query(ctx, query, ts)
 }
 
 // QueryRange performs a query for the given range.
@@ -40,7 +50,7 @@ func (api *recoverAPI) QueryRange(ctx context.Context, query string, r v1.Range)
 			err = r.(error)
 		}
 	}()
-	return api.API.QueryRange(ctx, query, r)
+	return api.A.QueryRange(ctx, query, r)
 }
 
 // Series finds series by label matchers.
@@ -50,7 +60,7 @@ func (api *recoverAPI) Series(ctx context.Context, matches []string, startTime t
 			err = r.(error)
 		}
 	}()
-	return api.API.Series(ctx, matches, startTime, endTime)
+	return api.A.Series(ctx, matches, startTime, endTime)
 }
 
 // GetValue loads the raw data for a given set of matchers in the time range
@@ -60,5 +70,5 @@ func (api *recoverAPI) GetValue(ctx context.Context, start, end time.Time, match
 			err = r.(error)
 		}
 	}()
-	return api.API.GetValue(ctx, start, end, matchers)
+	return api.A.GetValue(ctx, start, end, matchers)
 }


### PR DESCRIPTION
This way we can more easily catch missing wrapped methods with the
compiler