### PR TITLE
Fix goroutine leak on config reload

### DIFF
--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -63,7 +63,7 @@ func (p *proxyStorageState) Cancel(n *proxyStorageState) {
 			sg.Cancel()
 		}
 	}
-	// We call close if the new one is nil, or if the appanders don't match
+	// We call close if the new one is nil, or if the appenders don't match
 	if n == nil || p.appender != n.appender {
 		if p.appenderCloser != nil {
 			p.appenderCloser()
@@ -147,7 +147,7 @@ func (p *ProxyStorage) ApplyConfig(c *proxyconfig.Config) error {
 
 	newState.Ready()        // Wait for the newstate to be ready
 	p.state.Store(newState) // Store the new state
-	if oldState != nil && oldState.appender != newState.appender {
+	if oldState != nil {
 		oldState.Cancel(newState) // Cancel the old one
 	}
 


### PR DESCRIPTION
Promxy is leaking goroutines on config reloads leading to OOM kills in the long run.

two issues :
 - oldState ServerGroups are not cancelled if appenders didn't change
 - Prometheus discovery target managers never close SyncCh blocking the ServerGroup Sync() goroutine forever

This is a rebase of #508