### PR TITLE
[promxy] Header based query sharding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ release:
 	./build.bash github.com/jacksontj/promxy/cmd/promxy $(BUILD)
 	./build.bash github.com/jacksontj/promxy/cmd/remote_write_exporter $(BUILD)
 
+.PHONY: build-image
+build-image: clean ## Build the rollout-operator image
+	docker buildx build --load --platform linux/amd64 -t promxy:latest .
+
+
 testlocal-build:
 	docker build -t 127.0.0.1:32000/promxy:latest .
 	docker push 127.0.0.1:32000/promxy:latest

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ release:
 	./build.bash github.com/jacksontj/promxy/cmd/remote_write_exporter $(BUILD)
 
 .PHONY: build-image
-build-image: clean ## Build the rollout-operator image
+build-image: clean
 	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t promxy:latest -t promxy:$(IMAGE_TAG) .
 
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ GOFILES := $(shell find . -name "*.go" -type f ! -path "./vendor/*")
 GOFMT ?= gofmt
 GOIMPORTS ?= goimports -local=github.com/jacksontj/promxy
 STATICCHECK ?= staticcheck
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+GIT_REVISION := $(shell git rev-parse --short HEAD)
+IMAGE_TAG ?= $(subst /,-,$(GIT_BRANCH))-$(GIT_REVISION)
 
 .PHONY: clean
 clean:
@@ -33,7 +36,7 @@ release:
 
 .PHONY: build-image
 build-image: clean ## Build the rollout-operator image
-	docker buildx build --load --platform linux/amd64 -t promxy:latest .
+	docker buildx build --load --platform linux/amd64 --build-arg revision=$(GIT_REVISION) -t promxy:latest -t promxy:$(IMAGE_TAG) .
 
 
 testlocal-build:

--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -1,7 +1,40 @@
 ##
+## Regular prometheus configuration
+##
+
+# Uncomment below section to enable evaluation interval.
+#global:
+#  evaluation_interval: 5s
+#  external_labels:
+#    source: promxy
+
+# Rule files specifies a list of globs. Rules and alerts are read from
+# all matching files. Uncomment below section to enable.
+
+#rule_files:
+#  - "*rule"
+
+# Alerting specifies settings related to the Alertmanager. Uncomment below section to enable.
+
+#alerting:
+#  alertmanagers:
+#    - scheme: http
+#      static_configs:
+#        - targets:
+#            - "127.0.0.1:12345"
+
+# remote_write configuration is used by promxy as its local Appender, meaning all
+# metrics promxy would "write" (not export) would be sent to this. Examples
+# of this include: recording rules, metrics on alerting rules, etc. Uncomment below section to enable.
+
+#remote_write:
+#  - url: http://localhost:8083/receive
+
+##
 ### Promxy configuration
 ##
 promxy:
+  # In below examples, point 8000 & 8001 to prometheus servers.
   server_groups:
     # All upstream prometheus service discovery mechanisms are supported with the same
     # markup, all defined in https://github.com/prometheus/prometheus/blob/master/discovery/config/config.go#L33

--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -1,31 +1,4 @@
 ##
-## Regular prometheus configuration
-##
-global:
-  evaluation_interval: 5s
-  external_labels:
-    source: promxy
-
-# Rule files specifies a list of globs. Rules and alerts are read from
-# all matching files.
-rule_files:
-- "*rule"
-
-# Alerting specifies settings related to the Alertmanager.
-alerting:
-  alertmanagers:
-  - scheme: http
-    static_configs:
-    - targets:
-      - "127.0.0.1:12345"
-
-# remote_write configuration is used by promxy as its local Appender, meaning all
-# metrics promxy would "write" (not export) would be sent to this. Examples
-# of this include: recording rules, metrics on alerting rules, etc.
-remote_write:
-  - url: http://localhost:8083/receive
-
-##
 ### Promxy configuration
 ##
 promxy:
@@ -34,10 +7,10 @@ promxy:
     # markup, all defined in https://github.com/prometheus/prometheus/blob/master/discovery/config/config.go#L33
     - static_configs:
         - targets:
-          - localhost:9090
+          - localhost:8000
       # labels to be added to metrics retrieved from this server_group
       labels:
-        sg: localhost_9090
+        sg: localhost_8000
       # anti-affinity for merging values in timeseries between hosts in the server_group
       anti_affinity: 10s
       # time to wait for a server's response headers after fully writing the request (including its body, if any).
@@ -45,18 +18,14 @@ promxy:
       timeout: 5s
       # Controls whether to use remote_read or the prom API for fetching remote RAW data (e.g. matrix selectors)
       # Note, some prometheus implementations (e.g. [VictoriaMetrics](https://github.com/prometheus/prometheus/issues/4456) don't support remote_read.
-      remote_read: true
+      remote_read: false
       # configures the path to send remote read requests to. The default is "api/v1/read"
-      remote_read_path: api/v1/read
       # path_prefix defines a prefix to prepend to all queries to hosts in this servergroup
       # This can be relabeled using __path_prefix__
-      path_prefix: /example/prefix
+      path_prefix: /prometheus
       # query_params adds the following map of query parameters to downstream requests.
       # The initial use-case for this is to add `nocache=1` to VictoriaMetrics downstreams
       # (see https://github.com/jacksontj/promxy/issues/202)
-      query_params:
-        nocache: 1
-      # configures the protocol scheme used for requests. Defaults to http
       scheme: http
       # options for promxy's HTTP client when talking to hosts in server_groups
       http_client:
@@ -65,40 +34,5 @@ promxy:
         dial_timeout: 1s
         tls_config:
           insecure_skip_verify: true
-
-      # relative_time_range defines a relative-to-now time range that this server group contains.
-      # this is completely optional and start/end are both optional as well
-      # an example is if this servergroup only has the most recent 3h of data
-      # the "start" would be -3h and the end would be left out
-      relative_time_range:
-        start: -3h
-        end: -1h
-        truncate: false
-
-      # when merging sample streams, the max value at a given timestamp will be preferred
-      prefer_max: false
-
-      # absolute_time_range defines an absolute time range that this server group contains.
-      # this is completely optional and start/end are both optional as well
-      # and example is if the servergroup has been deprecated and is no longer receiving data
-      # you could set the specific times that it has data for.
-      absolute_time_range:
-        start: '2009-10-10T23:00:00Z'
-        end: '2009-10-11T23:00:00Z'
-        truncate: true
-
-    # as many additional server groups as you have
-    - static_configs:
-        - targets:
-          - localhost:9091
-      labels:
-        sg: localhost_9091
-      anti_affinity: 10s
-      scheme: http
-      http_client:
-        tls_config:
-          insecure_skip_verify: true
-      # ignore_error will make the given server group's response "optional"
-      # meaning if this servergroup returns and error and others don't the overall
-      # query can still succeed
-      ignore_error: true
+      # make response as optional
+      ignore_error: false

--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -36,3 +36,34 @@ promxy:
           insecure_skip_verify: true
       # make response as optional
       ignore_error: false
+    - static_configs:
+        - targets:
+            - localhost:8001
+      # labels to be added to metrics retrieved from this server_group
+      labels:
+        sg: localhost_8001
+      # anti-affinity for merging values in timeseries between hosts in the server_group
+      anti_affinity: 10s
+      # time to wait for a server's response headers after fully writing the request (including its body, if any).
+      # This time does not include the time to read the response body.
+      timeout: 5s
+      # Controls whether to use remote_read or the prom API for fetching remote RAW data (e.g. matrix selectors)
+      # Note, some prometheus implementations (e.g. [VictoriaMetrics](https://github.com/prometheus/prometheus/issues/4456) don't support remote_read.
+      remote_read: false
+      # configures the path to send remote read requests to. The default is "api/v1/read"
+      # path_prefix defines a prefix to prepend to all queries to hosts in this servergroup
+      # This can be relabeled using __path_prefix__
+      path_prefix: /prometheus
+      # query_params adds the following map of query parameters to downstream requests.
+      # The initial use-case for this is to add `nocache=1` to VictoriaMetrics downstreams
+      # (see https://github.com/jacksontj/promxy/issues/202)
+      scheme: http
+      # options for promxy's HTTP client when talking to hosts in server_groups
+      http_client:
+        # dial_timeout controls how long promxy will wait for a connection to the downstream
+        # the default is 200ms.
+        dial_timeout: 1s
+        tls_config:
+          insecure_skip_verify: true
+      # make response as optional
+      ignore_error: false

--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	_ "net/http/pprof"
 	"net/url"
 	"os"
 	"os/signal"
@@ -15,8 +16,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-
-	_ "net/http/pprof"
 
 	kitlog "github.com/go-kit/log"
 	"github.com/golang/glog"

--- a/pkg/middleware/headers.go
+++ b/pkg/middleware/headers.go
@@ -3,11 +3,13 @@ package middleware
 import (
 	"context"
 	"net/http"
+	"strconv"
+	"strings"
 )
 
-type contextKey int
-
-const headerKey contextKey = 0
+const headerKey int = 0
+const OrgIdKey string = "X-Scope-OrgID"
+const batchSizeKey string = "batch-size"
 
 func NewProxyHeaders(h http.Handler, headers []string) *ProxyHeaders {
 	return &ProxyHeaders{
@@ -23,13 +25,13 @@ type ProxyHeaders struct {
 
 func (p *ProxyHeaders) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	hdrs := make(map[string]string, len(p.headers))
+	var ctx = r.Context()
 	for _, header := range p.headers {
-		if v := r.Header.Get(header); v != "" {
-			hdrs[header] = v
+		if tenants := r.Header.Get(header); tenants != "" {
+			hdrs[header] = tenants
 		}
 	}
-
-	p.h.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), headerKey, hdrs)))
+	p.h.ServeHTTP(w, r.WithContext(context.WithValue(ctx, headerKey, hdrs)))
 }
 
 func GetHeaders(ctx context.Context) map[string]string {
@@ -39,4 +41,63 @@ func GetHeaders(ctx context.Context) map[string]string {
 	}
 
 	return v.(map[string]string)
+}
+
+func splitTenants(tenants string, batchSize int) []string {
+	result := make([]string, 0)
+	sep := "|"
+	if batchSize == 0 {
+		result = append(result, tenants)
+	} else {
+		tenantsList := strings.Split(tenants, sep)
+		var batchTenant = ""
+		var i = 0
+		for _, tenant := range tenantsList {
+			if i != 0 {
+				batchTenant = batchTenant + sep + tenant
+			} else {
+				if batchTenant != "" {
+					result = append(result, batchTenant)
+				}
+				batchTenant = tenant
+			}
+			i = (i + 1) % batchSize
+		}
+		result = append(result, batchTenant)
+	}
+	return result
+}
+
+func getBatchSize(values map[string]string) int {
+	for key, value := range values {
+		if key == batchSizeKey {
+			i, err := strconv.Atoi(value)
+			if err != nil {
+				return 0
+			} else {
+				return i
+			}
+		}
+	}
+	return 0
+}
+
+func MultipleContexts(ctx context.Context) []context.Context {
+	v := ctx.Value(headerKey)
+	value := v.(map[string]string)
+
+	resultContexts := make([]context.Context, 0)
+	batchSize := getBatchSize(value)
+	for key, tenants := range value {
+		if key == OrgIdKey {
+			tenantsList := splitTenants(tenants, batchSize)
+			for _, tenantIds := range tenantsList {
+				result := make(map[string]string, 1)
+				result[key] = tenantIds
+				resultContexts = append(resultContexts, context.WithValue(ctx, headerKey, result))
+			}
+		}
+
+	}
+	return resultContexts
 }

--- a/pkg/promclient/api.go
+++ b/pkg/promclient/api.go
@@ -1,21 +1,20 @@
 package promclient
 
 import (
-	"context"
-	"fmt"
-	"math"
-	"sort"
-	"time"
+  "context"
+  "fmt"
+  "math"
+  "sort"
+  "time"
 
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/prometheus/common/model"
-	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/model/timestamp"
-	"github.com/prometheus/prometheus/storage/remote"
-	"github.com/sirupsen/logrus"
+  v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+  "github.com/prometheus/common/model"
+  "github.com/prometheus/prometheus/model/labels"
+  "github.com/prometheus/prometheus/model/timestamp"
+  "github.com/prometheus/prometheus/storage/remote"
 
-	"github.com/jacksontj/promxy/pkg/middleware"
-	"github.com/jacksontj/promxy/pkg/promhttputil"
+  "github.com/jacksontj/promxy/pkg/middleware"
+  "github.com/jacksontj/promxy/pkg/promhttputil"
 )
 
 // Copied from prometheus' API (these should just be exported...)
@@ -47,9 +46,7 @@ func (p *PromAPIV1) LabelNames(ctx context.Context, matchers []string, startTime
 	result := make(map[string]struct{})
 	warnings := make(promhttputil.WarningSet)
 
-	for _, childChangedContext := range middleware.MultipleContexts(ctx) {
-		// Remove this later
-		logrus.Infof("LabelNames Query using header: %s", middleware.GetHeaders(childChangedContext)[middleware.OrgIdKey])
+	for _, childChangedContext := range middleware.CreateMultipleContexts(ctx) {
 		labelResults, warning, err := p.API.LabelNames(childChangedContext, matchers, startTime, endTime)
 		warnings.AddWarnings(warning)
 		if err == nil {
@@ -79,9 +76,7 @@ func (p *PromAPIV1) LabelValues(ctx context.Context, label string, matchers []st
 	var mergedResults model.LabelValues
 	warnings := make(promhttputil.WarningSet)
 
-	for _, childChangedContext := range middleware.MultipleContexts(ctx) {
-		// Remove this later
-		logrus.Infof("LabelValues Query using header: %s", middleware.GetHeaders(childChangedContext)[middleware.OrgIdKey])
+	for _, childChangedContext := range middleware.CreateMultipleContexts(ctx) {
 		result, warning, err := p.API.LabelValues(childChangedContext, label, matchers, startTime, endTime)
 		warnings.AddWarnings(warning)
 		if err == nil {
@@ -104,9 +99,7 @@ func (p *PromAPIV1) Query(ctx context.Context, query string, ts time.Time) (mode
 	var mergedResults model.Value
 	warnings := make(promhttputil.WarningSet)
 
-	for _, childChangedContext := range middleware.MultipleContexts(ctx) {
-		// Remove this later
-		logrus.Infof("Query using header: %s", middleware.GetHeaders(childChangedContext)[middleware.OrgIdKey])
+	for _, childChangedContext := range middleware.CreateMultipleContexts(ctx) {
 		result, warning, err := p.API.Query(childChangedContext, query, ts)
 		warnings.AddWarnings(warning)
 		if err == nil {
@@ -129,9 +122,7 @@ func (p *PromAPIV1) QueryRange(ctx context.Context, query string, r v1.Range) (m
 	var mergedResults model.Value
 	warnings := make(promhttputil.WarningSet)
 
-	for _, childChangedContext := range middleware.MultipleContexts(ctx) {
-		// Remove this later
-		logrus.Infof("QueryRange using header: %s", middleware.GetHeaders(childChangedContext)[middleware.OrgIdKey])
+	for _, childChangedContext := range middleware.CreateMultipleContexts(ctx) {
 		result, warning, err := p.API.QueryRange(childChangedContext, query, r)
 		warnings.AddWarnings(warning)
 		if err == nil {


### PR DESCRIPTION
### Summary

This change is meant to support query sharding using headers. Currently headers which are allowlisted via proxy-headers are being passed to each server group and each target within a server group as it is. 

This leads to couple of problems on the backend:

- In Grafana Mimir's [context](https://grafana.com/docs/mimir/latest/manage/secure/authentication-and-authorization/#grafana-mimir-authentication-and-authorization), for federation usecases this can leads to lot of tenants in a single query and since Query layer on Mimir doesn't shard based on # of tenants, it leads to resource exhaustion and timeouts on storage system.
- Slower queries as single sharded query deals with lot of tenants under the hood.

This change adds support to split a query into multiple sub-queries, No of tenants send to backend is governed by batch-size parameter. If batch-size is not provided, behavior works as expected.

### Testing

- Tested query and label API with new behavior and ensure backward compatibility without new params.

cc: @aallawala @edma2

