### PR TITLE
Add exemplar query support

### DIFF
--- a/pkg/promclient/api.go
+++ b/pkg/promclient/api.go
@@ -135,6 +135,11 @@ func (p *PromAPIV1) GetValue(ctx context.Context, start, end time.Time, matchers
 	return p.Query(ctx, query, end)
 }
 
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (p *PromAPIV1) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	return p.API.QueryExemplars(ctx, query, startTime, endTime)
+}
+
 // PromAPIRemoteRead implements our internal API interface using a combination of
 // the v1 HTTP API and the "experimental" remote_read API
 type PromAPIRemoteRead struct {

--- a/pkg/promclient/debug.go
+++ b/pkg/promclient/debug.go
@@ -171,3 +171,29 @@ func (d *DebugAPI) Metadata(ctx context.Context, metric, limit string) (map[stri
 
 	return v, err
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (d *DebugAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	fields := logrus.Fields{
+		"api":       "QueryExemplars",
+		"query":     query,
+		"startTime": startTime,
+		"endTime":   endTime,
+	}
+
+	logrus.WithFields(fields).Debug(d.PrefixMessage)
+
+	s := time.Now()
+	v, err := d.A.QueryExemplars(ctx, query, startTime, endTime)
+	fields["took"] = time.Since(s)
+
+	if logrus.GetLevel() > logrus.DebugLevel {
+		fields["value"] = v
+		fields["error"] = err
+		logrus.WithFields(fields).Trace(d.PrefixMessage)
+	} else {
+		logrus.WithFields(fields).Debug(d.PrefixMessage)
+	}
+
+	return v, err
+}

--- a/pkg/promclient/downgrade_error.go
+++ b/pkg/promclient/downgrade_error.go
@@ -72,3 +72,9 @@ func (n *DowngradeErrorAPI) Metadata(ctx context.Context, metric, limit string) 
 	v, _ := n.A.Metadata(ctx, metric, limit)
 	return v, nil
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (n *DowngradeErrorAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	v, _ := n.A.QueryExemplars(ctx, query, startTime, endTime)
+	return v, nil
+}

--- a/pkg/promclient/engine.go
+++ b/pkg/promclient/engine.go
@@ -134,3 +134,8 @@ func (a *EngineAPI) GetValue(ctx context.Context, start, end time.Time, matchers
 func (a *EngineAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (a *EngineAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/pkg/promclient/error_wrap.go
+++ b/pkg/promclient/error_wrap.go
@@ -76,3 +76,13 @@ func (e *ErrorWrap) Metadata(ctx context.Context, metric, limit string) (v map[s
 	}()
 	return e.A.Metadata(ctx, metric, limit)
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (e *ErrorWrap) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) (v []v1.ExemplarQueryResult, err error) {
+	defer func() {
+		if err != nil {
+			err = errors.Wrap(err, e.Msg)
+		}
+	}()
+	return e.A.QueryExemplars(ctx, query, startTime, endTime)
+}

--- a/pkg/promclient/exemplar_wrappers_test.go
+++ b/pkg/promclient/exemplar_wrappers_test.go
@@ -1,0 +1,246 @@
+package promclient
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
+)
+
+// recordingExemplarAPI is a minimal stub that records the calls it receives
+// and returns a canned response. Embeds stubAPI so it picks up no-op
+// implementations of the rest of the API surface.
+type recordingExemplarAPI struct {
+	stubAPI
+	calls []recordedCall
+	resp  []v1.ExemplarQueryResult
+}
+
+type recordedCall struct {
+	query string
+	start time.Time
+	end   time.Time
+}
+
+func (r *recordingExemplarAPI) QueryExemplars(_ context.Context, query string, start, end time.Time) ([]v1.ExemplarQueryResult, error) {
+	r.calls = append(r.calls, recordedCall{query, start, end})
+	return r.resp, nil
+}
+
+func TestAddLabelClient_QueryExemplarsTagsSeriesLabels(t *testing.T) {
+	stub := &recordingExemplarAPI{
+		resp: []v1.ExemplarQueryResult{
+			{
+				SeriesLabels: model.LabelSet{"__name__": "foo"},
+				Exemplars:    []v1.Exemplar{{Value: 1, Timestamp: 100}},
+			},
+		},
+	}
+	c := &AddLabelClient{API: stub, Labels: model.LabelSet{"az": "a"}}
+
+	got, err := c.QueryExemplars(context.Background(), `foo`, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("QueryExemplars: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 result, got %d", len(got))
+	}
+	if got[0].SeriesLabels["az"] != "a" {
+		t.Fatalf("expected az=a in SeriesLabels, got %v", got[0].SeriesLabels)
+	}
+	if got[0].SeriesLabels["__name__"] != "foo" {
+		t.Fatalf("expected original __name__ preserved, got %v", got[0].SeriesLabels)
+	}
+}
+
+func TestMetricsRelabelClient_QueryExemplarsRelabelsAndDrops(t *testing.T) {
+	stub := &recordingExemplarAPI{
+		resp: []v1.ExemplarQueryResult{
+			{SeriesLabels: model.LabelSet{"__name__": "keep_me"}},
+			{SeriesLabels: model.LabelSet{"__name__": "drop_me"}},
+		},
+	}
+
+	dropRule, err := relabel.NewRegexp("drop_me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := &MetricsRelabelClient{
+		API: stub,
+		RelabelConfigs: []*relabel.Config{
+			{
+				SourceLabels: model.LabelNames{model.MetricNameLabel},
+				Action:       relabel.Drop,
+				Regex:        dropRule,
+			},
+		},
+	}
+
+	got, err := c.QueryExemplars(context.Background(), `{__name__=~"keep_me|drop_me"}`, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("QueryExemplars: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 series after drop, got %d (%+v)", len(got), got)
+	}
+	if got[0].SeriesLabels["__name__"] != "keep_me" {
+		t.Fatalf("kept the wrong series: %v", got[0].SeriesLabels)
+	}
+}
+
+func TestAbsoluteTimeFilter_QueryExemplars(t *testing.T) {
+	tests := []struct {
+		name        string
+		filterStart time.Time
+		filterEnd   time.Time
+		truncate    bool
+		queryStart  time.Time
+		queryEnd    time.Time
+		wantCalled  bool
+		// truncate-mode: the request times we expect to forward
+		expectStart time.Time
+		expectEnd   time.Time
+	}{
+		{
+			name:        "in window passes through unchanged",
+			filterStart: time.Unix(100, 0),
+			filterEnd:   time.Unix(200, 0),
+			queryStart:  time.Unix(120, 0),
+			queryEnd:    time.Unix(180, 0),
+			wantCalled:  true,
+			expectStart: time.Unix(120, 0),
+			expectEnd:   time.Unix(180, 0),
+		},
+		{
+			name:        "entirely after window short-circuits",
+			filterStart: time.Unix(100, 0),
+			filterEnd:   time.Unix(200, 0),
+			queryStart:  time.Unix(300, 0),
+			queryEnd:    time.Unix(400, 0),
+			wantCalled:  false,
+		},
+		{
+			name:        "entirely before window short-circuits",
+			filterStart: time.Unix(100, 0),
+			filterEnd:   time.Unix(200, 0),
+			queryStart:  time.Unix(10, 0),
+			queryEnd:    time.Unix(50, 0),
+			wantCalled:  false,
+		},
+		{
+			name:        "truncate clamps to filter window",
+			filterStart: time.Unix(100, 0),
+			filterEnd:   time.Unix(200, 0),
+			truncate:    true,
+			queryStart:  time.Unix(50, 0),
+			queryEnd:    time.Unix(300, 0),
+			wantCalled:  true,
+			expectStart: time.Unix(100, 0),
+			expectEnd:   time.Unix(200, 0),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &recordingExemplarAPI{}
+			f := &AbsoluteTimeFilter{API: stub, Start: tc.filterStart, End: tc.filterEnd, Truncate: tc.truncate}
+			_, err := f.QueryExemplars(context.Background(), `foo`, tc.queryStart, tc.queryEnd)
+			if err != nil {
+				t.Fatalf("QueryExemplars: %v", err)
+			}
+			if tc.wantCalled {
+				if len(stub.calls) != 1 {
+					t.Fatalf("want 1 downstream call, got %d", len(stub.calls))
+				}
+				if !stub.calls[0].start.Equal(tc.expectStart) || !stub.calls[0].end.Equal(tc.expectEnd) {
+					t.Fatalf("call window: want %v..%v got %v..%v",
+						tc.expectStart, tc.expectEnd, stub.calls[0].start, stub.calls[0].end)
+				}
+			} else if len(stub.calls) != 0 {
+				t.Fatalf("expected no downstream call, got %d (%+v)", len(stub.calls), stub.calls)
+			}
+		})
+	}
+}
+
+func TestAddLabelClient_QueryExemplarsShortCircuits(t *testing.T) {
+	stub := &recordingExemplarAPI{
+		resp: []v1.ExemplarQueryResult{
+			{SeriesLabels: model.LabelSet{"__name__": "foo"}},
+		},
+	}
+	c := &AddLabelClient{API: stub, Labels: model.LabelSet{"az": "a"}}
+
+	// Query asks for az="b" — incompatible with our az="a", must short-circuit.
+	got, err := c.QueryExemplars(context.Background(), `foo{az="b"}`, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("QueryExemplars: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil result for incompatible az, got %v", got)
+	}
+	if len(stub.calls) != 0 {
+		t.Fatalf("expected no downstream call, got %d", len(stub.calls))
+	}
+
+	// Query asks for az="a" — must forward.
+	stub.calls = nil
+	got, err = c.QueryExemplars(context.Background(), `foo{az="a"}`, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("QueryExemplars: %v", err)
+	}
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected 1 downstream call, got %d", len(stub.calls))
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(got))
+	}
+}
+
+func TestLabelFilterClient_QueryExemplarsShortCircuits(t *testing.T) {
+	stub := &recordingExemplarAPI{
+		resp: []v1.ExemplarQueryResult{
+			{SeriesLabels: model.LabelSet{"__name__": "foo"}},
+		},
+	}
+	// Filter says we only know about metric_a — anything else short-circuits.
+	c := &LabelFilterClient{API: stub}
+	c.filter.Store(map[string]map[string]struct{}{
+		"__name__": {"metric_a": {}},
+	})
+
+	got, err := c.QueryExemplars(context.Background(), `metric_b`, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("QueryExemplars: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil for filtered-out metric, got %v", got)
+	}
+	if len(stub.calls) != 0 {
+		t.Fatalf("expected no downstream call, got %d", len(stub.calls))
+	}
+
+	stub.calls = nil
+	_, err = c.QueryExemplars(context.Background(), `metric_a`, time.Unix(0, 0), time.Unix(1, 0))
+	if err != nil {
+		t.Fatalf("QueryExemplars: %v", err)
+	}
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected 1 downstream call, got %d", len(stub.calls))
+	}
+}
+
+func TestErrorWrap_QueryExemplarsWrapsError(t *testing.T) {
+	stub := &errorAPI{API: &stubAPI{}, err: fmt.Errorf("inner")}
+	w := &ErrorWrap{A: stub, Msg: "outer"}
+	_, err := w.QueryExemplars(context.Background(), `foo`, time.Unix(0, 0), time.Unix(1, 0))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got != "outer: inner" {
+		t.Fatalf("error message: want %q got %q", "outer: inner", got)
+	}
+}

--- a/pkg/promclient/ignore_error.go
+++ b/pkg/promclient/ignore_error.go
@@ -67,3 +67,9 @@ func (n *IgnoreErrorAPI) Metadata(ctx context.Context, metric, limit string) (ma
 	v, _ := n.A.Metadata(ctx, metric, limit)
 	return v, nil
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (n *IgnoreErrorAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	v, _ := n.A.QueryExemplars(ctx, query, startTime, endTime)
+	return v, nil
+}

--- a/pkg/promclient/inject_matchers_test.go
+++ b/pkg/promclient/inject_matchers_test.go
@@ -54,6 +54,11 @@ func (a *recordingAPI) Metadata(ctx context.Context, metric, limit string) (map[
 	return nil, nil
 }
 
+func (a *recordingAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	a.query = query
+	return nil, nil
+}
+
 // mustMatchers parses a comma-separated set of bare matchers into label matchers.
 func mustMatchers(t *testing.T, s string) []*labels.Matcher {
 	t.Helper()

--- a/pkg/promclient/interface.go
+++ b/pkg/promclient/interface.go
@@ -26,6 +26,8 @@ type API interface {
 	GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) storage.SeriesSet
 	// Metadata returns metadata about metrics currently scraped by the metric name.
 	Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error)
+	// QueryExemplars performs a query for exemplars by the given query and time range.
+	QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error)
 }
 
 // APILabels includes a Key() mechanism to differentiate which APIs are "the same"

--- a/pkg/promclient/label.go
+++ b/pkg/promclient/label.go
@@ -247,3 +247,41 @@ func (c *AddLabelClient) GetValue(ctx context.Context, start, end time.Time, mat
 	}
 	return MapLabelsSeriesSet(c.API.GetValue(ctx, start, end, filteredMatchers), c.addLabels)
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+// Skips the downstream call when every selector in the query is incompatible
+// with this server-group's labels (mirrors the GetValue / Series matcher
+// filtering — without it we'd send a guaranteed-empty query for every
+// `metric{az="other"}` lookup). Tags each surviving result's SeriesLabels
+// with the server-group's labels so callers can attribute exemplars.
+func (c *AddLabelClient) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	expr, err := parser.ParseExpr(query)
+	if err == nil {
+		selectors := parser.ExtractSelectors(expr)
+		if len(selectors) > 0 {
+			anyMatch := false
+			for _, ms := range selectors {
+				if _, ok := FilterMatchers(c.Labels, ms); ok {
+					anyMatch = true
+					break
+				}
+			}
+			if !anyMatch {
+				return nil, nil
+			}
+		}
+	}
+	v, err := c.API.QueryExemplars(ctx, query, startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+	for i := range v {
+		if v[i].SeriesLabels == nil {
+			v[i].SeriesLabels = model.LabelSet{}
+		}
+		for k, lv := range c.Labels {
+			v[i].SeriesLabels[k] = lv
+		}
+	}
+	return v, nil
+}

--- a/pkg/promclient/label_test.go
+++ b/pkg/promclient/label_test.go
@@ -191,6 +191,11 @@ func (a *labelStubAPI) GetValue(ctx context.Context, start, end time.Time, match
 func (a *labelStubAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (a *labelStubAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	return nil, fmt.Errorf("not implemented")
+}
 func TestAddLabelClient(t *testing.T) {
 
 	stub := &labelStubAPI{

--- a/pkg/promclient/labelfilter.go
+++ b/pkg/promclient/labelfilter.go
@@ -274,6 +274,40 @@ func (c *LabelFilterClient) Metadata(ctx context.Context, metric, limit string) 
 	return c.API.Metadata(ctx, metric, limit)
 }
 
+// QueryExemplars performs a query for exemplars by the given query and time range.
+// Mirrors the matcher-filter logic used by Series / GetValue: parse the
+// query, extract every vector selector, and skip the downstream call when
+// every selector references labels this server-group can't satisfy. A
+// query that mixes a satisfiable selector with a non-satisfiable one is
+// still forwarded (we can't easily rewrite a PromQL string) — the
+// non-satisfiable side just returns no exemplars.
+func (c *LabelFilterClient) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	expr, err := parser.ParseExpr(query)
+	if err != nil {
+		// Parse error: let the downstream return the canonical error rather
+		// than swallowing it here.
+		return c.API.QueryExemplars(ctx, query, startTime, endTime)
+	}
+	selectors := parser.ExtractSelectors(expr)
+	if len(selectors) == 0 {
+		return c.API.QueryExemplars(ctx, query, startTime, endTime)
+	}
+	for _, ms := range selectors {
+		ok := true
+		for _, matcher := range ms {
+			if !FilterLabelMatchers(c.LabelFilter(), matcher) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return c.API.QueryExemplars(ctx, query, startTime, endTime)
+		}
+	}
+	filteredCount.WithLabelValues("QueryExemplars").Inc()
+	return nil, nil
+}
+
 func NewFilterLabelVisitor(filter map[string]map[string]struct{}) *FilterLabelVisitor {
 	return &FilterLabelVisitor{
 		labelFilter: filter,

--- a/pkg/promclient/labelfilter_test.go
+++ b/pkg/promclient/labelfilter_test.go
@@ -75,6 +75,12 @@ func (s *countAPI) Metadata(ctx context.Context, metric, limit string) (map[stri
 	return s.API.Metadata(ctx, metric, limit)
 }
 
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (s *countAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	s.callCount["QueryExemplars"]++
+	return s.API.QueryExemplars(ctx, query, startTime, endTime)
+}
+
 func TestLabelFilter(t *testing.T) {
 	/*
 

--- a/pkg/promclient/metric_relabel.go
+++ b/pkg/promclient/metric_relabel.go
@@ -324,6 +324,39 @@ func (c *MetricsRelabelClient) GetValue(ctx context.Context, start, end time.Tim
 	return MapLabelsSeriesSet(c.API.GetValue(ctx, start, end, newMatchers), c.relabelLabels)
 }
 
+// QueryExemplars performs a query for exemplars by the given query and time range.
+// We pass the query through unmodified — rewriting selectors inside an arbitrary
+// PromQL expression is non-trivial — and apply the configured relabel rules to
+// each result's SeriesLabels so caller-side labels match the rewritten metric
+// names.
+func (c *MetricsRelabelClient) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	v, err := c.API.QueryExemplars(ctx, query, startTime, endTime)
+	if err != nil {
+		return nil, err
+	}
+	if len(c.RelabelConfigs) == 0 {
+		return v, nil
+	}
+	out := v[:0]
+	for _, qr := range v {
+		labelStrings := make([]string, 0, len(qr.SeriesLabels)*2)
+		for k, lv := range qr.SeriesLabels {
+			labelStrings = append(labelStrings, string(k), string(lv))
+		}
+		lbls, keep := relabel.Process(labels.FromStrings(labelStrings...), c.RelabelConfigs...)
+		if !keep {
+			continue
+		}
+		ns := model.LabelSet{}
+		lbls.Range(func(lbl labels.Label) {
+			ns[model.LabelName(lbl.Name)] = model.LabelValue(lbl.Value)
+		})
+		qr.SeriesLabels = ns
+		out = append(out, qr)
+	}
+	return out, nil
+}
+
 func NewMetricsRelabelVisitor(m []*MetricRelabelConfig, r []*relabel.Config) *MetricsRelabelVisitor {
 	return &MetricsRelabelVisitor{
 		MetricsRelabelConfigs: m,

--- a/pkg/promclient/multi_api.go
+++ b/pkg/promclient/multi_api.go
@@ -515,3 +515,86 @@ func (m *MultiAPI) Metadata(ctx context.Context, metric, limit string) (map[stri
 
 	return result, nil
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+// We fan the query out to every server-group and concatenate the per-series
+// exemplar lists, deduplicating by series labels (sum-style merge — the union of
+// exemplars from all server-groups for the same series).
+func (m *MultiAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	childContext, childContextCancel := context.WithCancel(ctx)
+	defer childContextCancel()
+
+	type chanResult struct {
+		v   []v1.ExemplarQueryResult
+		err error
+		ls  model.Fingerprint
+	}
+
+	resultChans := make([]chan chanResult, len(m.apis))
+	outstandingRequests := make(map[model.Fingerprint]int)
+
+	for i, api := range m.apis {
+		resultChans[i] = make(chan chanResult, 1)
+		outstandingRequests[m.apiFingerprints[i]]++
+		go func(i int, retChan chan chanResult, api API) {
+			start := time.Now()
+			result, err := api.QueryExemplars(childContext, query, startTime, endTime)
+			took := time.Since(start)
+			if err != nil {
+				m.recordMetric(i, "query_exemplars", "error", took.Seconds())
+			} else {
+				m.recordMetric(i, "query_exemplars", "success", took.Seconds())
+			}
+			retChan <- chanResult{
+				v:   result,
+				err: NormalizePromError(err),
+				ls:  m.apiFingerprints[i],
+			}
+		}(i, resultChans[i], api)
+	}
+
+	// Wait for results, merging by series labels.
+	merged := map[model.Fingerprint]*v1.ExemplarQueryResult{}
+	var lastError error
+	successMap := make(map[model.Fingerprint]int)
+	for i := 0; i < len(m.apis); i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+
+		case ret := <-resultChans[i]:
+			outstandingRequests[ret.ls]--
+			if ret.err != nil {
+				if (outstandingRequests[ret.ls] + successMap[ret.ls]) < m.requiredCount {
+					return nil, ret.err
+				}
+				lastError = ret.err
+				continue
+			}
+			successMap[ret.ls]++
+			for j := range ret.v {
+				qr := ret.v[j]
+				fp := qr.SeriesLabels.Fingerprint()
+				existing, ok := merged[fp]
+				if !ok {
+					cp := qr
+					merged[fp] = &cp
+					continue
+				}
+				existing.Exemplars = append(existing.Exemplars, qr.Exemplars...)
+			}
+		}
+	}
+
+	for k := range outstandingRequests {
+		if successMap[k] < m.requiredCount {
+			return nil, errors.Wrap(lastError, "Unable to fetch from downstream servers")
+		}
+	}
+
+	out := make([]v1.ExemplarQueryResult, 0, len(merged))
+	for _, qr := range merged {
+		out = append(out, *qr)
+	}
+	return out, nil
+}

--- a/pkg/promclient/multi_api_test.go
+++ b/pkg/promclient/multi_api_test.go
@@ -18,13 +18,14 @@ import (
 )
 
 type stubAPI struct {
-	labelNames  func() []string
-	labelValues func(label string) model.LabelValues
-	query       func() model.Value
-	queryRange  func(q string, r v1.Range) model.Value
-	series      func() []model.LabelSet
-	getValue    func() model.Value
-	metadata    func() map[string][]v1.Metadata
+	labelNames     func() []string
+	labelValues    func(label string) model.LabelValues
+	query          func() model.Value
+	queryRange     func(q string, r v1.Range) model.Value
+	series         func() []model.LabelSet
+	getValue       func() model.Value
+	metadata       func() map[string][]v1.Metadata
+	queryExemplars func() []v1.ExemplarQueryResult
 }
 
 // LabelNames returns all the unique label names present in the block in sorted order.
@@ -81,6 +82,14 @@ func (s *stubAPI) Metadata(ctx context.Context, metric, limit string) (map[strin
 		return nil, nil
 	}
 	return s.metadata(), nil
+}
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (s *stubAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	if s.queryExemplars == nil {
+		return nil, nil
+	}
+	return s.queryExemplars(), nil
 }
 
 type errorAPI struct {
@@ -140,6 +149,14 @@ func (s *errorAPI) GetValue(ctx context.Context, start, end time.Time, matchers 
 		return storage.ErrSeriesSet(s.err)
 	}
 	return s.GetValue(ctx, start, end, matchers)
+}
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (s *errorAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.QueryExemplars(ctx, query, startTime, endTime)
 }
 
 func TestMultiAPIMerging(t *testing.T) {
@@ -576,4 +593,101 @@ func valueDataStrings(v model.Value) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func TestMultiAPIQueryExemplarsMerging(t *testing.T) {
+	mkResult := func(series model.LabelSet, traceID string, val float64, ts int64) v1.ExemplarQueryResult {
+		return v1.ExemplarQueryResult{
+			SeriesLabels: series,
+			Exemplars: []v1.Exemplar{
+				{Labels: model.LabelSet{"trace_id": model.LabelValue(traceID)}, Value: model.SampleValue(val), Timestamp: model.Time(ts)},
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		api           API
+		wantSeries    int // unique series in merged result
+		wantExemplars int // total exemplars across all series
+		wantErr       bool
+	}{
+		{
+			// Two server-groups, both returning the SAME series label set
+			// — exemplar lists must concatenate onto a single output entry.
+			name: "merge same series across groups",
+			api: NewMustMultiAPI([]API{
+				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
+					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "foo"}, "a", 1, 100)}
+				}},
+				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
+					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "foo"}, "b", 2, 200)}
+				}},
+			}, model.Time(0), nil, 1, false),
+			wantSeries:    1,
+			wantExemplars: 2,
+		},
+		{
+			// Different series in each group — both must appear.
+			name: "different series across groups",
+			api: NewMustMultiAPI([]API{
+				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
+					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "foo"}, "a", 1, 100)}
+				}},
+				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
+					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "bar"}, "b", 2, 200)}
+				}},
+			}, model.Time(0), nil, 1, false),
+			wantSeries:    2,
+			wantExemplars: 2,
+		},
+		{
+			// requiredCount=1, one error / one success → quorum met → success.
+			name: "tolerates one error when requiredCount=1",
+			api: NewMustMultiAPI([]API{
+				&errorAPI{API: &stubAPI{}, err: fmt.Errorf("boom")},
+				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
+					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "foo"}, "a", 1, 100)}
+				}},
+			}, model.Time(0), nil, 1, false),
+			wantSeries:    1,
+			wantExemplars: 1,
+		},
+		{
+			// requiredCount=2, only one stub is healthy → quorum fails.
+			name: "errors when quorum unmet",
+			api: NewMustMultiAPI([]API{
+				&errorAPI{API: &stubAPI{}, err: fmt.Errorf("boom")},
+				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
+					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "foo"}, "a", 1, 100)}
+				}},
+			}, model.Time(0), nil, 2, false),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.api.QueryExemplars(context.Background(), `foo`, time.Unix(0, 0), time.Unix(1, 0))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %d series", len(got))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tc.wantSeries {
+				t.Fatalf("series count: want=%d got=%d (%+v)", tc.wantSeries, len(got), got)
+			}
+			total := 0
+			for _, qr := range got {
+				total += len(qr.Exemplars)
+			}
+			if total != tc.wantExemplars {
+				t.Fatalf("exemplar count: want=%d got=%d (%+v)", tc.wantExemplars, total, got)
+			}
+		})
+	}
 }

--- a/pkg/promclient/recover.go
+++ b/pkg/promclient/recover.go
@@ -83,3 +83,13 @@ func (api *recoverAPI) Metadata(ctx context.Context, metric, limit string) (v ma
 	}()
 	return api.A.Metadata(ctx, metric, limit)
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (api *recoverAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) (v []v1.ExemplarQueryResult, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	return api.A.QueryExemplars(ctx, query, startTime, endTime)
+}

--- a/pkg/promclient/time_truncate.go
+++ b/pkg/promclient/time_truncate.go
@@ -48,3 +48,8 @@ func (t *TimeTruncate) Series(ctx context.Context, matches []string, startTime t
 func (t *TimeTruncate) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) storage.SeriesSet {
 	return t.API.GetValue(ctx, start.Truncate(truncateDuration), end.Truncate(truncateDuration), matchers)
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (t *TimeTruncate) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	return t.API.QueryExemplars(ctx, query, startTime.Truncate(truncateDuration), endTime.Truncate(truncateDuration))
+}

--- a/pkg/promclient/timefilter.go
+++ b/pkg/promclient/timefilter.go
@@ -121,6 +121,24 @@ func (tf *AbsoluteTimeFilter) GetValue(ctx context.Context, start, end time.Time
 	return tf.API.GetValue(ctx, start, end, matchers)
 }
 
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (tf *AbsoluteTimeFilter) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	if (!tf.Start.IsZero() && endTime.Before(tf.Start)) || (!tf.End.IsZero() && startTime.After(tf.End)) {
+		return nil, nil
+	}
+
+	if tf.Truncate {
+		if !tf.Start.IsZero() && startTime.Before(tf.Start) {
+			startTime = tf.Start
+		}
+		if !tf.End.IsZero() && endTime.After(tf.End) {
+			endTime = tf.End
+		}
+	}
+
+	return tf.API.QueryExemplars(ctx, query, startTime, endTime)
+}
+
 // RelativeTimeFilter will filter queries out (return nil,nil) for all queries outside the given durations relative to time.Now()
 type RelativeTimeFilter struct {
 	API
@@ -250,4 +268,23 @@ func (tf *RelativeTimeFilter) GetValue(ctx context.Context, start, end time.Time
 	}
 
 	return tf.API.GetValue(ctx, start, end, matchers)
+}
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (tf *RelativeTimeFilter) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	tfStart, tfEnd := tf.window()
+	if (!tfStart.IsZero() && endTime.Before(tfStart)) || (!tfEnd.IsZero() && startTime.After(tfEnd)) {
+		return nil, nil
+	}
+
+	if tf.Truncate {
+		if !tfStart.IsZero() && startTime.Before(tfStart) {
+			startTime = tfStart
+		}
+		if !tfEnd.IsZero() && endTime.Before(tfEnd) {
+			endTime = tfEnd
+		}
+	}
+
+	return tf.API.QueryExemplars(ctx, query, startTime, endTime)
 }

--- a/pkg/proxystorage/exemplar_querier.go
+++ b/pkg/proxystorage/exemplar_querier.go
@@ -1,0 +1,88 @@
+package proxystorage
+
+import (
+	"context"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/jacksontj/promxy/pkg/promclient"
+	"github.com/jacksontj/promxy/pkg/promhttputil"
+)
+
+// proxyExemplarQuerier implements storage.ExemplarQuerier on top of
+// promxy's promclient.API. The upstream queryExemplars HTTP handler parses
+// the `query` form param, extracts every vector selector via
+// parser.ExtractSelectors, and hands the resulting matcher sets to us as
+// the variadic argument to Select. We turn each matcher set back into a
+// PromQL selector string and submit it to the downstream's
+// /api/v1/query_exemplars endpoint, then convert the v1 response shape
+// into the storage layer's exemplar.QueryResult slice.
+type proxyExemplarQuerier struct {
+	ctx    context.Context
+	client promclient.API
+}
+
+func (q *proxyExemplarQuerier) Select(start, end int64, matchers ...[]*labels.Matcher) ([]exemplar.QueryResult, error) {
+	startT := timestamp.Time(start)
+	endT := timestamp.Time(end)
+
+	// Merge per-selector results by series labels: a query can extract
+	// multiple selectors that match the same series, and we'd otherwise
+	// emit duplicates that grafana then has to dedup itself.
+	merged := map[uint64]*exemplar.QueryResult{}
+	for _, ms := range matchers {
+		query, err := promhttputil.MatcherToString(ms)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := q.client.QueryExemplars(q.ctx, query, startT, endT)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range v {
+			lbls := labelSetToLabels(r.SeriesLabels)
+			fp := lbls.Hash()
+			existing, ok := merged[fp]
+			if !ok {
+				existing = &exemplar.QueryResult{SeriesLabels: lbls}
+				merged[fp] = existing
+			}
+			for _, ex := range r.Exemplars {
+				existing.Exemplars = append(existing.Exemplars, exemplar.Exemplar{
+					Labels: labelSetToLabels(ex.Labels),
+					Value:  float64(ex.Value),
+					Ts:     int64(ex.Timestamp),
+					HasTs:  true,
+				})
+			}
+		}
+	}
+
+	out := make([]exemplar.QueryResult, 0, len(merged))
+	for _, r := range merged {
+		out = append(out, *r)
+	}
+	return out, nil
+}
+
+func labelSetToLabels(ls model.LabelSet) labels.Labels {
+	b := labels.NewScratchBuilder(len(ls))
+	for k, v := range ls {
+		b.Add(string(k), string(v))
+	}
+	b.Sort()
+	return b.Labels()
+}
+
+// ExemplarQuerier returns a new ExemplarQuerier on the storage.
+func (p *ProxyStorage) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
+	return &proxyExemplarQuerier{
+		ctx:    ctx,
+		client: p.GetState().client,
+	}, nil
+}

--- a/pkg/proxystorage/exemplar_querier_test.go
+++ b/pkg/proxystorage/exemplar_querier_test.go
@@ -1,0 +1,148 @@
+package proxystorage
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type exemplarStubAPI struct {
+	stubAPI
+	calls []exemplarCall
+	resps map[string][]v1.ExemplarQueryResult
+}
+
+type exemplarCall struct {
+	query string
+	start time.Time
+	end   time.Time
+}
+
+func (a *exemplarStubAPI) QueryExemplars(_ context.Context, query string, start, end time.Time) ([]v1.ExemplarQueryResult, error) {
+	a.calls = append(a.calls, exemplarCall{query, start, end})
+	return a.resps[query], nil
+}
+
+func TestProxyExemplarQuerier_Select(t *testing.T) {
+	api := &exemplarStubAPI{
+		resps: map[string][]v1.ExemplarQueryResult{
+			`{__name__="foo",job="api"}`: {
+				{
+					SeriesLabels: model.LabelSet{"__name__": "foo", "job": "api"},
+					Exemplars: []v1.Exemplar{
+						{Labels: model.LabelSet{"trace_id": "abc"}, Value: 1.5, Timestamp: 1500},
+					},
+				},
+			},
+			`{__name__="bar"}`: {
+				{
+					SeriesLabels: model.LabelSet{"__name__": "bar"},
+					Exemplars: []v1.Exemplar{
+						{Labels: model.LabelSet{"trace_id": "xyz"}, Value: 0.25, Timestamp: 2000},
+					},
+				},
+			},
+		},
+	}
+
+	q := &proxyExemplarQuerier{ctx: context.Background(), client: api}
+
+	fooMatchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "__name__", "foo"),
+		labels.MustNewMatcher(labels.MatchEqual, "job", "api"),
+	}
+	barMatchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "__name__", "bar"),
+	}
+
+	got, err := q.Select(1000, 3000, fooMatchers, barMatchers)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	sort.Slice(got, func(i, j int) bool { return got[i].SeriesLabels.Get("__name__") < got[j].SeriesLabels.Get("__name__") })
+
+	want := []exemplar.QueryResult{
+		{
+			SeriesLabels: labels.FromStrings("__name__", "bar"),
+			Exemplars: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("trace_id", "xyz"), Value: 0.25, Ts: 2000, HasTs: true},
+			},
+		},
+		{
+			SeriesLabels: labels.FromStrings("__name__", "foo", "job", "api"),
+			Exemplars: []exemplar.Exemplar{
+				{Labels: labels.FromStrings("trace_id", "abc"), Value: 1.5, Ts: 1500, HasTs: true},
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("result mismatch\nwant: %#v\ngot:  %#v", want, got)
+	}
+
+	// Each selector becomes one downstream query; time params come from Select.
+	if len(api.calls) != 2 {
+		t.Fatalf("want 2 downstream calls, got %d (%+v)", len(api.calls), api.calls)
+	}
+	for _, c := range api.calls {
+		if c.start.UnixMilli() != 1000 || c.end.UnixMilli() != 3000 {
+			t.Errorf("unexpected time params: %+v", c)
+		}
+	}
+}
+
+func TestProxyExemplarQuerier_DeduplicatesAcrossSelectors(t *testing.T) {
+	// Same series labels returned for two different selectors — exemplars
+	// from both calls should land on the single output series, not two
+	// separate ones with duplicate metadata.
+	dup := v1.ExemplarQueryResult{
+		SeriesLabels: model.LabelSet{"__name__": "foo"},
+	}
+	api := &exemplarStubAPI{
+		resps: map[string][]v1.ExemplarQueryResult{
+			`{__name__="foo",job="a"}`: {
+				func() v1.ExemplarQueryResult {
+					r := dup
+					r.Exemplars = []v1.Exemplar{{Value: 1, Timestamp: 100}}
+					r.SeriesLabels = model.LabelSet{"__name__": "foo"}
+					return r
+				}(),
+			},
+			`{__name__="foo",job="b"}`: {
+				func() v1.ExemplarQueryResult {
+					r := dup
+					r.Exemplars = []v1.Exemplar{{Value: 2, Timestamp: 200}}
+					r.SeriesLabels = model.LabelSet{"__name__": "foo"}
+					return r
+				}(),
+			},
+		},
+	}
+
+	q := &proxyExemplarQuerier{ctx: context.Background(), client: api}
+	got, err := q.Select(0, 1000,
+		[]*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, "__name__", "foo"),
+			labels.MustNewMatcher(labels.MatchEqual, "job", "a"),
+		},
+		[]*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, "__name__", "foo"),
+			labels.MustNewMatcher(labels.MatchEqual, "job", "b"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 merged series, got %d", len(got))
+	}
+	if len(got[0].Exemplars) != 2 {
+		t.Fatalf("want 2 exemplars on the merged series, got %d", len(got[0].Exemplars))
+	}
+}

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -359,11 +359,6 @@ func (p *ProxyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, err
 	return nil, errors.New("not implemented")
 }
 
-// ExemplarQuerier returns a new ExemplarQuerier on the storage.
-func (p *ProxyStorage) ExemplarQuerier(ctx context.Context) (storage.ExemplarQuerier, error) {
-	return nil, errors.New("not implemented")
-}
-
 // Implement web.LocalStorage
 func (p *ProxyStorage) CleanTombstones() (err error) { return nil }
 func (p *ProxyStorage) Delete(_ context.Context, mint, maxt int64, ms ...*labels.Matcher) error {

--- a/pkg/proxystorage/proxy_test.go
+++ b/pkg/proxystorage/proxy_test.go
@@ -74,6 +74,11 @@ func (a *stubAPI) Metadata(ctx context.Context, metric, limit string) (map[strin
 	return nil, nil
 }
 
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (a *stubAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	return nil, nil
+}
+
 func TestNodeReplacer(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -542,3 +542,8 @@ func (s *ServerGroup) Series(ctx context.Context, matches []string, startTime, e
 func (s *ServerGroup) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
 	return s.State().apiClient.Metadata(ctx, metric, limit)
 }
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (s *ServerGroup) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	return s.State().apiClient.QueryExemplars(ctx, query, startTime, endTime)
+}

--- a/test/exemplar_test.go
+++ b/test/exemplar_test.go
@@ -1,0 +1,248 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sort"
+	"testing"
+	"time"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/prometheus/common/route"
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/util/teststorage"
+	v1 "github.com/prometheus/prometheus/web/api/v1"
+
+	proxyconfig "github.com/jacksontj/promxy/pkg/config"
+	"github.com/jacksontj/promxy/pkg/proxystorage"
+)
+
+// startAPIWithExemplars boots a real prometheus v1 API server backed by a
+// real test storage that supports exemplars. Returns the bound addr so the
+// caller can wire it into a promxy server-group config; the test storage
+// is also returned so the caller can ingest series + exemplars before
+// hitting the API.
+func startAPIWithExemplars(t *testing.T) (*teststorage.TestStorage, string, func()) {
+	t.Helper()
+
+	stor := teststorage.New(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	cfgFunc := func() config.Config { return config.DefaultConfig }
+	readyFunc := func(f http.HandlerFunc) http.HandlerFunc { return f }
+
+	api := v1.NewAPI(
+		promql.NewEngine(promql.EngineOpts{
+			Timeout:                  10 * time.Minute,
+			MaxSamples:               50000000,
+			NoStepSubqueryIntervalFn: func(int64) int64 { return (1 * time.Minute).Milliseconds() },
+		}),
+		stor,
+		nil,
+		stor.ExemplarQueryable(),
+		nil, nil, nil,
+		cfgFunc,
+		nil,
+		v1.GlobalURLOptions{ListenAddress: addr, Host: "localhost", Scheme: "http"},
+		readyFunc,
+		nil, "", false,
+		nil, nil,
+		50000000, 1000, 1048576,
+		false,
+		nil, nil, nil, nil, nil, nil, nil, nil,
+		false, nil,
+		false, false, false, false,
+	)
+
+	apiRouter := route.New()
+	api.Register(apiRouter.WithPrefix("/api/v1"))
+
+	srv := &http.Server{Handler: apiRouter}
+	stopCh := make(chan struct{})
+	go func() {
+		defer close(stopCh)
+		_ = srv.Serve(ln)
+	}()
+
+	stop := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+		<-stopCh
+		_ = stor.Close()
+	}
+	return stor, addr, stop
+}
+
+func ingestExemplar(t *testing.T, stor *teststorage.TestStorage, lset labels.Labels, value float64, ts int64, exLabels labels.Labels, exValue float64, exTs int64) {
+	t.Helper()
+	app := stor.Appender(context.Background())
+	if _, err := app.Append(0, lset, ts, value); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := app.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	// teststorage builds its TSDB with EnableExemplarStorage=false by
+	// default, so the head appender silently drops exemplars. Append
+	// directly to the side-channel exemplar storage instead — the
+	// ExemplarQueryable returned by teststorage reads from it.
+	if _, err := stor.AppendExemplar(0, lset, exemplar.Exemplar{Labels: exLabels, Value: exValue, Ts: exTs, HasTs: true}); err != nil {
+		t.Fatalf("AppendExemplar: %v", err)
+	}
+}
+
+// TestExemplarsEndToEnd ingests series + exemplars into a real test storage
+// fronted by a real Prometheus v1 API server, configures promxy to point at
+// it, and verifies promxy.ProxyStorage.ExemplarQuerier (which the
+// /api/v1/query_exemplars HTTP handler uses) round-trips the data.
+func TestExemplarsEndToEnd(t *testing.T) {
+	stor, addr, stop := startAPIWithExemplars(t)
+	defer stop()
+
+	now := time.Now().Unix() * 1000
+	ingestExemplar(t,
+		stor,
+		labels.FromStrings(labels.MetricName, "http_requests_total", "job", "api", "code", "200"),
+		1, now,
+		labels.FromStrings("trace_id", "abc"), 1.5, now,
+	)
+	ingestExemplar(t,
+		stor,
+		labels.FromStrings(labels.MetricName, "http_requests_total", "job", "api", "code", "500"),
+		1, now,
+		labels.FromStrings("trace_id", "xyz"), 0.25, now,
+	)
+
+	psConfig := &proxyconfig.Config{}
+	if err := yaml.Unmarshal([]byte(fmt.Sprintf(`
+promxy:
+  http_client:
+    tls_config:
+      insecure_skip_verify: true
+  server_groups:
+    - static_configs:
+        - targets:
+          - %s
+`, addr)), &psConfig); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+
+	ps, err := proxystorage.NewProxyStorage(func(int64) int64 { return 60000 }, "")
+	if err != nil {
+		t.Fatalf("NewProxyStorage: %v", err)
+	}
+	if err := ps.ApplyConfig(psConfig); err != nil {
+		t.Fatalf("ApplyConfig: %v", err)
+	}
+
+	eq, err := ps.ExemplarQuerier(context.Background())
+	if err != nil {
+		t.Fatalf("ExemplarQuerier: %v", err)
+	}
+
+	t.Run("specific selector hits one series", func(t *testing.T) {
+		got, err := eq.Select(now-5000, now+5000, []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "http_requests_total"),
+			labels.MustNewMatcher(labels.MatchEqual, "code", "200"),
+		})
+		if err != nil {
+			t.Fatalf("Select: %v", err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("want 1 series, got %d (%+v)", len(got), got)
+		}
+		if got[0].SeriesLabels.Get("code") != "200" {
+			t.Fatalf("wrong series: %v", got[0].SeriesLabels)
+		}
+		if len(got[0].Exemplars) != 1 || got[0].Exemplars[0].Labels.Get("trace_id") != "abc" {
+			t.Fatalf("wrong exemplar: %+v", got[0].Exemplars)
+		}
+	})
+
+	t.Run("regex selector hits both series", func(t *testing.T) {
+		got, err := eq.Select(now-5000, now+5000, []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "http_requests_total"),
+			labels.MustNewMatcher(labels.MatchRegexp, "code", "200|500"),
+		})
+		if err != nil {
+			t.Fatalf("Select: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("want 2 series, got %d (%+v)", len(got), got)
+		}
+		sort.Slice(got, func(i, j int) bool { return got[i].SeriesLabels.Get("code") < got[j].SeriesLabels.Get("code") })
+		traces := []string{
+			got[0].Exemplars[0].Labels.Get("trace_id"),
+			got[1].Exemplars[0].Labels.Get("trace_id"),
+		}
+		want := []string{"abc", "xyz"}
+		if traces[0] != want[0] || traces[1] != want[1] {
+			t.Fatalf("trace mismatch: want %v got %v", want, traces)
+		}
+	})
+
+	t.Run("multiple selectors merge to deduplicated series", func(t *testing.T) {
+		// Both selectors target the same series — Select should emit one
+		// merged result, not two duplicates.
+		got, err := eq.Select(now-5000, now+5000,
+			[]*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "http_requests_total"),
+				labels.MustNewMatcher(labels.MatchEqual, "code", "200"),
+			},
+			[]*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "http_requests_total"),
+				labels.MustNewMatcher(labels.MatchEqual, "job", "api"),
+				labels.MustNewMatcher(labels.MatchEqual, "code", "200"),
+			},
+		)
+		if err != nil {
+			t.Fatalf("Select: %v", err)
+		}
+		count := 0
+		for _, qr := range got {
+			if qr.SeriesLabels.Get("code") == "200" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("expected 1 merged code=200 series, got %d (%+v)", count, got)
+		}
+	})
+
+	// Sanity: the underlying storage really has both exemplars, so any
+	// failure above is in promxy's path, not the data.
+	if got := exemplarCount(t, stor); got != 2 {
+		t.Fatalf("test storage should hold 2 exemplars, got %d", got)
+	}
+}
+
+func exemplarCount(t *testing.T, stor *teststorage.TestStorage) int {
+	t.Helper()
+	q, err := stor.ExemplarQueryable().ExemplarQuerier(context.Background())
+	if err != nil {
+		t.Fatalf("ExemplarQuerier: %v", err)
+	}
+	res, err := q.Select(0, time.Now().Unix()*1000+10000,
+		[]*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "http_requests_total")},
+	)
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	n := 0
+	for _, r := range res {
+		n += len(r.Exemplars)
+	}
+	return n
+}


### PR DESCRIPTION
## Summary

Closes #420.

`ProxyStorage.ExemplarQuerier` was a stub returning `not implemented`, which surfaced as a 404 (or, with access logs enabled, an upstream-side panic from `web/api/v1/api.go`'s `queryExemplars` handler dereferencing a nil queryable wrapper). Wire `/api/v1/query_exemplars` through the existing fan-out pipeline.

- **`promclient.API` interface**: add `QueryExemplars(ctx, query, start, end) ([]v1.ExemplarQueryResult, error)`. Every wrapper gets the method (`PromAPIV1`, `MultiAPI`, `DebugAPI`, `ErrorWrap`, `recoverAPI`, `TimeTruncate`, `AbsoluteTimeFilter`, `RelativeTimeFilter`, `LabelFilter`, `AddLabelClient`, `MetricsRelabelClient`, `IgnoreErrorAPI`, `DowngradeErrorAPI`, `EngineAPI`, `ServerGroup`, plus the test-side stubs).
- **`MultiAPI`**: fans the call out across server-groups in parallel, with the same `requiredCount` quorum behavior as the other operations. Per-series merge: results from different server-groups that share a `SeriesLabels` fingerprint get their exemplar lists concatenated, so a series visible in N server-groups returns the union of its exemplars rather than N duplicate entries. Records a `query_exemplars` latency metric per server-group, same shape as the existing `query` / `query_range` instrumentation.
- **`AddLabelClient`**: tags each result's `SeriesLabels` with the server-group's configured labels — same attribution pattern used elsewhere.
- **`MetricsRelabelClient`**: runs configured relabel rules over each result's `SeriesLabels` and drops series the rules reject.
- **`proxyExemplarQuerier` (new, `pkg/proxystorage/exemplar_querier.go`)**: replaces the stub. The upstream `queryExemplars` HTTP handler parses the `query` form param, extracts every vector selector via `parser.ExtractSelectors`, and hands the matcher sets to `Select(start, end, matchers...)`. We turn each matcher set back into a `{labelset}` PromQL string with `promhttputil.MatcherToString`, call `QueryExemplars`, and dedupe across selectors so a query that extracts the same series via multiple paths emits one merged result.

## Test plan

- [x] `go test ./...` — clean
- [x] `pkg/proxystorage/exemplar_querier_test.go`: covers per-selector → per-query mapping (right query string, right time range), and dedup of series labels across selectors
- [ ] Manual smoke against a real Prometheus + grafana exemplar dashboard — left to a follow-up since I don't have a running env handy

🤖 Generated with [Claude Code](https://claude.com/claude-code)