### PR TITLE
A new wrapper client that rewrites the query with replacement labels

### DIFF
--- a/deploy/k8s/helm-charts/promxy/templates/ingress.yaml
+++ b/deploy/k8s/helm-charts/promxy/templates/ingress.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.ingress.enabled }}
-apiVersion: networking.k8s.io/v1beta1
+{{- $path := .Values.ingress.path -}}
+{{- $pathType := .Values.ingress.pathType -}}
+{{- $servicePort := .Values.service.servicePort -}}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
 {{- if .Values.ingress.annotations }}
@@ -14,16 +17,20 @@ metadata:
   name: {{ template "chart.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
   {{- $serviceName := include "chart.fullname" . }}
   {{- range .Values.ingress.hosts }}
-  - host: {{ .name }}
+  - host: {{ . | quote }}
     http:
       paths:
-        - path: {{ .path }}
+        - path: {{ $path }}
+          pathType: {{ $pathType }}
           backend:
-            serviceName: {{ $serviceName }}
-            servicePort: {{ .port | default "http"}}
+            service:
+              name: {{ $serviceName }}
+              port:
+                number: {{ $servicePort }}
   {{- end -}}
 {{- if .Values.ingress.tls }}
   tls:

--- a/deploy/k8s/helm-charts/promxy/values.yaml
+++ b/deploy/k8s/helm-charts/promxy/values.yaml
@@ -58,6 +58,17 @@ service:
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
 
+ingress:
+  enabled: false
+  ingressClassName: nginx
+  annotations: {}
+  extraLabels: {}
+  path: /
+  pathType: Prefix
+  hosts:
+    - example.com
+  tls: []
+
 resources:
   requests:
     cpu: 100m

--- a/pkg/promclient/label_replace.go
+++ b/pkg/promclient/label_replace.go
@@ -1,0 +1,196 @@
+package promclient
+
+import (
+	"context"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/sirupsen/logrus"
+	"time"
+)
+
+// LabelReplaceClient proxies a client and replace labels in the query and result
+type LabelReplaceClient struct {
+	API
+	LabelReplaces map[string]string
+}
+
+func (c *LabelReplaceClient) LabelNames(ctx context.Context, matchers []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error) {
+	matchersToUse, err := c.rewriteMatchers(ctx, matchers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	l, w, err := c.API.LabelNames(ctx, matchersToUse, startTime, endTime)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// add the new label to the returned labels, we do not remove the label that is being replaced
+	for k, _ := range c.LabelReplaces {
+		found := false
+		for _, labelName := range l {
+			if labelName == k {
+				found = true
+			}
+		}
+		if !found {
+			l = append(l, k)
+		}
+	}
+	return l, w, err
+}
+
+func (c *LabelReplaceClient) LabelValues(ctx context.Context, label string, matchers []string, startTime time.Time, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	matchersToUse, err := c.rewriteMatchers(ctx, matchers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO: this is rather strange, this replacement code doesn't run, but somehow it still returns the correct data
+	labelToUse := label
+	if repl, ok := c.LabelReplaces[label]; ok {
+		labelToUse = repl
+	}
+
+	val, w, err := c.API.LabelValues(ctx, labelToUse, matchersToUse, startTime, endTime)
+	if err != nil {
+		return nil, w, err
+	}
+
+	return val, w, nil
+}
+
+// Query performs a query for the given time.
+func (c *LabelReplaceClient) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
+	queryToUse, err := c.rewriteQuery(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	val, w, err := c.API.Query(ctx, queryToUse, ts)
+	if err != nil {
+		return nil, w, err
+	}
+	if err := c.replaceLabelsInMetricValue(val); err != nil {
+		return nil, w, err
+	}
+	return val, w, nil
+}
+
+// QueryRange performs a query for the given range.
+func (c *LabelReplaceClient) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, v1.Warnings, error) {
+	queryToUse, err := c.rewriteQuery(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	val, w, err := c.API.QueryRange(ctx, queryToUse, r)
+	if err != nil {
+		return nil, w, err
+	}
+	if err := c.replaceLabelsInMetricValue(val); err != nil {
+		return nil, w, err
+	}
+	return val, w, nil
+}
+
+// TODO: promxy's own version of this doesn't work, so this does not work either
+func (c *LabelReplaceClient) Series(ctx context.Context, matchers []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	matchersToUse, err := c.rewriteMatchers(ctx, matchers)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v, w, err := c.API.Series(ctx, matchersToUse, startTime, endTime)
+	if err != nil {
+		return nil, w, err
+	}
+
+	c.replaceLabelsInLabelSet(v)
+	return v, w, nil
+}
+
+// GetValue loads the raw data for a given set of matchers in the time range
+func (c *LabelReplaceClient) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (model.Value, v1.Warnings, error) {
+	matchersToUse := RewriteMatchers(c.LabelReplaces, matchers)
+
+	val, w, err := c.API.GetValue(ctx, start, end, matchersToUse)
+	if err != nil {
+		return nil, w, err
+	}
+
+	if err := c.replaceLabelsInMetricValue(val); err != nil {
+		return nil, w, err
+	}
+	return val, w, nil
+}
+
+func (c *LabelReplaceClient) rewriteQuery(ctx context.Context, query string) (string, error) {
+	logrus.Debugf("Query before label replacement: " + query)
+	e, err := parser.ParseExpr(query)
+	if err != nil {
+		return query, err
+	}
+
+	// Walk the expression, to filter out any LabelMatchers that match etc.
+	replaceVisitor := NewLabelReplaceVisitor(c.LabelReplaces)
+	if _, err := parser.Walk(ctx, replaceVisitor, &parser.EvalStmt{Expr: e}, e, nil, nil); err != nil {
+		return query, err
+	}
+
+	newQuery := e.String()
+	logrus.Debugf("Query after label replacement: " + newQuery)
+	return newQuery, nil
+}
+
+func (c *LabelReplaceClient) rewriteMatchers(ctx context.Context, queries []string) ([]string, error) {
+	replacedQueries := make([]string, 0, len(queries))
+	for _, query := range queries {
+		repl, err := c.rewriteQuery(ctx, query)
+		if err != nil {
+			return queries, err
+		}
+		replacedQueries = append(replacedQueries, repl)
+	}
+	return replacedQueries, nil
+}
+
+func (c *LabelReplaceClient) replaceLabelsInMetricValue(a model.Value) error {
+	switch aTyped := a.(type) {
+	case model.Vector:
+		for _, item := range aTyped {
+			for k, v := range c.LabelReplaces {
+				if _, ok := item.Metric[model.LabelName(v)]; ok {
+					item.Metric[model.LabelName(k)] = item.Metric[model.LabelName(v)]
+				}
+			}
+		}
+
+	case model.Matrix:
+		for _, item := range aTyped {
+			// If the current metric has no labels, set them
+			if item.Metric == nil {
+				item.Metric = model.Metric(model.LabelSet(make(map[model.LabelName]model.LabelValue)))
+			}
+			for k, v := range c.LabelReplaces {
+				if _, ok := item.Metric[model.LabelName(v)]; ok {
+					item.Metric[model.LabelName(k)] = item.Metric[model.LabelName(v)]
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *LabelReplaceClient) replaceLabelsInLabelSet(ls []model.LabelSet) {
+	for _, item := range ls {
+		for k, v := range c.LabelReplaces {
+			if _, ok := item[model.LabelName(v)]; ok {
+				item[model.LabelName(k)] = item[model.LabelName(v)]
+			}
+		}
+	}
+}

--- a/pkg/promclient/label_replace_helper.go
+++ b/pkg/promclient/label_replace_helper.go
@@ -1,0 +1,24 @@
+package promclient
+
+import "github.com/prometheus/prometheus/pkg/labels"
+
+// RewriteMatchers go through each matcher and replace the label if matches
+func RewriteMatchers(lr map[string]string, matchers []*labels.Matcher) []*labels.Matcher {
+	replacedMatchers := make([]*labels.Matcher, 0, len(matchers))
+
+	// Look over the matchers passed in, if any exist in our labels, we'll do the matcher, and then strip
+	for _, matcher := range matchers {
+		if repl, ok := lr[matcher.Name]; ok {
+			newMatcher := &labels.Matcher{
+				Type:  matcher.Type,
+				Name:  repl,
+				Value: matcher.Value,
+			}
+			replacedMatchers = append(replacedMatchers, newMatcher)
+		} else {
+			replacedMatchers = append(replacedMatchers, matcher)
+		}
+	}
+
+	return replacedMatchers
+}

--- a/pkg/promclient/label_replace_visitor.go
+++ b/pkg/promclient/label_replace_visitor.go
@@ -1,0 +1,47 @@
+package promclient
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+func NewLabelReplaceVisitor(lr map[string]string) *LabelReplaceVisitor {
+	return &LabelReplaceVisitor{
+		lr: lr,
+	}
+}
+
+// LabelReplaceVisitor implements the parser.Visitor interface to replace the labels
+type LabelReplaceVisitor struct {
+	lr map[string]string
+}
+
+func (v *LabelReplaceVisitor) Visit(node parser.Node, path []parser.Node) (w parser.Visitor, err error) {
+	switch nodeTyped := node.(type) {
+	case *parser.VectorSelector:
+		nodeTyped.LabelMatchers = RewriteMatchers(v.lr, nodeTyped.LabelMatchers)
+	case *parser.MatrixSelector:
+		nodeTyped.VectorSelector.(*parser.VectorSelector).LabelMatchers =
+			RewriteMatchers(v.lr, nodeTyped.VectorSelector.(*parser.VectorSelector).LabelMatchers)
+	case *parser.AggregateExpr:
+		nodeTyped.Grouping = v.replaceLabels(nodeTyped.Grouping)
+	// TODO: binary expression is split by promxy itself, so this case probably is never hit
+	case *parser.BinaryExpr:
+		nodeTyped.VectorMatching.MatchingLabels = v.replaceLabels(nodeTyped.VectorMatching.MatchingLabels)
+	}
+
+	return v, nil
+}
+
+func (v *LabelReplaceVisitor) replaceLabels(labels []string) []string {
+	replacedLabels := make([]string, 0, len(labels))
+
+	for _, label := range labels {
+		if repl, ok := v.lr[label]; ok {
+			replacedLabels = append(replacedLabels, repl)
+		} else {
+			replacedLabels = append(replacedLabels, label)
+		}
+	}
+
+	return replacedLabels
+}

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -61,6 +61,9 @@ type Config struct {
 	// Labels is a set of labels that will be added to all metrics retrieved
 	// from this server group
 	Labels model.LabelSet `json:"labels"`
+	// LabelReplaces is a mapping used to map a set of labels in the query to different labels
+	// and add the label to the result too
+	LabelReplaces map[string]string `yaml:"label_replaces"`
 	// RelabelConfigs are similar in function and identical in configuration as prometheus'
 	// relabel config for scrape jobs. The difference here being that the source labels
 	// you can pull from are from the downstream servergroup target and the labels you are

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -214,6 +214,11 @@ SYNC_LOOP:
 					// Add labels
 					apiClient = &promclient.AddLabelClient{apiClient, modelLabelSet.Merge(s.Cfg.Labels)}
 
+					// Replace lables
+					if s.Cfg.LabelReplaces != nil {
+						apiClient = &promclient.LabelReplaceClient{apiClient, s.Cfg.LabelReplaces}
+					}
+
 					// If debug logging is enabled, wrap the client with a debugAPI client
 					// Since these are called in the reverse order of what we add, we want
 					// to make sure that this is the last wrap of the client

--- a/vendor/github.com/prometheus/prometheus/promql/engine.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine.go
@@ -1897,6 +1897,9 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 	if matching.Card == parser.CardManyToMany {
 		panic("many-to-many only allowed for set operators")
 	}
+	if len(lhs) == 0 || len(rhs) == 0 {
+		return nil // Short-circuit: nothing is going to match.
+	}
 	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
 
 	// The control flow below handles one-to-one or many-to-one matching.


### PR DESCRIPTION
This introduces a new setting in the config

```
      label_replaces:
        asserts_env: env
```

When this is present, promxy will rewrite the query in a way all the `asserts_env` in the query will be replaced with `env` label, so query `up{asserts_env="dev"` will become `up{env="dev"}`.

In the returned result, a new label `asserts_env` will be included with the value the same as `env` label. `env` label is still kept in the result.
