### PR TITLE
Customize the configmap-reload image from Helm

### DIFF
--- a/deploy/k8s/helm-charts/promxy/templates/deployment.yaml
+++ b/deploy/k8s/helm-charts/promxy/templates/deployment.yaml
@@ -99,7 +99,8 @@ spec:
         args:
         - "--volume-dir=/etc/promxy"
         - "--webhook-url=http://localhost:8082/-/reload"
-        image: jimmidyson/configmap-reload:v0.5.0
+        image: "{{ .Values.configmapReloader.image.repository }}:{{ .Values.configmapReloader.image.tag }}"
+        imagePullPolicy: {{ .Values.configmapReloader.image.pullPolicy }}
         volumeMounts:
         - mountPath: "/etc/promxy/"
           name: config

--- a/deploy/k8s/helm-charts/promxy/values.yaml
+++ b/deploy/k8s/helm-charts/promxy/values.yaml
@@ -15,6 +15,12 @@ image:
   tag: "master" # rewrites Chart.AppVersion
   pullPolicy: IfNotPresent
 
+configmapReloader:
+  image:
+    repository: jimmidyson/configmap-reload
+    tag: "v0.5.0"
+    pullPolicy: IfNotPresent
+
 podDisruptionBudget:
   enabled: false
   # minAvailable: 1


### PR DESCRIPTION
It was not possible to host this image in a private registry before.
Using a Kustomize postrender script is not ideal as it prevents from getting potential future image tags.