### PR TITLE
Marshal server group inline configs.

### DIFF
--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -209,6 +209,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// MarshalYAML implements the yaml.Marshaler interface.
+func (c *Config) MarshalYAML() (interface{}, error) {
+	return discovery.MarshalYAMLWithInlineConfigs(c)
+}
+
 // HTTPClientConfig extends prometheus' HTTPClientConfig
 type HTTPClientConfig struct {
 	DialTimeout time.Duration                `yaml:"dial_timeout"`


### PR DESCRIPTION
Currently, the /config page doesn't show service discovery configuration, since it's an inline configuration and ignored by the default yaml marshaller. This patch uses the MarshalYAMLWithInlineConfigs helper from prometheus to include the service discovery configuration in the marshalled yaml.