### PR TITLE
Allow for NodeReplacer on SubQuery expressions with Aggregates

### DIFF
--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -359,8 +359,15 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *parser.EvalStmt, nod
 	}
 
 	if aggFinder.Found > 0 {
-		// If there was a single agg and that was us, then we're okay
-		if !((isAgg(node) || isSubQuery(node) || isBinaryExpr(node)) && aggFinder.Found == 1) {
+
+		switch {
+		// // If there was a single agg and that was us, then we're okay
+		case (isAgg(node) || isBinaryExpr(node)) && aggFinder.Found == 1:
+			break
+		// If the aggregations are in a SubQuery; we can allow Subquery to run through NodeReplacerZz
+		case isSubQuery(node):
+			break
+		default:
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
Previously we would disallow any NodeReplacement for statements with more than 1 aggregation in them. This logic was in-place well before SubQuery support; and now needs some adjustment. In all cases its safe to let SubQuery run as it recursively calls NodeReplacer with its subquery.

For an example query of `avg_over_time(sum(count(up))[10m:15s])` we would previously do a `GetValue` of `up`.

With this change we now do a `queryRange` for `count(up)`

Fixes #723