### PR TITLE
Fix pprof endpoints when using RoutePrefix

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -413,7 +413,7 @@ func main() {
 	r.NotFound = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Have our fallback rules
 		if strings.HasPrefix(r.URL.Path, path.Join(webOptions.RoutePrefix, "/debug")) {
-			http.DefaultServeMux.ServeHTTP(w, r)
+			http.StripPrefix(webOptions.RoutePrefix, http.DefaultServeMux).ServeHTTP(w, r)
 		} else if r.URL.Path == path.Join(webOptions.RoutePrefix, "/-/ready") {
 			if stopping {
 				w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
Previously the path prefix wasn't being stripped so if a RoutePrefix was in use the pprof endpoints were inaccessible