### PR TITLE
Correctly override node in aggregateBinaryExpr

### DIFF
--- a/pkg/proxystorage/proxy_test.go
+++ b/pkg/proxystorage/proxy_test.go
@@ -192,32 +192,62 @@ func TestNodeReplacer(t *testing.T) {
 		// we expect to re-do the AggregateExpr but have replaced the VectorSelector with the query
 		{
 			in:  "min(foo{}) > 1",
-			out: "min() > 1",
+			out: "min()",
 			queries: []string{
 				"min(foo) > 1 @ 10000",
 			},
 		},
 		{
 			in:  "max(foo{}) > 1",
-			out: "max() > 1",
+			out: "max()",
 			queries: []string{
 				"max(foo) > 1 @ 10000",
 			},
 		},
 		{
 			in:  "topk(5, foo{}) > 1",
-			out: "topk(5, ) > 1",
+			out: "topk(5, )",
 			queries: []string{
 				"topk(5, foo) > 1 @ 10000",
 			},
 		},
 		{
 			in:  "bottomk(5, foo{}) > 1",
-			out: "bottomk(5, ) > 1",
+			out: "bottomk(5, )",
 			queries: []string{
 				"bottomk(5, foo) > 1 @ 10000",
 			},
 		},
+
+		{
+			in:  "min(foo{}) * 1000",
+			out: "min()",
+			queries: []string{
+				"min(foo) * 1000 @ 10000",
+			},
+		},
+		{
+			in:  "max(foo{}) * 1000",
+			out: "max()",
+			queries: []string{
+				"max(foo) * 1000 @ 10000",
+			},
+		},
+		{
+			in:  "topk(5, foo{}) * 1000",
+			out: "topk(5, )",
+			queries: []string{
+				"topk(5, foo) * 1000 @ 10000",
+			},
+		},
+		{
+			in:  "bottomk(5, foo{}) * 1000",
+			out: "bottomk(5, )",
+			queries: []string{
+				"bottomk(5, foo) * 1000 @ 10000",
+			},
+		},
+
 		// Check that some others do nothing
 		{
 			in: "avg(foo) > 1",


### PR DESCRIPTION
In #676 we added support for query push down for BinaryExp where it is a literal and either a VectorSelector or a subset of AggregateExprs. However this initial implementation introduced a bug for AggregateExprs. Specifically it was doing the query push down but not doing the node replace properly -- such that the literal operation was done twice (e.g. add twice, multiply twice, etc.).

This patch will have the aggregateBinaryExpr replace the Binary Expr (i.e. `(max(foo) * 100)` ) with the "filled in" AggregateExpr -- such that the re-execution of the aggregation still occurs without re-doing the literal calculation.

Fixes #688