### PR TITLE
fix sort or sort_desc error

### DIFF
--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -478,6 +478,12 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *parser.EvalStmt, nod
 	// prometheus node to answer
 	case *parser.Call:
 		logrus.Debugf("call %v %v", n, n.Type())
+
+		// the functions of sort() and sort_desc() need whole results to calculate.
+		if n.Func.Name == "sort" || n.Func.Name == "sort_desc" {
+			return n, nil
+		}
+
 		removeOffsetFn()
 
 		var result model.Value


### PR DESCRIPTION
issue: https://github.com/jacksontj/promxy/issues/490
While executing sort(xx), promxy will return ordered timeseries within the result from each server_group. However, the results across different datasources haven't been combined and sorted.