### PR TITLE
Switch test to prometheus demo

### DIFF
--- a/cmd/promxy/Makefile
+++ b/cmd/promxy/Makefile
@@ -1,5 +1,5 @@
-test-robust:
-	go build -race -mod=vendor -tags netgo,builtinassets && ./promxy --rules.alertbackfill --log-level=debug --http.shutdown-delay=0s --config=demo_robust.conf --web.external-url=http://localhost:8082/promxy
+test-demo:
+	go build -race -mod=vendor -tags netgo,builtinassets && ./promxy --rules.alertbackfill --log-level=debug --http.shutdown-delay=0s --config=demo.conf --web.external-url=http://localhost:8082/promxy
 
 
 test-local:

--- a/cmd/promxy/demo.conf
+++ b/cmd/promxy/demo.conf
@@ -19,19 +19,21 @@ promxy:
   server_groups:
     - static_configs:
         - targets:
-          - demo.robustperception.io:9090
+          - prometheus.demo.prometheus.io:443
       http_client:
         dial_timeout: 1s
         tls_config:
           insecure_skip_verify: true
+      scheme: https
       labels:
         replica: a
     - static_configs:
         - targets:
-          - demo.robustperception.io:9090
+          - prometheus.demo.prometheus.io:443
       http_client:
         dial_timeout: 1s
         tls_config:
           insecure_skip_verify: true
+      scheme: https
       labels:
         replica: b


### PR DESCRIPTION
It seems that the previous robustperception demo site is gone