### PR TITLE
enhance server group configuration with optional names

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -33,7 +33,10 @@ promxy:
   server_groups:
     # All upstream prometheus service discovery mechanisms are supported with the same
     # markup, all defined in https://github.com/prometheus/prometheus/blob/master/discovery/config/config.go#L33
-    - static_configs:
+    - # Optional human-readable name for this server group
+      name: primary-cluster
+      
+      static_configs:
         - targets:
           - localhost:9090
 
@@ -186,7 +189,9 @@ promxy:
         X-Promxy-Source: promxy-1
 
     # as many additional server groups as you have
-    - static_configs:
+    - name: secondary-cluster
+      
+      static_configs:
         - targets:
           - localhost:9091
       labels:

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -39,6 +39,8 @@ const (
 // This is where the vast majority of options exist.
 type Config struct {
 	Ordinal int `yaml:"-"`
+	// Name is an optional human-readable identifier for this server group.
+	Name string `yaml:"name,omitempty"`
 	// RemoteRead directs promxy to load RAW data (meaning matrix selectors such as `foo[1h]`)
 	// through the RemoteRead API on prom.
 	// Pros:

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -96,6 +96,35 @@ type ServerGroup struct {
 	state atomic.Value
 }
 
+func (s *ServerGroup) groupIdentifier() string {
+	if s.Cfg != nil {
+		if s.Cfg.Name != "" {
+			return s.Cfg.Name
+		}
+		return fmt.Sprintf("ord=%d", s.Cfg.Ordinal)
+	}
+	return "unknown"
+}
+
+func (s *ServerGroup) logTargetTransition(oldCount, newCount int, initial bool) {
+	ident := s.groupIdentifier()
+	fields := logrus.Fields{
+		"server_group": ident,
+		"old_targets":  oldCount,
+		"new_targets":  newCount,
+	}
+	if s.Cfg != nil {
+		fields["ordinal"] = s.Cfg.Ordinal
+	}
+
+	switch {
+	case initial && newCount == 0:
+		logrus.WithFields(fields).Warnf("ServerGroup '%s' started with zero targets; check service discovery configuration and relabel rules", ident)
+	case oldCount > 0 && newCount == 0:
+		logrus.WithFields(fields).Warnf("ServerGroup '%s' transitioned to zero targets; check service discovery configuration and relabel rules", ident)
+	}
+}
+
 // Cancel stops backround processes (e.g. discovery manager)
 func (s *ServerGroup) Cancel() {
 	s.ctxCancel()
@@ -144,6 +173,11 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 	apiClients := make([]promclient.API, 0)
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
+	oldState := s.State()
+	oldCount := 0
+	if oldState != nil {
+		oldCount = len(oldState.Targets)
+	}
 	defer func() {
 		if err != nil {
 			ctxCancel()
@@ -284,7 +318,9 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 		serverGroupSummary.WithLabelValues(targets[i], api, status).Observe(took)
 	}
 
+	currentTargetCount := len(targets)
 	logrus.Debugf("Updating targets from discovery manager: %v", targets)
+
 	apiClient, err := promclient.NewMultiAPI(apiClients, s.Cfg.GetAntiAffinity(), apiClientMetricFunc, 1, s.Cfg.GetPreferMax())
 	if err != nil {
 		return err
@@ -306,7 +342,9 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 		newState.apiClient = &promclient.DowngradeErrorAPI{newState.apiClient}
 	}
 
-	oldState := s.State()   // Fetch the current state (so we can stop it)
+	initialLoad := !s.loaded
+	s.logTargetTransition(oldCount, currentTargetCount, initialLoad)
+
 	s.state.Store(newState) // Store new state
 	if oldState != nil {
 		oldState.ctxCancel() // Cancel the old state


### PR DESCRIPTION
    - Updated the server group struct and logging to utilize the new `name` field, improving clarity in target transition logs.
   
Fixes #742 