### PR TITLE
Fix permanent redirection loop on /debug/pprof

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -448,7 +448,8 @@ func main() {
 	r.NotFound = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Have our fallback rules
 		if strings.HasPrefix(r.URL.Path, path.Join(webOptions.RoutePrefix, "/debug")) {
-			http.StripPrefix(webOptions.RoutePrefix, http.DefaultServeMux).ServeHTTP(w, r)
+			prefix := strings.TrimSuffix(path.Join(webOptions.RoutePrefix, "/debug"), "/debug")
+			http.StripPrefix(prefix, http.DefaultServeMux).ServeHTTP(w, r)
 		} else if r.URL.Path == path.Join(webOptions.RoutePrefix, "/-/ready") {
 			if stopping {
 				w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
The `webOptions.RoutePrefix` is `"/"` by default, which makes `http.StripPrefix` matching `debug/pprof` when requesting `/debug/pprof` which results in a permanent 302 (to `/debug/pprof`) loop. The PR fixes the prefix to strip.