### PR TITLE
Fix goroutine leak on config reload

### DIFF
--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -61,7 +61,7 @@ func (p *proxyStorageState) Cancel(n *proxyStorageState) {
 			sg.Cancel()
 		}
 	}
-	// We call close if the new one is nil, or if the appanders don't match
+	// We call close if the new one is nil, or if the appenders don't match
 	if n == nil || p.appender != n.appender {
 		if p.appenderCloser != nil {
 			p.appenderCloser()
@@ -145,7 +145,7 @@ func (p *ProxyStorage) ApplyConfig(c *proxyconfig.Config) error {
 
 	newState.Ready()        // Wait for the newstate to be ready
 	p.state.Store(newState) // Store the new state
-	if oldState != nil && oldState.appender != newState.appender {
+	if oldState != nil {
 		oldState.Cancel(newState) // Cancel the old one
 	}
 


### PR DESCRIPTION
Promxy is leaking goroutines on config reloads leading to OOM kills in the long run.

From  : https://instance-that-reload-its-config-way-too-often/debug/pprof/goroutine?debug=1
```
goroutine profile: total 63342
21111 @ 0x4374c0 0x447763 0x9bb257 0x467571
#	0x9bb256	github.com/prometheus/prometheus/discovery.(*Manager).sender+0x116	/home/jacksontj/workspace/golang/src/github.com/jacksontj/promxy/vendor/github.com/prometheus/prometheus/discovery/manager.go:234

21110 @ 0x4374c0 0x405f77 0x405c7b 0x20cc731 0x467571
#	0x20cc730	github.com/jacksontj/promxy/pkg/servergroup.(*ServerGroup).Sync+0x16b0	/home/jacksontj/workspace/golang/src/github.com/jacksontj/promxy/pkg/servergroup/servergroup.go:103

21110 @ 0x4374c0 0x405f77 0x405c7b 0x9ba052 0x467571
#	0x9ba051	github.com/prometheus/prometheus/discovery.(*Manager).Run+0x71	/home/jacksontj/workspace/golang/src/github.com/jacksontj/promxy/vendor/github.com/prometheus/prometheus/discovery/manager.go:142
...
```

To reproduce start a Promxy instance with the default configuration from the repository and send some SIGHUPs.

---

I found two issues :
- oldState ServerGroups are not cancelled if appenders didn't change
- Prometheus discovery target managers never close `SyncCh` blocking the `ServerGroup Sync()` goroutine forever