### PR TITLE
add support for custom http request headers per servergroup

### DIFF
--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -195,6 +195,12 @@ type Config struct {
 	LabelFilterConfig *promclient.LabelFilterConfig `yaml:"label_filter"`
 
 	PreferMax bool `yaml:"prefer_max,omitempty"`
+
+	// HTTPClientHeaders are a map of HTTP headers to add to remote read HTTP calls made to this downstream
+	// the main use-case for this is to support the X-Scope-OrgID header required by Mimir and Cortex
+	// in multi-tenancy mode
+	// (see https://github.com/jacksontj/promxy/issues/643)
+	HTTPClientHeaders map[string]string `yaml:"http_headers"`
 }
 
 // GetScheme returns the scheme for this servergroup

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -106,6 +106,10 @@ func (s *ServerGroup) RoundTrip(r *http.Request) (*http.Response, error) {
 	for k, v := range middleware.GetHeaders(r.Context()) {
 		r.Header.Set(k, v)
 	}
+	for k, v := range s.Cfg.HTTPClientHeaders {
+		r.Header.Set(k, v)
+		logrus.Tracef("Set ServerGroup custom header %s: %s", k, v)
+	}
 	return s.client.Transport.RoundTrip(r)
 }
 


### PR DESCRIPTION
### Context
* Grafana Mimir and Cortex-Tenant both require the use of an `X-Scope-OrgID` header to specify for which TSDB tenant a read or write request is being made for (these may be concatenated with pipes between each tenant string); more [here](https://cortexmetrics.io/docs/guides/auth/)
* To support the query and remote read paths for Grafana Mimir, this change adds a configurable map of headers to be attached to each request for a given ServerGroup via config
* Addresses https://github.com/jacksontj/promxy/issues/643

### Changes
* Add `HTTPClientHeaders` as a simple string map to ServerGroup config to match the middleware format
* On the custom RoundTripper, also mutate the request with the SG level headers on each request, _after_ the middleware to respect proxy-headers

Fixes #643