### PR TITLE
LabelFilter: proactively best-effort filter querries to downstreams

### DIFF
--- a/pkg/promclient/labelfilter.go
+++ b/pkg/promclient/labelfilter.go
@@ -34,8 +34,9 @@ func init() {
 }
 
 type LabelFilterConfig struct {
-	LabelsToFilter []string      `yaml:"labels_to_filter"`
-	SyncInterval   time.Duration `yaml:"sync_interval"`
+	LabelsToFilter []string            `yaml:"labels_to_filter"`
+	SyncInterval   time.Duration       `yaml:"sync_interval"`
+	ExcludeLabels  map[string][]string `yaml:"exclude_labels"`
 }
 
 func (c *LabelFilterConfig) Validate() error {
@@ -140,6 +141,16 @@ func (c *LabelFilterClient) Sync(ctx context.Context) error {
 			labelFilter[string(v)] = struct{}{}
 		}
 		filter[label] = labelFilter
+	}
+
+	// Apply exclude list
+	for k, vList := range c.cfg.ExcludeLabels {
+		if filterMap, ok := filter[k]; ok {
+			for _, item := range vList {
+				delete(filterMap, item)
+			}
+			filter[k] = filterMap
+		}
 	}
 
 	c.filter.Store(filter)

--- a/pkg/promclient/labelfilter.go
+++ b/pkg/promclient/labelfilter.go
@@ -1,0 +1,122 @@
+package promclient
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// TODO: config
+func NewLabelFilterClient(a API) (*LabelFilterClient, error) {
+	c := &LabelFilterClient{
+		API:            a,
+		LabelsToFilter: []string{"__name__", "job", "version"},
+	}
+
+	// TODO; background
+	if err := c.Sync(context.TODO()); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// LabelFilterClient proxies a client and adds the given labels to all results
+type LabelFilterClient struct {
+	API
+
+	LabelsToFilter []string // Which labels we want to pull to check
+
+	// TODO: move to a local block (to disk)?? or optionally so?
+	// labelFilter is a map of labelName -> labelValue -> nothing (for quick lookups)
+	labelFilter map[string]map[string]struct{}
+}
+
+func (c *LabelFilterClient) Sync(ctx context.Context) error {
+	filter := make(map[string]map[string]struct{})
+
+	for _, label := range c.LabelsToFilter {
+		labelFilter := make(map[string]struct{})
+		// TODO: warn?
+		vals, _, err := c.LabelValues(ctx, label, nil, model.Time(0).Time(), model.Now().Time())
+		if err != nil {
+			return err
+		}
+		for _, v := range vals {
+			labelFilter[string(v)] = struct{}{}
+		}
+		filter[label] = labelFilter
+	}
+
+	c.labelFilter = filter
+
+	return nil
+}
+
+// Query performs a query for the given time.
+func (c *LabelFilterClient) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
+	// Parse out the promql query into expressions etc.
+	e, err := parser.ParseExpr(query)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	filterVisitor := NewFilterLabelVisitor(c.labelFilter)
+	if _, err := parser.Walk(ctx, filterVisitor, &parser.EvalStmt{Expr: e}, e, nil, nil); err != nil {
+		return nil, nil, err
+	}
+	if !filterVisitor.filterMatch {
+		return nil, nil, nil
+	}
+
+	return c.API.Query(ctx, query, ts)
+}
+
+func NewFilterLabelVisitor(filter map[string]map[string]struct{}) *FilterLabelVisitor {
+	return &FilterLabelVisitor{
+		labelFilter: filter,
+		filterMatch: true,
+	}
+}
+
+// FilterLabel implements the parser.Visitor interface to filter selectors based on a labelstet
+type FilterLabelVisitor struct {
+	l           sync.Mutex
+	labelFilter map[string]map[string]struct{}
+	filterMatch bool
+}
+
+// Visit checks if the given node matches the labels in the filter
+func (l *FilterLabelVisitor) Visit(node parser.Node, path []parser.Node) (w parser.Visitor, err error) {
+	switch nodeTyped := node.(type) {
+	case *parser.VectorSelector:
+		for _, matcher := range nodeTyped.LabelMatchers {
+			for labelName, labelFilter := range l.labelFilter {
+				if matcher.Name == labelName {
+					match := false
+					// Check that there is a match somewhere!
+					for v := range labelFilter {
+						if matcher.Matches(v) {
+							match = true
+							break
+						}
+					}
+					if !match {
+						l.l.Lock()
+						l.filterMatch = false
+						l.l.Unlock()
+						return nil, nil
+					}
+				}
+			}
+		}
+	case *parser.MatrixSelector:
+		// TODO:
+	}
+
+	return l, nil
+}

--- a/pkg/promclient/labelfilter_test.go
+++ b/pkg/promclient/labelfilter_test.go
@@ -113,8 +113,11 @@ func TestLabelFilter(t *testing.T) {
 
 	// Create the LabelFilter client
 	cfg := &LabelFilterConfig{
-		LabelsToFilter: []string{"__name__", "filterlabel"},
-		ExcludeLabels: map[string][]string{
+		DynamicLabels: []string{"__name__", "filterlabel"},
+		StaticLabelsInclude: map[string][]string{
+			"__name__": {"staticinclude"},
+		},
+		StaticLabelsExclude: map[string][]string{
 			"__name__": {"up"},
 		},
 	}
@@ -130,6 +133,7 @@ func TestLabelFilter(t *testing.T) {
 	}{
 		{query: "notametric"},                            // A metric that definitely doesn't exist
 		{query: "testmetric", callCount: 1},              // A metric that does exist
+		{query: "staticinclude", callCount: 1},           // A metric that statically exists
 		{query: "up"},                                    // A metric that does exist, but we filter out
 		{query: `{filterlabel="notavalue"}`},             // A metric that definitely doesn't exist
 		{query: `{notalabel="notavalue"}`, callCount: 1}, // A metric that definitely doesn't exist, but isn't filterable

--- a/pkg/promclient/labelfilter_test.go
+++ b/pkg/promclient/labelfilter_test.go
@@ -1,0 +1,236 @@
+package promclient
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+func newCountAPI(a API) *countAPI {
+	return &countAPI{
+		API: a,
+		callCount: map[string]int{
+			"LabelNames":  0,
+			"LabelValues": 0,
+			"Query":       0,
+			"QueryRange":  0,
+			"Series":      0,
+			"GetValue":    0,
+			"Metadata":    0,
+		},
+	}
+}
+
+type countAPI struct {
+	API
+	callCount map[string]int
+}
+
+// LabelNames returns all the unique label names present in the block in sorted order.
+func (s *countAPI) LabelNames(ctx context.Context, matchers []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error) {
+	s.callCount["LabelNames"]++
+	return s.API.LabelNames(ctx, matchers, startTime, endTime)
+}
+
+// LabelValues performs a query for the values of the given label.
+func (s *countAPI) LabelValues(ctx context.Context, label string, matchers []string, startTime time.Time, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	s.callCount["LabelValues"]++
+	return s.API.LabelValues(ctx, label, matchers, startTime, endTime)
+}
+
+// Query performs a query for the given time.
+func (s *countAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
+	s.callCount["Query"]++
+	return s.API.Query(ctx, query, ts)
+}
+
+// QueryRange performs a query for the given range.
+func (s *countAPI) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, v1.Warnings, error) {
+	s.callCount["QueryRange"]++
+	return s.API.QueryRange(ctx, query, r)
+}
+
+// Series finds series by label matchers.
+func (s *countAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	s.callCount["Series"]++
+	return s.API.Series(ctx, matches, startTime, endTime)
+}
+
+// GetValue loads the raw data for a given set of matchers in the time range
+func (s *countAPI) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (model.Value, v1.Warnings, error) {
+	s.callCount["GetValue"]++
+	return s.API.GetValue(ctx, start, end, matchers)
+}
+
+// Metadata returns metadata about metrics currently scraped by the metric name.
+func (s *countAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	s.callCount["Metadata"]++
+	return s.API.Metadata(ctx, metric, limit)
+}
+
+func TestLabelFilter(t *testing.T) {
+	/*
+
+	   The idea here is that the datasource has the following data:
+
+	   up{filterlabel="a"}
+	   up{filterlabel="b"}
+	   testmetric{filterlabel="a"}
+	   testmetric{filterlabel="b"}
+
+	*/
+
+	stub := &stubAPI{
+		// Override the LabelValues endpoint (which is the one that LabelFilter uses to determine its filter)
+		labelValues: func(label string) model.LabelValues {
+			switch label {
+			case "__name__":
+				return model.LabelValues{
+					"up",
+					"testmetric",
+				}
+			case "filterlabel":
+				return model.LabelValues{
+					"a",
+					"b",
+				}
+			}
+			return model.LabelValues{}
+		},
+	}
+
+	// Wrap the stub in a counter
+	countAPI := newCountAPI(stub)
+
+	// Set up some vars
+	ctx := context.TODO() // TODO
+
+	// Create the LabelFilter client
+	cfg := &LabelFilterConfig{
+		LabelsToFilter: []string{"__name__", "filterlabel"},
+		ExcludeLabels: map[string][]string{
+			"__name__": {"up"},
+		},
+	}
+
+	filterClient, err := NewLabelFilterClient(ctx, countAPI, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		query     string // query to run
+		callCount int    // how many calls expected
+	}{
+		{query: "notametric"},                            // A metric that definitely doesn't exist
+		{query: "testmetric", callCount: 1},              // A metric that does exist
+		{query: "up"},                                    // A metric that does exist, but we filter out
+		{query: `{filterlabel="notavalue"}`},             // A metric that definitely doesn't exist
+		{query: `{notalabel="notavalue"}`, callCount: 1}, // A metric that definitely doesn't exist, but isn't filterable
+		{query: `{filterlabel="a"}`, callCount: 1},       // A metric that does exist
+		{query: `{filterlabel="b"}`, callCount: 1},       // A metric that does exist
+	}
+
+	t.Run("Query", func(t *testing.T) {
+		for i, test := range tests {
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				beforeCount := countAPI.callCount["Query"]
+				_, _, err := filterClient.Query(ctx, test.query, model.Time(100).Time())
+				if err != nil {
+					t.Fatal(err)
+				}
+				callCount := countAPI.callCount["Query"] - beforeCount
+				if test.callCount != callCount {
+					t.Fatalf("mismatch in callCount when running %s expected=%d actual=%d", test.query, test.callCount, callCount)
+				}
+			})
+		}
+	})
+
+	t.Run("QueryRange", func(t *testing.T) {
+		for i, test := range tests {
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				beforeCount := countAPI.callCount["QueryRange"]
+				_, _, err := filterClient.QueryRange(ctx, test.query, v1.Range{Start: model.Time(0).Time(), End: model.Time(100).Time(), Step: time.Millisecond})
+				if err != nil {
+					t.Fatal(err)
+				}
+				callCount := countAPI.callCount["QueryRange"] - beforeCount
+				if test.callCount != callCount {
+					t.Fatalf("mismatch in callCount when running %s expected=%d actual=%d", test.query, test.callCount, callCount)
+				}
+			})
+		}
+	})
+
+	t.Run("Series", func(t *testing.T) {
+		for i, test := range tests {
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				beforeCount := countAPI.callCount["Series"]
+				_, _, err := filterClient.Series(ctx, []string{test.query}, model.Time(0).Time(), model.Time(100).Time())
+				if err != nil {
+					t.Fatal(err)
+				}
+				callCount := countAPI.callCount["Series"] - beforeCount
+				if test.callCount != callCount {
+					t.Fatalf("mismatch in callCount when running %s expected=%d actual=%d", test.query, test.callCount, callCount)
+				}
+			})
+		}
+	})
+
+	t.Run("GetValue", func(t *testing.T) {
+		for i, test := range tests {
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				beforeCount := countAPI.callCount["GetValue"]
+
+				// TODO: convert query to matchers
+				matchers, err := parser.ParseMetricSelector(test.query)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				_, _, err = filterClient.GetValue(ctx, model.Time(0).Time(), model.Time(100).Time(), matchers)
+				if err != nil {
+					t.Fatal(err)
+				}
+				callCount := countAPI.callCount["GetValue"] - beforeCount
+				if test.callCount != callCount {
+					t.Fatalf("mismatch in callCount when running %s expected=%d actual=%d", test.query, test.callCount, callCount)
+				}
+			})
+		}
+	})
+
+	t.Run("Metadata", func(t *testing.T) {
+		tests := []struct {
+			metric    string // query to run
+			callCount int    // how many calls expected
+		}{
+			{metric: "notametric"},               // A metric that definitely doesn't exist
+			{metric: "testmetric", callCount: 1}, // A metric that does exist
+			{metric: "up"},                       // A metric that does exist, but we filter out
+		}
+
+		for i, test := range tests {
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				beforeCount := countAPI.callCount["Metadata"]
+				_, err := filterClient.Metadata(ctx, test.metric, "")
+				if err != nil {
+					t.Fatal(err)
+				}
+				callCount := countAPI.callCount["Metadata"] - beforeCount
+				if test.callCount != callCount {
+					t.Fatalf("mismatch in callCount when running %s expected=%d actual=%d", test.metric, test.callCount, callCount)
+				}
+			})
+		}
+	})
+
+}

--- a/pkg/promclient/multi_api_test.go
+++ b/pkg/promclient/multi_api_test.go
@@ -14,7 +14,7 @@ import (
 
 type stubAPI struct {
 	labelNames  func() []string
-	labelValues func() model.LabelValues
+	labelValues func(label string) model.LabelValues
 	query       func() model.Value
 	queryRange  func() model.Value
 	series      func() []model.LabelSet
@@ -24,36 +24,57 @@ type stubAPI struct {
 
 // LabelNames returns all the unique label names present in the block in sorted order.
 func (s *stubAPI) LabelNames(ctx context.Context, matchers []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error) {
+	if s.labelNames == nil {
+		return nil, nil, nil
+	}
 	return s.labelNames(), nil, nil
 }
 
 // LabelValues performs a query for the values of the given label.
 func (s *stubAPI) LabelValues(ctx context.Context, label string, matchers []string, startTime time.Time, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
-	return s.labelValues(), nil, nil
+	if s.labelValues == nil {
+		return nil, nil, nil
+	}
+	return s.labelValues(label), nil, nil
 }
 
 // Query performs a query for the given time.
 func (s *stubAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
+	if s.query == nil {
+		return nil, nil, nil
+	}
 	return s.query(), nil, nil
 }
 
 // QueryRange performs a query for the given range.
 func (s *stubAPI) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, v1.Warnings, error) {
+	if s.queryRange == nil {
+		return nil, nil, nil
+	}
 	return s.queryRange(), nil, nil
 }
 
 // Series finds series by label matchers.
 func (s *stubAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	if s.series == nil {
+		return nil, nil, nil
+	}
 	return s.series(), nil, nil
 }
 
 // GetValue loads the raw data for a given set of matchers in the time range
 func (s *stubAPI) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (model.Value, v1.Warnings, error) {
+	if s.getValue == nil {
+		return nil, nil, nil
+	}
 	return s.getValue(), nil, nil
 }
 
 // Metadata returns metadata about metrics currently scraped by the metric name.
 func (s *stubAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	if s.metadata == nil {
+		return nil, nil
+	}
 	return s.metadata(), nil
 }
 
@@ -130,7 +151,7 @@ func TestMultiAPIMerging(t *testing.T) {
 			return []string{"a"}
 		},
 
-		labelValues: func() model.LabelValues {
+		labelValues: func(_ string) model.LabelValues {
 			return model.LabelValues{}
 		},
 		query: func() model.Value {

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -160,6 +160,9 @@ type Config struct {
 	// An example use-case would be if a specific servergroup was was "deprecated" and wasn't getting
 	// any new data after a specific given point in time
 	AbsoluteTimeRangeConfig *AbsoluteTimeRangeConfig `yaml:"absolute_time_range"`
+
+	// TODO: docs
+	LabelFilterConfig *promclient.LabelFilterConfig `yaml:"label_filter"`
 }
 
 // GetScheme returns the scheme for this servergroup

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -161,7 +161,30 @@ type Config struct {
 	// any new data after a specific given point in time
 	AbsoluteTimeRangeConfig *AbsoluteTimeRangeConfig `yaml:"absolute_time_range"`
 
-	// TODO: docs
+	// LabelFilterConfig is a mechanism to restrict which queries are sent to the particular downstream.
+	// This is done by maintaining a "filter" of labels that are downstream and ensuring that the
+	// matchers for any particular query match that in-memory filter. This can be defined both
+	// statically and dynamically.
+	// NOTE: this is not a "secure" mechanism as it is relying on the query's matchers. So it is trivial
+	// for a malicious actor to work around this filter by changing matchers.
+	// Example:
+	//
+	//    label_filter:
+	//      # This will dynamically query the downstream for the values of `__name__` and `job`
+	//      dynamic_labels:
+	//        - __name__
+	//        - job
+	//      # (optional) this will define a re-sync interval for dynamic labels from the downstream
+	//      sync_interval: 5m
+	//      # This will statically define a filter of labels
+	//      static_labels_include:
+	//        instance:
+	//          - instance1
+	//      # This will statically define an exclusion list (removed from the filter)|
+	//      static_labels_exclude:
+	//        __name__:
+	//          - up
+
 	LabelFilterConfig *promclient.LabelFilterConfig `yaml:"label_filter"`
 }
 

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -252,6 +252,11 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 					apiClient = &promclient.DebugAPI{apiClient, u.String()}
 				}
 
+				apiClient, err = promclient.NewLabelFilterClient(apiClient)
+				if err != nil {
+					return err
+				}
+
 				apiClients = append(apiClients, apiClient)
 			}
 		}

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -262,7 +262,7 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 					apiClient = &promclient.DebugAPI{apiClient, u.String()}
 				}
 
-                // Add LabelFilter if configured
+				// Add LabelFilter if configured
 				if s.Cfg.LabelFilterConfig != nil {
 					apiClient, err = promclient.NewLabelFilterClient(ctx, apiClient, s.Cfg.LabelFilterConfig)
 					if err != nil {


### PR DESCRIPTION
This PR is an implementation for #558 

TODO:
- [x] sync metrics
- [x] QueryRange
- [x] Series
- [x] GetValue
- [x] Metadata
- [x] tests
- [x] docs
