### PR TITLE
ci: automate release build and upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build release binaries
+        run: make release
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/*
+          draft: false
+          prerelease: false
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow to build and upload release binaries on tag push, eliminating the manual `make release` + upload step.

- Triggers on `v*` tag push
- Reuses existing `build.bash` script to create cross-platform binaries for promxy and remote_write_exporter
- Uploads binaries + SHA256SUMS to GitHub release with auto-generated release notes
- Uses softprops/action-gh-release as suggested in the issue

## Test plan
- [ ] Push a test tag to verify workflow triggers
- [ ] Verify binaries are built for all platforms
- [ ] Verify SHA256SUMS file is correct
- [ ] Verify release notes are auto-generated

Fixes #582