### PR TITLE
Check labels for values in remote write

### DIFF
--- a/pkg/remote/queue_manager.go
+++ b/pkg/remote/queue_manager.go
@@ -234,6 +234,11 @@ func (t *QueueManager) Append(s *model.Sample) error {
 
 	ls := relabel.Process(b.Labels(), t.relabelConfigs...)
 
+	// If there are no labels; don't queue the sample
+	if len(ls) < 1 {
+		return nil
+	}
+
 	snew.Metric = make(model.Metric, len(ls))
 	for _, label := range ls {
 		snew.Metric[model.LabelName(label.Name)] = model.LabelValue(label.Value)


### PR DESCRIPTION
The older remote write client we forked didn't include the appropriate check for the labels post-relabel; so samples with no remaining labels could get through.

Fixes #547