### PR TITLE
Add timeout option to config file

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -40,6 +40,9 @@ promxy:
         sg: localhost_9090
       # anti-affinity for merging values in timeseries between hosts in the server_group
       anti_affinity: 10s
+      # time to wait for a server's response headers after fully writing the request (including its body, if any).
+      # This time does not include the time to read the response body.
+      timeout: 5s
       # Controls whether to use remote_read or the prom API for fetching remote RAW data (e.g. matrix selectors)
       # Note, some prometheus implementations (e.g. [VictoriaMetrics](https://github.com/prometheus/prometheus/issues/4456) don't support remote_read.
       remote_read: true


### PR DESCRIPTION
This PR is to document in the sample `config.yaml` file the `timeout` option as accepted by https://github.com/jacksontj/promxy/blob/d4609ebcfd2a50d58f2115c1f079bf4779fc5515/pkg/servergroup/config.go#L116