### PR TITLE
Ensure that TimeFilter's adjustments to a QueryRange Range are valid

### DIFF
--- a/pkg/promclient/multi_api_test.go
+++ b/pkg/promclient/multi_api_test.go
@@ -16,7 +16,7 @@ type stubAPI struct {
 	labelNames  func() []string
 	labelValues func(label string) model.LabelValues
 	query       func() model.Value
-	queryRange  func() model.Value
+	queryRange  func(q string, r v1.Range) model.Value
 	series      func() []model.LabelSet
 	getValue    func() model.Value
 	metadata    func() map[string][]v1.Metadata
@@ -51,7 +51,7 @@ func (s *stubAPI) QueryRange(ctx context.Context, query string, r v1.Range) (mod
 	if s.queryRange == nil {
 		return nil, nil, nil
 	}
-	return s.queryRange(), nil, nil
+	return s.queryRange(query, r), nil, nil
 }
 
 // Series finds series by label matchers.
@@ -159,7 +159,7 @@ func TestMultiAPIMerging(t *testing.T) {
 				getSample(model.LabelSet{model.MetricNameLabel: "testmetric"}),
 			}
 		},
-		queryRange: func() model.Value {
+		queryRange: func(_ string, _ v1.Range) model.Value {
 			return model.Vector{
 				getSample(model.LabelSet{model.MetricNameLabel: "testmetric"}),
 			}

--- a/pkg/promclient/timefilter.go
+++ b/pkg/promclient/timefilter.go
@@ -69,7 +69,12 @@ func (tf *AbsoluteTimeFilter) QueryRange(ctx context.Context, query string, r v1
 
 	if tf.Truncate {
 		if !tf.Start.IsZero() && r.Start.Before(tf.Start) {
-			r.Start = tf.Start
+			remainder := tf.Start.Sub(r.Start) % r.Step
+			if remainder > 0 {
+				r.Start = tf.Start.Add(r.Step - remainder)
+			} else {
+				r.Start = tf.Start
+			}
 		}
 		if !tf.End.IsZero() && r.End.After(tf.End) {
 			r.End = tf.End
@@ -193,7 +198,12 @@ func (tf *RelativeTimeFilter) QueryRange(ctx context.Context, query string, r v1
 
 	if tf.Truncate {
 		if !tfStart.IsZero() && r.Start.Before(tfStart) {
-			r.Start = tfStart
+			remainder := tfStart.Sub(r.Start) % r.Step
+			if remainder > 0 {
+				r.Start = tfStart.Add(r.Step - remainder)
+			} else {
+				r.Start = tfStart
+			}
 		}
 		if !tfEnd.IsZero() && r.End.After(tfEnd) {
 			r.End = tfEnd


### PR DESCRIPTION
Query range is a bit of an odd beast. It requires a start, end, and a step. Promql's calculations assume that the datapoint times are start plus a multiple of step; if they aren't you are subject to LookbackDelta constraints.

Specifically with TimeFilter -- where we are setting either an absolute or relative time barrier we were causing some issues as we were previously truncating the time -- instead of finding the first multiple of step within our timerange.

To explain the issue; lets consider the following query:

```
Start: t10
End: t25
Step: 3
```

If this were to run normally we'd get results with data at 10,13,16,19,22,25

If we at the same time have an absoluteTimeFilter @ t20 -- we'd (prior to this patch) get: 10, 13, 16, 19, 20, 23.

For shorter-range queries (i.e. within a day) this is generally not an issue because the step isn't generally long enough to exceed the LookbackDelta default of 5m. But as you look at *longer* time ranges this problem is easier and easier to hit (in #659 I was able to reproduce easily with a ~3 day query -- where step was ~9m.

Fixes #659