### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . /go/src/github.com/jacksontj/promxy
 RUN cd /go/src/github.com/jacksontj/promxy/cmd/promxy && CGO_ENABLED=0 go build -mod=vendor -tags netgo,builtinassets
 RUN cd /go/src/github.com/jacksontj/promxy/cmd/remote_write_exporter && CGO_ENABLED=0 go build -mod=vendor
 
-FROM alpine:3.17.2
+FROM alpine:3.18.11
 MAINTAINER Thomas Jackson <jacksontj.89@gmail.com>
 EXPOSE     8082
 


### PR DESCRIPTION
The hardcoded 3.17.2 version of alpine used to build the final image has known vulnerabilities which lead to promxy being flagged by scanners (even though it's likely that promxy installations aren't actually affected). 

Bumping the version to the latest patch of the 3.18 series aligns it with what's used in the Go build, but both are not the latest available – Go 1.23 and Alpine 3.21 are available.