### PR TITLE
Update to Alpine 3.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . /go/src/github.com/jacksontj/promxy
 RUN cd /go/src/github.com/jacksontj/promxy/cmd/promxy && CGO_ENABLED=0 go build -mod=vendor -tags netgo,builtinassets
 RUN cd /go/src/github.com/jacksontj/promxy/cmd/remote_write_exporter && CGO_ENABLED=0 go build -mod=vendor
 
-FROM alpine:3.15.0
+FROM alpine:3.16.1
 MAINTAINER Thomas Jackson <jacksontj.89@gmail.com>
 EXPOSE     8082
 


### PR DESCRIPTION
Related to https://github.com/jacksontj/promxy/pull/485

There are still quite a few open CVEs. Hopefully this will close some of them.