### PR TITLE
Add loong64 as a supported platform

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -19,7 +19,7 @@ fi
 package_split=(${package//\// })
 package_name=${package_split[-1]}
 
-platforms=("linux/amd64" "linux/386" "darwin/amd64" "darwin/arm64" "linux/arm" "linux/arm64")
+platforms=("linux/amd64" "linux/386" "darwin/amd64" "darwin/arm64" "linux/arm" "linux/arm64" "linux/loong64")
 
 for platform in "${platforms[@]}"
 do


### PR DESCRIPTION
Please refer to https://go.dev/blog/go1.19 and https://docs.kernel.org/arch/loongarch/introduction.html for an introduction to the Ioong64 architecture