### PR TITLE
Fix offset finder

### DIFF
--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -376,14 +376,16 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *parser.EvalStmt, nod
 
 	// If the tree below us is not all the same offset, then we can't do anything below -- we'll need
 	// to wait until further in execution where they all match
-	var offset time.Duration
+	var offset time.Duration = 0
 
-	// If we couldn't find an offset, then something is wrong-- lets skip
-	// Also if there was an error, skip
-	if !offsetFinder.Found || offsetFinder.Error != nil {
+	// If we couldn't find an offset, the offset should be 0.
+	// If there was an error, let's skip.
+	if offsetFinder.Error != nil {
 		return nil, nil
 	}
-	offset = offsetFinder.Offset
+	if offsetFinder.Found {
+		offset = offsetFinder.Offset
+	}
 
 	// Function to recursivelt remove offset. This is needed as we're using
 	// the node API to String() the query to downstreams. Promql's iterators require

--- a/pkg/proxystorage/util.go
+++ b/pkg/proxystorage/util.go
@@ -55,25 +55,25 @@ func (o *OffsetFinder) Visit(node parser.Node, _ []parser.Node) (parser.Visitor,
 	defer o.l.Unlock()
 	switch n := node.(type) {
 	case *parser.SubqueryExpr:
-		if !o.Found {
-			if n.OriginalOffset > 0 {
+		if n.OriginalOffset > 0 {
+			if !o.Found {
 				o.Offset = n.OriginalOffset
 				o.Found = true
-			}
-		} else {
-			if n.OriginalOffset != o.Offset {
-				o.Error = fmt.Errorf("mismatched offsets %v %v", n.OriginalOffset, o.Offset)
+			} else {
+				if n.OriginalOffset != o.Offset {
+					o.Error = fmt.Errorf("mismatched offsets %v %v", n.OriginalOffset, o.Offset)
+				}
 			}
 		}
 	case *parser.VectorSelector:
-		if !o.Found {
-			if n.OriginalOffset > 0 {
+		if n.OriginalOffset > 0 {
+			if !o.Found {
 				o.Offset = n.OriginalOffset
 				o.Found = true
-			}
-		} else {
-			if n.OriginalOffset != o.Offset {
-				o.Error = fmt.Errorf("mismatched offsets %v %v", n.OriginalOffset, o.Offset)
+			} else {
+				if n.OriginalOffset != o.Offset {
+					o.Error = fmt.Errorf("mismatched offsets %v %v", n.OriginalOffset, o.Offset)
+				}
 			}
 		}
 	}

--- a/pkg/proxystorage/util.go
+++ b/pkg/proxystorage/util.go
@@ -56,8 +56,10 @@ func (o *OffsetFinder) Visit(node parser.Node, _ []parser.Node) (parser.Visitor,
 	switch n := node.(type) {
 	case *parser.SubqueryExpr:
 		if !o.Found {
-			o.Offset = n.OriginalOffset
-			o.Found = true
+			if n.OriginalOffset > 0 {
+				o.Offset = n.OriginalOffset
+				o.Found = true
+			}
 		} else {
 			if n.OriginalOffset != o.Offset {
 				o.Error = fmt.Errorf("mismatched offsets %v %v", n.OriginalOffset, o.Offset)
@@ -65,8 +67,10 @@ func (o *OffsetFinder) Visit(node parser.Node, _ []parser.Node) (parser.Visitor,
 		}
 	case *parser.VectorSelector:
 		if !o.Found {
-			o.Offset = n.OriginalOffset
-			o.Found = true
+			if n.OriginalOffset > 0 {
+				o.Offset = n.OriginalOffset
+				o.Found = true
+			}
 		} else {
 			if n.OriginalOffset != o.Offset {
 				o.Error = fmt.Errorf("mismatched offsets %v %v", n.OriginalOffset, o.Offset)


### PR DESCRIPTION
Fixes #678

The offset finder didn't check the offset value, which incorrectly found an offset of 0 in the query below

```promql
max(max_over_time(sum(rate(stream_executor_row_count{namespace=~"default"}[30s] offset 30m))[12h2m27s:30s]))
```

, and it returns an error of `mismatched offsets` which is [swallowed silently](https://github.com/jacksontj/promxy/blob/7c5eda61650f1df182a6fb037367522f5cc7743a/pkg/proxystorage/proxy.go#L383). 

With the fix, the query above correctly triggered `QueryRange`, as showed below.

```plain
DEBU[2024-09-10T19:55:38+08:00] http://localhost:8428                         api=QueryRange query="sum(rate(stream_executor_row_count{namespace=~\"default\"}[30s]))" r="{2024-09-08 23:23:30 +0000 UTC 2024-09-10 11:25:38.141 +0000 UTC 30s}"
```

The request time range is `[2024-09-08 23:53:30 +0000 UTC 2024-09-10 11:55:38.141]` and the offset `30m` was respected.