### PR TITLE
fix: wrong query result from aggregation Operators

### DIFF
--- a/pkg/promhttputil/merge.go
+++ b/pkg/promhttputil/merge.go
@@ -287,7 +287,7 @@ func MergeSampleStream(antiAffinityBuffer model.Time, a, b *model.SampleStream, 
 			// see if there is a sample from b within antiAffinityBuffer, that is larger than a
 			for i := lastOffset; i < len(b.Values); i++ {
 				bValue := b.Values[i]
-				if bValue.Timestamp >= (aValue.Timestamp + antiAffinityBuffer) {
+				if bValue.Timestamp >= (aValue.Timestamp+antiAffinityBuffer) && bValue.Timestamp != aValue.Timestamp {
 					break
 				}
 				// b is within antiAffinityBuffer of a

--- a/pkg/promhttputil/merge.go
+++ b/pkg/promhttputil/merge.go
@@ -287,6 +287,7 @@ func MergeSampleStream(antiAffinityBuffer model.Time, a, b *model.SampleStream, 
 			// see if there is a sample from b within antiAffinityBuffer, that is larger than a
 			for i := lastOffset; i < len(b.Values); i++ {
 				bValue := b.Values[i]
+				// b is not within antiAffinityBuffer of a
 				if bValue.Timestamp >= (aValue.Timestamp+antiAffinityBuffer) && bValue.Timestamp != aValue.Timestamp {
 					break
 				}


### PR DESCRIPTION
Partially fixes: #703 

I said to partially fix the #703 issue since if you do the query `count(up{label_key="label_value"})`, you will have the sum of all values from all server groups defined, and not just the max one from a single server group.

I don't know if is expected or not, but per my tests, I see the `preferMax` always reaches with value `false` to the merge functions due to [this setup](https://github.com/jacksontj/promxy/blob/c6ce66d13bb6c77c2f6141879cd322bdd21c84ea/pkg/proxystorage/proxy.go#L133). 

I opened this PR for discussion 🙌 