### PR TITLE
Remove build cache as github actions won't run it

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,13 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Restore Cache
-      uses: actions/cache@preview
-      id: cache
-      with:
-        path: ~/.cache/go-build/
-        key: ${{ runner.os }}
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:


### PR DESCRIPTION
Github actions has a 200MB cache size limit; the build cache is ~900MB so it is just using 1 minute of time each CI run to fail.