### PR TITLE
feat: add external_labels config that does not overwrite metric labels

### DIFF
--- a/pkg/promclient/label_test.go
+++ b/pkg/promclient/label_test.go
@@ -197,11 +197,12 @@ func TestAddLabelClient(t *testing.T) {
 	}
 
 	tests := []struct {
-		labelSet    model.LabelSet
-		err         bool
-		matchers    []string
-		labelValues []string
-		labelNames  []string
+		labelSet         model.LabelSet
+		externalLabelSet model.LabelSet
+		err              bool
+		matchers         []string
+		labelValues      []string
+		labelNames       []string
 	}{
 		{
 			labelSet:    model.LabelSet{"b": "1"},
@@ -235,7 +236,7 @@ func TestAddLabelClient(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		a := &AddLabelClient{stub, test.labelSet}
+		a := NewAddLabelClient(stub, test.labelSet, test.externalLabelSet)
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Run("LabelNames", func(t *testing.T) {
 				v, _, err := a.LabelValues(context.TODO(), "a", test.matchers, time.Time{}, time.Time{})

--- a/pkg/promclient/multi_api_test.go
+++ b/pkg/promclient/multi_api_test.go
@@ -193,7 +193,7 @@ func TestMultiAPIMerging(t *testing.T) {
 		},
 		// Ensure that simple label addition works
 		{
-			a:           &AddLabelClient{stub, model.LabelSet{"a": "b"}},
+			a:           NewAddLabelClient(stub, model.LabelSet{"a": "b"}, model.LabelSet{}),
 			labelNames:  []string{"a"},
 			labelValues: []model.LabelValue{"b"},
 			v: model.Vector{
@@ -206,8 +206,8 @@ func TestMultiAPIMerging(t *testing.T) {
 		// Ensure a single layer of multi merges
 		{
 			a: NewMustMultiAPI([]API{
-				&AddLabelClient{stub, model.LabelSet{"a": "1"}},
-				&AddLabelClient{stub, model.LabelSet{"a": "2"}},
+				NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}),
+				NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
 			}, model.Time(0), nil, 1, false),
 			labelNames:  []string{"a"},
 			labelValues: []model.LabelValue{"1", "2"},
@@ -224,12 +224,12 @@ func TestMultiAPIMerging(t *testing.T) {
 		{
 			a: NewMustMultiAPI([]API{
 				NewMustMultiAPI([]API{
-					&AddLabelClient{stub, model.LabelSet{"a": "1"}},
-					&AddLabelClient{stub, model.LabelSet{"a": "1"}},
+					NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}),
+					NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}),
 				}, model.Time(0), nil, 1, false),
 				NewMustMultiAPI([]API{
-					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
+					NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
+					NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
 				}, model.Time(0), nil, 1, false),
 			}, model.Time(0), nil, 2, false),
 			labelNames:  []string{"a"},
@@ -248,22 +248,22 @@ func TestMultiAPIMerging(t *testing.T) {
 			a: NewMustMultiAPI([]API{
 				NewMustMultiAPI([]API{
 					NewMustMultiAPI([]API{
-						&AddLabelClient{stub, model.LabelSet{"a": "1"}},
-						&AddLabelClient{stub, model.LabelSet{"a": "1"}},
+						NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}),
+						NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}),
 					}, model.Time(0), nil, 1, false),
 					NewMustMultiAPI([]API{
-						&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-						&AddLabelClient{stub, model.LabelSet{"a": "2"}},
+						NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
+						NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
 					}, model.Time(0), nil, 1, false),
 				}, model.Time(0), nil, 2, false),
 				NewMustMultiAPI([]API{
 					NewMustMultiAPI([]API{
-						&AddLabelClient{stub, model.LabelSet{"b": "1"}},
-						&AddLabelClient{stub, model.LabelSet{"b": "1"}},
+						NewAddLabelClient(stub, model.LabelSet{"b": "1"}, model.LabelSet{}),
+						NewAddLabelClient(stub, model.LabelSet{"b": "1"}, model.LabelSet{}),
 					}, model.Time(0), nil, 1, false),
 					NewMustMultiAPI([]API{
-						&AddLabelClient{stub, model.LabelSet{"b": "2"}},
-						&AddLabelClient{stub, model.LabelSet{"b": "2"}},
+						NewAddLabelClient(stub, model.LabelSet{"b": "2"}, model.LabelSet{}),
+						NewAddLabelClient(stub, model.LabelSet{"b": "2"}, model.LabelSet{}),
 					}, model.Time(0), nil, 1, false),
 				}, model.Time(0), nil, 2, false),
 			}, model.Time(0), nil, 2, false),
@@ -293,12 +293,12 @@ func TestMultiAPIMerging(t *testing.T) {
 		{
 			a: NewMustMultiAPI([]API{
 				NewMustMultiAPI([]API{
-					&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
-					&AddLabelClient{stub, model.LabelSet{"a": "1"}},
+					&errorAPI{NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}), fmt.Errorf("")},
+					NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}),
 				}, model.Time(0), nil, 1, false),
 				NewMustMultiAPI([]API{
-					&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "2"}}, fmt.Errorf("")},
-					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
+					&errorAPI{NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}), fmt.Errorf("")},
+					NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
 				}, model.Time(0), nil, 1, false),
 			}, model.Time(0), nil, 2, false),
 			labelNames:  []string{"a"},
@@ -316,12 +316,12 @@ func TestMultiAPIMerging(t *testing.T) {
 		{
 			a: NewMustMultiAPI([]API{
 				NewMustMultiAPI([]API{
-					&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
-					&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
+					&errorAPI{NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}), fmt.Errorf("")},
+					&errorAPI{NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}), fmt.Errorf("")},
 				}, model.Time(0), nil, 1, false),
 				NewMustMultiAPI([]API{
-					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
+					NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
+					NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
 				}, model.Time(0), nil, 1, false),
 			}, model.Time(0), nil, 2, false),
 			err: true,
@@ -329,17 +329,17 @@ func TestMultiAPIMerging(t *testing.T) {
 		// if in a multi, all that "match" error, we should error
 		{
 			a: NewMustMultiAPI([]API{
-				&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
-				&AddLabelClient{stub, model.LabelSet{"a": "2"}},
+				&errorAPI{NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}), fmt.Errorf("")},
+				NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
 			}, model.Time(0), nil, 1, false),
 			err: true,
 		},
 		// however, in a multi if a single one succeeds for a given "group" then it should pass
 		{
 			a: NewMustMultiAPI([]API{
-				&AddLabelClient{stub, model.LabelSet{"a": "1"}},
-				&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
-				&AddLabelClient{stub, model.LabelSet{"a": "2"}},
+				NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}),
+				&errorAPI{NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}), fmt.Errorf("")},
+				NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
 			}, model.Time(0), nil, 1, false),
 			labelNames:  []string{"a"},
 			labelValues: []model.LabelValue{"1", "2"},
@@ -356,8 +356,8 @@ func TestMultiAPIMerging(t *testing.T) {
 		{
 			a: NewMustMultiAPI([]API{
 				stub,
-				&AddLabelClient{stub, model.LabelSet{"a": "1"}},
-				&AddLabelClient{stub, model.LabelSet{"a": "2"}},
+				NewAddLabelClient(stub, model.LabelSet{"a": "1"}, model.LabelSet{}),
+				NewAddLabelClient(stub, model.LabelSet{"a": "2"}, model.LabelSet{}),
 			}, model.Time(0), nil, 1, false),
 			labelNames:  []string{"a"},
 			labelValues: []model.LabelValue{"1", "2"},

--- a/pkg/promhttputil/merge.go
+++ b/pkg/promhttputil/merge.go
@@ -44,12 +44,17 @@ func (s WarningSet) Warnings() v1.Warnings {
 }
 
 // ValueAddLabelSet adds the labelset `l` to the value `a`
-func ValueAddLabelSet(a model.Value, l model.LabelSet) error {
+func ValueAddLabelSet(a model.Value, l, extL model.LabelSet) error {
 	switch aTyped := a.(type) {
 	case model.Vector:
 		for _, item := range aTyped {
 			for k, v := range l {
 				item.Metric[k] = v
+			}
+			for k, v := range extL {
+				if _, ok := item.Metric[k]; !ok {
+					item.Metric[k] = v
+				}
 			}
 		}
 
@@ -61,6 +66,11 @@ func ValueAddLabelSet(a model.Value, l model.LabelSet) error {
 			}
 			for k, v := range l {
 				item.Metric[k] = v
+			}
+			for k, v := range extL {
+				if _, ok := item.Metric[k]; !ok {
+					item.Metric[k] = v
+				}
 			}
 		}
 	}

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -67,7 +67,9 @@ type Config struct {
 	Scheme string `yaml:"scheme"`
 	// Labels is a set of labels that will be added to all metrics retrieved
 	// from this server group
-	Labels model.LabelSet `json:"labels"`
+	Labels model.LabelSet `yaml:"labels"`
+	// ExternalLabels are the labels that will be added to all metrics retrieved same as Prometheus does. (does not overwrite existing labels)
+	ExternalLabels model.LabelSet `yaml:"external_labels"`
 	// RelabelConfigs are similar in function and identical in configuration as prometheus'
 	// relabel config for scrape jobs. The difference here being that the source labels
 	// you can pull from are from the downstream servergroup target and the labels you are

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -254,7 +254,7 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 				}
 
 				// Add labels
-				apiClient = &promclient.AddLabelClient{apiClient, modelLabelSet.Merge(s.Cfg.Labels)}
+				apiClient = promclient.NewAddLabelClient(apiClient, modelLabelSet.Merge(s.Cfg.Labels), s.Cfg.ExternalLabels)
 
 				// Add MetricRelabel if set
 				if len(s.Cfg.MetricsRelabelConfigs) > 0 {


### PR DESCRIPTION
Tries to address https://github.com/jacksontj/promxy/issues/727

the `external_labels` config name is probably not self-explanatory, maybe something like `additional_labels` ?

This is more of a POC 

What it does:
  - adds the external_labels to responses ONLY if are not present already
  - It removes the selectors for these labels ONLY if it matches the value actually (cannot be left there, because most probably metrics don't have that label)
    Otherwise, it keeps the selector because it could match the label values of metrics where the value is possibly unknown by promxy
    
There is still at least one edge case...

Consider server group with `external_labels: {"cluster": "cluster1"}` and Prometheis in it, having metrics `up{cluster="cluster2"}` and `up{cluster="cluster3"}`.

Then if you run query `up{cluster="cluster1"}` you get a response matching both the metrics because the selector `cluster="cluster1"` got removed, and now it matches both the metrics :/
This is at least confusing  :confounded: 

WDYT?