### PR TITLE
Added corresponding key for ingress kind in Helm values

### DIFF
--- a/deploy/k8s/helm-charts/promxy/templates/ingress.yaml
+++ b/deploy/k8s/helm-charts/promxy/templates/ingress.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+{{- $path := .Values.ingress.path -}}
+{{- $pathType := .Values.ingress.pathType -}}
+{{- $servicePort := .Values.service.servicePort -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- if .Values.ingress.annotations }}
@@ -14,16 +17,20 @@ metadata:
   name: {{ template "chart.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
   {{- $serviceName := include "chart.fullname" . }}
   {{- range .Values.ingress.hosts }}
-  - host: {{ .name }}
+  - host: {{ . | quote }}
     http:
       paths:
-        - path: {{ .path }}
+        - path: {{ $path }}
+          pathType: {{ $pathType }}
           backend:
-            serviceName: {{ $serviceName }}
-            servicePort: {{ .port | default "http"}}
+            service:
+              name: {{ $serviceName }}
+              port:
+                number: {{ $servicePort }}
   {{- end -}}
 {{- if .Values.ingress.tls }}
   tls:

--- a/deploy/k8s/helm-charts/promxy/values.yaml
+++ b/deploy/k8s/helm-charts/promxy/values.yaml
@@ -58,6 +58,17 @@ service:
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
 
+ingress:
+  enabled: false
+  ingressClassName: nginx
+  annotations: {}
+  extraLabels: {}
+  path: /
+  pathType: Prefix
+  hosts:
+    - example.com
+  tls: []
+
 resources:
   requests:
     cpu: 100m


### PR DESCRIPTION
**The following error receiving while installing via Helm**
```Error: template: promxy/templates/ingress.yaml:1:14: executing "promxy/templates/ingress.yaml" at <.Values.ingress.enabled>: nil pointer evaluating interface {}.enabled```

**What this PR does / why we need it:**
This PR is about fixing Helm values related to ingress.