### PR TITLE
Fix Parallel walk edge-case panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,5 @@ vendor:
 
 .PHONY: update-prom-fork
 update-prom-fork:
-	GO111MODULE=on $(GO) mod edit -replace github.com/prometheus/prometheus=github.com/jacksontj/prometheus@v0.2.37.3-fork
+	GO111MODULE=on $(GO) mod edit -replace github.com/prometheus/prometheus=github.com/jacksontj/prometheus@v0.2.37.4-fork
 	$(MAKE) vendor

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog v1.0.0
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 )
 
 require (
@@ -158,13 +159,12 @@ require (
 	k8s.io/client-go v0.24.2 // indirect
 	k8s.io/klog/v2 v2.70.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/jacksontj/prometheus v1.8.1-0.20230309220703-968ded36c597
+replace github.com/prometheus/prometheus => github.com/jacksontj/prometheus v1.8.1-0.20230316162245-bf26a7edb634
 
 replace github.com/golang/glog => github.com/kubermatic/glog-gokit v0.0.0-20181129151237-8ab7e4c2d352
 

--- a/go.sum
+++ b/go.sum
@@ -521,8 +521,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/ionos-cloud/sdk-go/v6 v6.1.0 h1:0EZz5H+t6W23zHt6dgHYkKavr72/30O9nA97E3FZaS4=
 github.com/ionos-cloud/sdk-go/v6 v6.1.0/go.mod h1:Ox3W0iiEz0GHnfY9e5LmAxwklsxguuNFEUSu0gVRTME=
-github.com/jacksontj/prometheus v1.8.1-0.20230309220703-968ded36c597 h1:EdeyyTk+pKFaBK81FuooCIfc2GZaI3NIFJngKBRSuS0=
-github.com/jacksontj/prometheus v1.8.1-0.20230309220703-968ded36c597/go.mod h1:637xk6elYZWENDfmM/Lpb9tzMI7oKvB7WAboalOs998=
+github.com/jacksontj/prometheus v1.8.1-0.20230316162245-bf26a7edb634 h1:nZEyw8j2UOg7YCe9akUCqbyREm/UrcIXXeY1P+mZdwQ=
+github.com/jacksontj/prometheus v1.8.1-0.20230316162245-bf26a7edb634/go.mod h1:637xk6elYZWENDfmM/Lpb9tzMI7oKvB7WAboalOs998=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/test/testdata/issue_562.test
+++ b/test/testdata/issue_562.test
@@ -1,0 +1,7 @@
+# Test for https://github.com/jacksontj/promxy/issues/562
+load 5m
+    metric_1{a="1"} 0+10x1000 100+30x1000
+
+eval instant at 5m max_over_time(metric_1[5m]) + metric_1
+    {a="1", az="a"} 20
+    {a="1", az="b"} 20

--- a/vendor/github.com/prometheus/prometheus/promql/engine_extra.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine_extra.go
@@ -12,6 +12,11 @@ func findPathRange(path []parser.Node, eRanges []evalRange) time.Duration {
 		depth     int
 	)
 	for _, r := range eRanges {
+		// If the prefix is longer then it can't be the parent of `child`
+		if len(r.Prefix) > len(path) {
+			continue
+		}
+
 		// Check if we are a child
 		child := true
 		for i, p := range r.Prefix {
@@ -29,7 +34,7 @@ func findPathRange(path []parser.Node, eRanges []evalRange) time.Duration {
 	return evalRange
 }
 
-// evalRange summarizes a defined evalRange (from a MatrixSelector) within the asg
+// evalRange summarizes a defined evalRange (from a MatrixSelector) within the ast
 type evalRange struct {
 	Prefix []parser.PositionRange
 	Range  time.Duration

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -475,7 +475,7 @@ github.com/prometheus/exporter-toolkit/web
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20210707132820-dc8f50559534 => github.com/jacksontj/prometheus v1.8.1-0.20230309220703-968ded36c597
+# github.com/prometheus/prometheus v1.8.2-0.20210707132820-dc8f50559534 => github.com/jacksontj/prometheus v1.8.1-0.20230316162245-bf26a7edb634
 ## explicit; go 1.18
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1104,6 +1104,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/prometheus/prometheus => github.com/jacksontj/prometheus v1.8.1-0.20230309220703-968ded36c597
+# github.com/prometheus/prometheus => github.com/jacksontj/prometheus v1.8.1-0.20230316162245-bf26a7edb634
 # github.com/golang/glog => github.com/kubermatic/glog-gokit v0.0.0-20181129151237-8ab7e4c2d352
 # k8s.io/klog => github.com/simonpasquier/klog-gokit v0.1.0


### PR DESCRIPTION
As reported in #562 with the new parallel walking there is an edge case causing panics. None of the tests cases caught this and it took a while to find a repro case, but was able to find that something like:

```
max_over_time(prometheus_build_info[5m]) + prometheus_build_info
```

this PR adds a test for this case (which was able to repro is locally and in [CI](https://github.com/jacksontj/promxy/actions/runs/4439336369/jobs/7791660233#step:6:37)) and includes a fix to make that case pass.

Fixes #562 