### PR TITLE
Fix AddLabelClient handling of multiple matching labels

### DIFF
--- a/pkg/promclient/label.go
+++ b/pkg/promclient/label.go
@@ -94,6 +94,14 @@ func (c *AddLabelClient) filterMatchers(matchers []string) ([]string, bool, erro
 
 // LabelNames returns all the unique label names present in the block in sorted order.
 func (c *AddLabelClient) LabelNames(ctx context.Context, matchers []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error) {
+	matchers, ok, err := c.filterMatchers(matchers)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !ok {
+		return nil, nil, nil
+	}
+
 	l, w, err := c.API.LabelNames(ctx, matchers, startTime, endTime)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/promclient/label_test.go
+++ b/pkg/promclient/label_test.go
@@ -181,6 +181,21 @@ func TestAddLabelClient(t *testing.T) {
 			labelValues: []string{"1"},
 			matchers:    []string{`{b="1"}`},
 		},
+		{
+			labelSet:    model.LabelSet{"b": "1", "c": "1"},
+			labelValues: []string{"1"},
+			matchers:    []string{`{b="1", c="1"}`},
+		},
+		{
+			labelSet:    model.LabelSet{"b": "1", "c": "1", "d": "1"},
+			labelValues: []string{"1"},
+			matchers:    []string{`{b="1", c="1"}`},
+		},
+		{
+			labelSet:    model.LabelSet{"b": "1", "c": "1", "d": "1"},
+			labelValues: []string{"1"},
+			matchers:    []string{`{a="1", b="1", c="1"}`},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
As reported in #665 the initial implementation fixed *some* cases but not all. This fixes the typo and edge-case handling missed in the previous PR.

Fixes #665