### PR TITLE
Per-series dynamic anti-affinity for mixed scrape intervals

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -50,6 +50,17 @@ promxy:
       # Best practice for this value is to set it to your scrape interval
       anti_affinity: 10s
 
+      # When true, the merge layer infers each series's anti-affinity buffer
+      # from the inter-sample spacing of the data (half the median gap) and
+      # uses `anti_affinity` only as the fallback when too few samples are
+      # available. Set this when a single server_group hosts metrics scraped
+      # at different intervals (e.g. some jobs at 15s, some at 1m) — a
+      # single static `anti_affinity` is too tight for the slow series (gaps
+      # look like missed scrapes and get filled, doubling count_over_time)
+      # or too wide for the fast one (legitimate fresh samples get deduped).
+      # See https://github.com/jacksontj/promxy/issues/734.
+      anti_affinity_dynamic: false
+
       # time to wait for a server's response headers after fully writing the request (including its body, if any).
       # This time does not include the time to read the response body.
       timeout: 5s

--- a/pkg/promclient/merge_seriesset.go
+++ b/pkg/promclient/merge_seriesset.go
@@ -138,7 +138,7 @@ func SeriesSetToMatrix(ss storage.SeriesSet) (model.Matrix, error) {
 	return m, ss.Err()
 }
 
-func mergeAntiAffinity(antiAffinity model.Time, preferMax bool) storage.VerticalSeriesMergeFunc {
+func mergeAntiAffinity(antiAffinity model.Time, dynamic bool, preferMax bool) storage.VerticalSeriesMergeFunc {
 	return func(series ...storage.Series) storage.Series {
 		if len(series) == 0 {
 			return nil
@@ -146,7 +146,7 @@ func mergeAntiAffinity(antiAffinity model.Time, preferMax bool) storage.Vertical
 		lbls := series[0].Labels()
 		merged := seriesToSampleStream(series[0])
 		for _, s := range series[1:] {
-			merged, _ = promhttputil.MergeSampleStream(antiAffinity, merged, seriesToSampleStream(s), preferMax)
+			merged, _ = promhttputil.MergeSampleStream(antiAffinity, dynamic, merged, seriesToSampleStream(s), preferMax)
 		}
 		return sampleStreamToSeries(merged, lbls)
 	}
@@ -167,8 +167,10 @@ func sortedSeriesSet(ss storage.SeriesSet) storage.SeriesSet {
 }
 
 // MergeSeriesSets merges HA-member SeriesSets with anti-affinity dedup,
-// preserving promxy's existing merge semantics.
-func MergeSeriesSets(antiAffinity model.Time, preferMax bool, sets ...storage.SeriesSet) storage.SeriesSet {
+// preserving promxy's existing merge semantics. When dynamic is true the
+// anti-affinity buffer is inferred per series from inter-sample spacing (with
+// antiAffinity as the fallback); see promhttputil.MergeSampleStream and #734.
+func MergeSeriesSets(antiAffinity model.Time, dynamic bool, preferMax bool, sets ...storage.SeriesSet) storage.SeriesSet {
 	if len(sets) == 0 {
 		return promapi.NewSeriesSet(nil, annotations.Annotations{}, nil)
 	}
@@ -181,5 +183,5 @@ func MergeSeriesSets(antiAffinity model.Time, preferMax bool, sets ...storage.Se
 	}
 	// limit 0 = unlimited; the merge func applies anti-affinity to same-labeled
 	// series across the sets.
-	return storage.NewMergeSeriesSet(sorted, 0, mergeAntiAffinity(antiAffinity, preferMax))
+	return storage.NewMergeSeriesSet(sorted, 0, mergeAntiAffinity(antiAffinity, dynamic, preferMax))
 }

--- a/pkg/promclient/merge_seriesset_test.go
+++ b/pkg/promclient/merge_seriesset_test.go
@@ -118,13 +118,13 @@ func TestMergeSeriesSetsMatchesMergeValues(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			want, err := promhttputil.MergeValues(tc.antiAffinity, tc.a, tc.b, tc.preferMax)
+			want, err := promhttputil.MergeValues(tc.antiAffinity, false, tc.a, tc.b, tc.preferMax)
 			if err != nil {
 				t.Fatalf("MergeValues: %v", err)
 			}
 			wantDump := dumpMatrix(want.(model.Matrix))
 
-			got := MergeSeriesSets(tc.antiAffinity, tc.preferMax, matrixToSeriesSet(tc.a), matrixToSeriesSet(tc.b))
+			got := MergeSeriesSets(tc.antiAffinity, false, tc.preferMax, matrixToSeriesSet(tc.a), matrixToSeriesSet(tc.b))
 			gotDump := dumpSS(t, got)
 
 			if len(gotDump) != len(wantDump) {
@@ -144,7 +144,7 @@ func TestMergeSeriesSetsMatchesMergeValues(t *testing.T) {
 // preserve its warnings and data unchanged).
 func TestMergeSeriesSetsEdgeCases(t *testing.T) {
 	t.Run("no_sets", func(t *testing.T) {
-		ss := MergeSeriesSets(0, false)
+		ss := MergeSeriesSets(0, false, false)
 		if ss.Next() {
 			t.Fatal("expected empty result")
 		}
@@ -158,7 +158,7 @@ func TestMergeSeriesSetsEdgeCases(t *testing.T) {
 		single := matrixToSeriesSet(model.Matrix{stream("m", 0, 1, 10, 2)})
 		single = WithWarnings(single, warn)
 
-		got := MergeSeriesSets(0, false, single)
+		got := MergeSeriesSets(0, false, false, single)
 		dump := dumpSS(t, got)
 		if len(dump) != 1 {
 			t.Fatalf("expected 1 series, got %d: %v", len(dump), dump)
@@ -224,5 +224,35 @@ func TestMaterializeSeriesSetDecouplesFromSource(t *testing.T) {
 	})
 	if d := dumpSS(t, dead); d[`{__name__="m"}`] != "" {
 		t.Fatalf("expected canceled source to yield no samples, got %v", d)
+	}
+}
+
+// TestMergeSeriesSetsDynamic_FixesMixedScrapeIntervals proves the dynamic
+// anti-affinity flag (#734) actually takes effect through the live SeriesSet
+// merge path — MergeSeriesSets -> mergeAntiAffinity -> MergeSampleStream — and
+// not just the legacy model.Value MergeValues path the promhttputil tests
+// cover. Mirrors promhttputil.TestMergeValues_FixesMixedScrapeIntervals.
+func TestMergeSeriesSetsDynamic_FixesMixedScrapeIntervals(t *testing.T) {
+	// Two 60s-scrape sides of the same series; b is offset so its samples
+	// land inside a's 60s gaps but outside a tight static buffer — exactly
+	// the case the static algorithm misreads as a missed scrape to fill.
+	a := model.Matrix{stream("slow", 0, 1, 60_000, 1, 120_000, 1)}
+	b := model.Matrix{stream("slow", 30_000, 1, 90_000, 1, 150_000, 1)}
+
+	staticBuffer := model.Time(15_000) // 15s — wrong for a 60s scraper
+	const key = `{__name__="slow"}`
+
+	// Static (dynamic=false): each 60s gap exceeds 2*15s so b splices in →
+	// 6 samples. This is the #734 bug, reproduced through the SeriesSet path.
+	static := dumpSS(t, MergeSeriesSets(staticBuffer, false, false, matrixToSeriesSet(a), matrixToSeriesSet(b)))
+	if got := len(strings.Fields(static[key])); got != 6 {
+		t.Fatalf("static path sanity (expect the bug — 6 samples): got %d (%q)", got, static[key])
+	}
+
+	// Dynamic (dynamic=true): the per-series buffer is estimated (~30s) from
+	// the data, so the 60s gaps no longer trigger a fill → a's 3 samples only.
+	dynamic := dumpSS(t, MergeSeriesSets(staticBuffer, true, false, matrixToSeriesSet(a), matrixToSeriesSet(b)))
+	if want := "0=1 60000=1 120000=1 "; dynamic[key] != want {
+		t.Fatalf("dynamic path through MergeSeriesSets: want %q got %q", want, dynamic[key])
 	}
 }

--- a/pkg/promclient/multi_api.go
+++ b/pkg/promclient/multi_api.go
@@ -65,16 +65,21 @@ func NormalizePromError(err error) error {
 type MultiAPIMetricFunc func(i int, api, status string, took float64)
 
 // NewMustMultiAPI returns a MultiAPI
-func NewMustMultiAPI(apis []API, antiAffinity model.Time, metricFunc MultiAPIMetricFunc, requiredCount int, preferMax bool) *MultiAPI {
-	a, err := NewMultiAPI(apis, antiAffinity, metricFunc, requiredCount, preferMax)
+func NewMustMultiAPI(apis []API, antiAffinity model.Time, antiAffinityDynamic bool, metricFunc MultiAPIMetricFunc, requiredCount int, preferMax bool) *MultiAPI {
+	a, err := NewMultiAPI(apis, antiAffinity, antiAffinityDynamic, metricFunc, requiredCount, preferMax)
 	if err != nil {
 		panic(err)
 	}
 	return a
 }
 
-// NewMultiAPI returns a MultiAPI
-func NewMultiAPI(apis []API, antiAffinity model.Time, metricFunc MultiAPIMetricFunc, requiredCount int, preferMax bool) (*MultiAPI, error) {
+// NewMultiAPI returns a MultiAPI. When antiAffinityDynamic is true,
+// MergeSampleStream infers the per-series anti-affinity from the inter-
+// sample spacing of the data, using antiAffinity only as a fallback when
+// too few samples are present to estimate. This lets a single server-
+// group host series with mixed scrape intervals without forcing one
+// global buffer that's wrong for half the metrics. See #734.
+func NewMultiAPI(apis []API, antiAffinity model.Time, antiAffinityDynamic bool, metricFunc MultiAPIMetricFunc, requiredCount int, preferMax bool) (*MultiAPI, error) {
 	fingerprintCounts := make(map[model.Fingerprint]int)
 	apiFingerprints := make([]model.Fingerprint, len(apis))
 	for i, api := range apis {
@@ -95,23 +100,25 @@ func NewMultiAPI(apis []API, antiAffinity model.Time, metricFunc MultiAPIMetricF
 	}
 
 	return &MultiAPI{
-		apis:            apis,
-		apiFingerprints: apiFingerprints,
-		antiAffinity:    antiAffinity,
-		metricFunc:      metricFunc,
-		requiredCount:   requiredCount,
-		preferMax:       preferMax,
+		apis:                apis,
+		apiFingerprints:     apiFingerprints,
+		antiAffinity:        antiAffinity,
+		antiAffinityDynamic: antiAffinityDynamic,
+		metricFunc:          metricFunc,
+		requiredCount:       requiredCount,
+		preferMax:           preferMax,
 	}, nil
 }
 
 // MultiAPI implements the API interface while merging the results from the apis it wraps
 type MultiAPI struct {
-	apis            []API
-	apiFingerprints []model.Fingerprint
-	antiAffinity    model.Time
-	metricFunc      MultiAPIMetricFunc
-	requiredCount   int // number "per key" that we require to respond
-	preferMax       bool
+	apis                []API
+	apiFingerprints     []model.Fingerprint
+	antiAffinity        model.Time
+	antiAffinityDynamic bool
+	metricFunc          MultiAPIMetricFunc
+	requiredCount       int // number "per key" that we require to respond
+	preferMax           bool
 }
 
 func (m *MultiAPI) recordMetric(i int, api, status string, took float64) {
@@ -340,7 +347,7 @@ func (m *MultiAPI) scatterMerge(ctx context.Context, op string, call func(contex
 		}
 	}
 
-	return WithWarnings(MergeSeriesSets(m.antiAffinity, m.preferMax, sets...), warnings)
+	return WithWarnings(MergeSeriesSets(m.antiAffinity, m.antiAffinityDynamic, m.preferMax, sets...), warnings)
 }
 
 func (m *MultiAPI) Query(ctx context.Context, query string, ts time.Time) storage.SeriesSet {

--- a/pkg/promclient/multi_api_test.go
+++ b/pkg/promclient/multi_api_test.go
@@ -230,7 +230,7 @@ func TestMultiAPIMerging(t *testing.T) {
 			a: NewMustMultiAPI([]API{
 				&AddLabelClient{stub, model.LabelSet{"a": "1"}},
 				&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-			}, model.Time(0), nil, 1, false),
+			}, model.Time(0), false, nil, 1, false),
 			labelNames:  []string{"a"},
 			labelValues: []model.LabelValue{"1", "2"},
 			v: model.Vector{
@@ -248,12 +248,12 @@ func TestMultiAPIMerging(t *testing.T) {
 				NewMustMultiAPI([]API{
 					&AddLabelClient{stub, model.LabelSet{"a": "1"}},
 					&AddLabelClient{stub, model.LabelSet{"a": "1"}},
-				}, model.Time(0), nil, 1, false),
+				}, model.Time(0), false, nil, 1, false),
 				NewMustMultiAPI([]API{
 					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
 					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-				}, model.Time(0), nil, 1, false),
-			}, model.Time(0), nil, 2, false),
+				}, model.Time(0), false, nil, 1, false),
+			}, model.Time(0), false, nil, 2, false),
 			labelNames:  []string{"a"},
 			labelValues: []model.LabelValue{"1", "2"},
 			v: model.Vector{
@@ -272,23 +272,23 @@ func TestMultiAPIMerging(t *testing.T) {
 					NewMustMultiAPI([]API{
 						&AddLabelClient{stub, model.LabelSet{"a": "1"}},
 						&AddLabelClient{stub, model.LabelSet{"a": "1"}},
-					}, model.Time(0), nil, 1, false),
+					}, model.Time(0), false, nil, 1, false),
 					NewMustMultiAPI([]API{
 						&AddLabelClient{stub, model.LabelSet{"a": "2"}},
 						&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-					}, model.Time(0), nil, 1, false),
-				}, model.Time(0), nil, 2, false),
+					}, model.Time(0), false, nil, 1, false),
+				}, model.Time(0), false, nil, 2, false),
 				NewMustMultiAPI([]API{
 					NewMustMultiAPI([]API{
 						&AddLabelClient{stub, model.LabelSet{"b": "1"}},
 						&AddLabelClient{stub, model.LabelSet{"b": "1"}},
-					}, model.Time(0), nil, 1, false),
+					}, model.Time(0), false, nil, 1, false),
 					NewMustMultiAPI([]API{
 						&AddLabelClient{stub, model.LabelSet{"b": "2"}},
 						&AddLabelClient{stub, model.LabelSet{"b": "2"}},
-					}, model.Time(0), nil, 1, false),
-				}, model.Time(0), nil, 2, false),
-			}, model.Time(0), nil, 2, false),
+					}, model.Time(0), false, nil, 1, false),
+				}, model.Time(0), false, nil, 2, false),
+			}, model.Time(0), false, nil, 2, false),
 			labelNames:  []string{"a", "b"},
 			labelValues: []model.LabelValue{"1", "2"},
 			v: model.Vector{
@@ -317,12 +317,12 @@ func TestMultiAPIMerging(t *testing.T) {
 				NewMustMultiAPI([]API{
 					&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
 					&AddLabelClient{stub, model.LabelSet{"a": "1"}},
-				}, model.Time(0), nil, 1, false),
+				}, model.Time(0), false, nil, 1, false),
 				NewMustMultiAPI([]API{
 					&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "2"}}, fmt.Errorf("")},
 					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-				}, model.Time(0), nil, 1, false),
-			}, model.Time(0), nil, 2, false),
+				}, model.Time(0), false, nil, 1, false),
+			}, model.Time(0), false, nil, 2, false),
 			labelNames:  []string{"a"},
 			labelValues: []model.LabelValue{"1", "2"},
 			v: model.Vector{
@@ -340,12 +340,12 @@ func TestMultiAPIMerging(t *testing.T) {
 				NewMustMultiAPI([]API{
 					&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
 					&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
-				}, model.Time(0), nil, 1, false),
+				}, model.Time(0), false, nil, 1, false),
 				NewMustMultiAPI([]API{
 					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
 					&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-				}, model.Time(0), nil, 1, false),
-			}, model.Time(0), nil, 2, false),
+				}, model.Time(0), false, nil, 1, false),
+			}, model.Time(0), false, nil, 2, false),
 			err: true,
 		},
 		// if in a multi, all that "match" error, we should error
@@ -353,7 +353,7 @@ func TestMultiAPIMerging(t *testing.T) {
 			a: NewMustMultiAPI([]API{
 				&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
 				&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-			}, model.Time(0), nil, 1, false),
+			}, model.Time(0), false, nil, 1, false),
 			err: true,
 		},
 		// however, in a multi if a single one succeeds for a given "group" then it should pass
@@ -362,7 +362,7 @@ func TestMultiAPIMerging(t *testing.T) {
 				&AddLabelClient{stub, model.LabelSet{"a": "1"}},
 				&errorAPI{&AddLabelClient{stub, model.LabelSet{"a": "1"}}, fmt.Errorf("")},
 				&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-			}, model.Time(0), nil, 1, false),
+			}, model.Time(0), false, nil, 1, false),
 			labelNames:  []string{"a"},
 			labelValues: []model.LabelValue{"1", "2"},
 			v: model.Vector{
@@ -380,7 +380,7 @@ func TestMultiAPIMerging(t *testing.T) {
 				stub,
 				&AddLabelClient{stub, model.LabelSet{"a": "1"}},
 				&AddLabelClient{stub, model.LabelSet{"a": "2"}},
-			}, model.Time(0), nil, 1, false),
+			}, model.Time(0), false, nil, 1, false),
 			labelNames:  []string{"a"},
 			labelValues: []model.LabelValue{"1", "2"},
 			v: model.Vector{
@@ -623,7 +623,7 @@ func TestMultiAPIQueryExemplarsMerging(t *testing.T) {
 				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
 					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "foo"}, "b", 2, 200)}
 				}},
-			}, model.Time(0), nil, 1, false),
+			}, model.Time(0), false, nil, 1, false),
 			wantSeries:    1,
 			wantExemplars: 2,
 		},
@@ -637,7 +637,7 @@ func TestMultiAPIQueryExemplarsMerging(t *testing.T) {
 				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
 					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "bar"}, "b", 2, 200)}
 				}},
-			}, model.Time(0), nil, 1, false),
+			}, model.Time(0), false, nil, 1, false),
 			wantSeries:    2,
 			wantExemplars: 2,
 		},
@@ -649,7 +649,7 @@ func TestMultiAPIQueryExemplarsMerging(t *testing.T) {
 				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
 					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "foo"}, "a", 1, 100)}
 				}},
-			}, model.Time(0), nil, 1, false),
+			}, model.Time(0), false, nil, 1, false),
 			wantSeries:    1,
 			wantExemplars: 1,
 		},
@@ -661,7 +661,7 @@ func TestMultiAPIQueryExemplarsMerging(t *testing.T) {
 				&stubAPI{queryExemplars: func() []v1.ExemplarQueryResult {
 					return []v1.ExemplarQueryResult{mkResult(model.LabelSet{"__name__": "foo"}, "a", 1, 100)}
 				}},
-			}, model.Time(0), nil, 2, false),
+			}, model.Time(0), false, nil, 2, false),
 			wantErr: true,
 		},
 	}

--- a/pkg/promhttputil/merge.go
+++ b/pkg/promhttputil/merge.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -106,8 +107,12 @@ func ValueAddLabelSet(a model.Value, l model.LabelSet) error {
 
 }
 
-// MergeValues merges values `a` and `b` with the given antiAffinityBuffer
-func MergeValues(antiAffinityBuffer model.Time, a, b model.Value, preferMax bool) (model.Value, error) {
+// MergeValues merges values `a` and `b` with the given antiAffinityBuffer.
+// When dynamic is true, each merged SampleStream infers its own anti-
+// affinity from the inter-sample spacing of the longer series and uses
+// antiAffinityBuffer only as a fallback when there isn't enough data to
+// estimate. See #734.
+func MergeValues(antiAffinityBuffer model.Time, dynamic bool, a, b model.Value, preferMax bool) (model.Value, error) {
 	if a == nil {
 		return b, nil
 	}
@@ -198,7 +203,7 @@ func MergeValues(antiAffinityBuffer model.Time, a, b model.Value, preferMax bool
 			// If we've seen this fingerPrint before, lets make sure that a value exists
 			if index, ok := fingerPrintMap[finger]; ok {
 				// TODO: check this error? For now the only one is sig collision, which we check
-				newValue[index], _ = MergeSampleStream(antiAffinityBuffer, newValue[index], stream, preferMax)
+				newValue[index], _ = MergeSampleStream(antiAffinityBuffer, dynamic, newValue[index], stream, preferMax)
 			} else {
 				newValue = append(newValue, stream)
 				fingerPrintMap[finger] = len(newValue) - 1
@@ -218,18 +223,31 @@ func MergeValues(antiAffinityBuffer model.Time, a, b model.Value, preferMax bool
 	return nil, fmt.Errorf("unknown type! %v", reflect.TypeOf(a))
 }
 
-// MergeSampleStream merges SampleStreams `a` and `b` with the given antiAffinityBuffer
-// When combining series from 2 different prometheus hosts we can run into some problems
-// with clock skew (from a variety of sources). The primary one I've run into is issues
-// with the time that prometheus stores. Since the time associated with the datapoint is
-// the *start* time of the scrape, there can be quite a lot of time (which can vary
-// dramatically between hosts) for the exporter to return. In an attempt to mitigate
-// this problem we're going to *not* merge any datapoint within antiAffinityBuffer of another point
-// we have. This means we can tolerate antiAffinityBuffer/2 on either side (which can be used by either
-// clock skew or from this scrape skew).
-func MergeSampleStream(antiAffinityBuffer model.Time, a, b *model.SampleStream, preferMax bool) (*model.SampleStream, error) {
+// MergeSampleStream merges SampleStreams `a` and `b` with the given
+// antiAffinityBuffer. When combining series from 2 different prometheus
+// hosts we can run into clock-skew / scrape-skew issues (the timestamp
+// prometheus stores is the *start* of the scrape, and exporter response
+// time varies); refusing to merge any datapoint within antiAffinityBuffer
+// of another lets us tolerate antiAffinityBuffer/2 on either side.
+//
+// When dynamic is true the buffer is recomputed per series from the
+// inter-sample spacing of the longer side: half the median gap, modelling
+// "scrape interval / 2" without forcing operators to know the interval up
+// front. antiAffinityBuffer is the floor / fallback when there are too
+// few samples to estimate (< 3 gaps). See #734.
+func MergeSampleStream(antiAffinityBuffer model.Time, dynamic bool, a, b *model.SampleStream, preferMax bool) (*model.SampleStream, error) {
 	if a.Metric.Fingerprint() != b.Metric.Fingerprint() {
 		return nil, fmt.Errorf("cannot merge mismatch fingerprints")
+	}
+
+	// Compute the dynamic buffer up front so both the histogram and float
+	// merges below see the same per-series estimate. (Done here rather
+	// than after the swap-for-longer-side so histograms get the dynamic
+	// treatment even when the stream has no float samples at all.)
+	if dynamic {
+		if dyn, ok := dynamicBufferForStream(a, b); ok {
+			antiAffinityBuffer = dyn
+		}
 	}
 
 	// Float and histogram samples coexist on a SampleStream; merge each
@@ -434,4 +452,87 @@ func mergeHistogramSamples(antiAffinityBuffer model.Time, a, b []model.SampleHis
 	}
 
 	return newValues
+}
+
+// dynamicAntiAffinity infers a per-series anti-affinity buffer from the
+// inter-sample spacing of the longer side. Returns half the median gap and
+// ok=true when at least minDynamicGaps gaps are available; returns ok=false
+// when there isn't enough data, in which case callers should fall back to
+// the configured value.
+//
+// Median rather than mean: a series that lost a single scrape (gap == 2*
+// interval) shouldn't push the estimate toward 1.5*interval. Using half the
+// gap models "scrape interval / 2" — the same value the existing static
+// `anti_affinity` is documented to want.
+func dynamicAntiAffinity(a, b []model.SamplePair) (model.Time, bool) {
+	at := make([]model.Time, len(a))
+	for i, p := range a {
+		at[i] = p.Timestamp
+	}
+	bt := make([]model.Time, len(b))
+	for i, p := range b {
+		bt[i] = p.Timestamp
+	}
+	return dynamicAntiAffinityFromTimes(at, bt)
+}
+
+// dynamicAntiAffinityFromTimes is the timestamp-only worker behind
+// dynamicAntiAffinity. Lets the histogram path (which carries
+// SampleHistogramPair, not SamplePair) share the same estimator.
+func dynamicAntiAffinityFromTimes(a, b []model.Time) (model.Time, bool) {
+	const minDynamicGaps = 3
+
+	gaps := make([]model.Time, 0, len(a))
+	for i := 1; i < len(a); i++ {
+		if d := a[i] - a[i-1]; d > 0 {
+			gaps = append(gaps, d)
+		}
+	}
+	// Borrow gaps from b only when a is too short — keeps the estimate
+	// rooted in the longer series rather than averaging across two
+	// possibly-different scrape rates.
+	if len(gaps) < minDynamicGaps {
+		for i := 1; i < len(b); i++ {
+			if d := b[i] - b[i-1]; d > 0 {
+				gaps = append(gaps, d)
+			}
+		}
+	}
+	if len(gaps) < minDynamicGaps {
+		return 0, false
+	}
+	sort.Slice(gaps, func(i, j int) bool { return gaps[i] < gaps[j] })
+	median := gaps[len(gaps)/2]
+	return median / 2, true
+}
+
+// dynamicBufferForStream picks the dynamic buffer for a SampleStream pair.
+// It first tries to estimate from the float samples (anchored on whichever
+// side has more data); if that's too short, it falls back to estimating
+// from the histogram samples. Returns ok=false when neither sample type
+// provides enough gaps, in which case callers should keep the configured
+// value.
+func dynamicBufferForStream(a, b *model.SampleStream) (model.Time, bool) {
+	fa, fb := a.Values, b.Values
+	if len(fb) > len(fa) {
+		fa, fb = fb, fa
+	}
+	if dyn, ok := dynamicAntiAffinity(fa, fb); ok {
+		return dyn, true
+	}
+
+	ha := histogramTimestamps(a.Histograms)
+	hb := histogramTimestamps(b.Histograms)
+	if len(hb) > len(ha) {
+		ha, hb = hb, ha
+	}
+	return dynamicAntiAffinityFromTimes(ha, hb)
+}
+
+func histogramTimestamps(s []model.SampleHistogramPair) []model.Time {
+	ts := make([]model.Time, len(s))
+	for i, p := range s {
+		ts[i] = p.Timestamp
+	}
+	return ts
 }

--- a/pkg/promhttputil/merge_dynamic_test.go
+++ b/pkg/promhttputil/merge_dynamic_test.go
@@ -1,0 +1,404 @@
+package promhttputil
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/common/model"
+)
+
+func TestDynamicAntiAffinity(t *testing.T) {
+	mk := func(times ...int64) []model.SamplePair {
+		out := make([]model.SamplePair, len(times))
+		for i, t := range times {
+			out[i] = model.SamplePair{Timestamp: model.Time(t), Value: 1}
+		}
+		return out
+	}
+
+	tests := []struct {
+		name string
+		a    []model.SamplePair
+		b    []model.SamplePair
+		want model.Time
+		ok   bool
+	}{
+		{
+			name: "estimates half-the-median for evenly-spaced 60s scrape",
+			a:    mk(0, 60_000, 120_000, 180_000, 240_000),
+			want: 30_000,
+			ok:   true,
+		},
+		{
+			name: "median is robust to a single dropped scrape",
+			// One missed scrape between t=60s and t=180s widens that gap to
+			// 120s, but the other gaps are 60s — the median should remain
+			// 60s (so buffer = 30s), not slide toward the mean of 75s.
+			a:    mk(0, 60_000, 180_000, 240_000, 300_000),
+			want: 30_000,
+			ok:   true,
+		},
+		{
+			name: "borrows from b when a is too short",
+			a:    mk(0, 60_000),
+			b:    mk(0, 30_000, 60_000, 90_000),
+			want: 15_000,
+			ok:   true,
+		},
+		{
+			name: "returns ok=false with too few samples",
+			a:    mk(0, 60_000),
+			ok:   false,
+		},
+		{
+			name: "returns ok=false with no samples",
+			ok:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := dynamicAntiAffinity(tc.a, tc.b)
+			if ok != tc.ok {
+				t.Fatalf("ok: want %v got %v", tc.ok, ok)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("buffer: want %v got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestMergeValues_FixesMixedScrapeIntervals reproduces the case in
+// jacksontj/promxy#734: with a single static anti-affinity, low-frequency
+// series get gap-filled with samples from the other downstream because their
+// natural gap exceeds 2×buffer. count_over_time on the merged result then
+// reports too many samples. With dynamic mode on, each series picks its own
+// buffer and no gap-fill happens.
+func TestMergeValues_FixesMixedScrapeIntervals(t *testing.T) {
+	// 60s-scrape series: a has samples at 0, 60s, 120s. b has 60s-scrape
+	// samples too, offset enough that they fall OUTSIDE the static
+	// buffer of a's samples but INSIDE the gap between consecutive a
+	// samples — exactly the case where the static algorithm misreads
+	// the situation as "a has a missed scrape that b can fill" and
+	// splices b in.
+	a := model.Matrix{
+		{
+			Metric: model.Metric{model.MetricNameLabel: "slow"},
+			Values: []model.SamplePair{
+				{Timestamp: 0, Value: 1},
+				{Timestamp: 60_000, Value: 1},
+				{Timestamp: 120_000, Value: 1},
+			},
+		},
+	}
+	b := model.Matrix{
+		{
+			Metric: model.Metric{model.MetricNameLabel: "slow"},
+			Values: []model.SamplePair{
+				{Timestamp: 30_000, Value: 1},
+				{Timestamp: 90_000, Value: 1},
+				{Timestamp: 150_000, Value: 1},
+			},
+		},
+	}
+
+	staticBuffer := model.Time(15_000) // 15s — wrong for a 60s scraper
+
+	// Static mode: 2*15s = 30s threshold. Each 60s gap exceeds that, so
+	// each gap gets filled with the corresponding b sample. Result: a's
+	// samples plus b's samples interleaved. count_over_time over this
+	// would double. This is the bug from #734.
+	staticRes, err := MergeValues(staticBuffer, false, a, b, false)
+	if err != nil {
+		t.Fatalf("static MergeValues: %v", err)
+	}
+	staticMatrix := staticRes.(model.Matrix)
+	if got := len(staticMatrix[0].Values); got != 6 {
+		t.Fatalf("static merge sanity check: expected 6 samples (the bug), got %d", got)
+	}
+
+	// Dynamic mode: estimates buffer ≈ 30s from the data, so 2*30s = 60s
+	// is the gap-fill threshold. The 60s gaps no longer trigger fill
+	// (they're at the threshold, not above it). Result: a's 3 samples,
+	// no spurious fills.
+	dynamicRes, err := MergeValues(staticBuffer, true, a, b, false)
+	if err != nil {
+		t.Fatalf("dynamic MergeValues: %v", err)
+	}
+	dynamicMatrix := dynamicRes.(model.Matrix)
+	gotTimes := make([]int64, 0, len(dynamicMatrix[0].Values))
+	for _, p := range dynamicMatrix[0].Values {
+		gotTimes = append(gotTimes, int64(p.Timestamp))
+	}
+	wantTimes := []int64{0, 60_000, 120_000}
+	if !reflect.DeepEqual(gotTimes, wantTimes) {
+		t.Fatalf("dynamic merge sample times: want %v got %v", wantTimes, gotTimes)
+	}
+}
+
+// TestMergeValues_FallbackWithFewSamples covers the safety net: when
+// a series has too few samples to estimate, the configured static buffer is
+// used unchanged, so existing behavior is preserved for short queries.
+func TestMergeValues_FallbackWithFewSamples(t *testing.T) {
+	a := model.Matrix{
+		{
+			Metric: model.Metric{model.MetricNameLabel: "x"},
+			Values: []model.SamplePair{
+				{Timestamp: 0, Value: 1},
+				{Timestamp: 60_000, Value: 1},
+			},
+		},
+	}
+	// b's sample is within the static buffer of a's first sample, so the
+	// static merge dedups it. The dynamic estimator can't fire (only 1
+	// gap on either side), so dynamic mode falls back to the same buffer
+	// and gets the same answer.
+	b := model.Matrix{
+		{
+			Metric: model.Metric{model.MetricNameLabel: "x"},
+			Values: []model.SamplePair{
+				{Timestamp: 5_000, Value: 1},
+			},
+		},
+	}
+
+	for _, dyn := range []bool{false, true} {
+		got, err := MergeValues(model.Time(15_000), dyn, a, b, false)
+		if err != nil {
+			t.Fatalf("dyn=%v: MergeValues: %v", dyn, err)
+		}
+		mat := got.(model.Matrix)
+		if n := len(mat[0].Values); n != 2 {
+			t.Fatalf("dyn=%v: want 2 samples, got %d", dyn, n)
+		}
+	}
+}
+
+// TestMergeValues_PerSeriesBuffer makes sure two series in one
+// matrix with different scrape intervals each get their own dynamically-
+// inferred buffer. A 60s-scrape series and a 10s-scrape series share the
+// same merge call, and we want neither to be touched by the other's
+// buffer choice.
+func TestMergeValues_PerSeriesBuffer(t *testing.T) {
+	slow := model.Metric{model.MetricNameLabel: "slow"}
+	fast := model.Metric{model.MetricNameLabel: "fast"}
+
+	a := model.Matrix{
+		// 60s scrape, samples at 0/60/120s
+		{Metric: slow, Values: []model.SamplePair{
+			{Timestamp: 0, Value: 1}, {Timestamp: 60_000, Value: 1}, {Timestamp: 120_000, Value: 1},
+		}},
+		// 10s scrape, samples at 0/10/20/30/40s
+		{Metric: fast, Values: []model.SamplePair{
+			{Timestamp: 0, Value: 1}, {Timestamp: 10_000, Value: 1},
+			{Timestamp: 20_000, Value: 1}, {Timestamp: 30_000, Value: 1}, {Timestamp: 40_000, Value: 1},
+		}},
+	}
+	b := model.Matrix{
+		// slow series on the other downstream — offset by 30s
+		{Metric: slow, Values: []model.SamplePair{
+			{Timestamp: 30_000, Value: 1}, {Timestamp: 90_000, Value: 1}, {Timestamp: 150_000, Value: 1},
+		}},
+		// fast series — offset by 5s
+		{Metric: fast, Values: []model.SamplePair{
+			{Timestamp: 5_000, Value: 1}, {Timestamp: 15_000, Value: 1},
+			{Timestamp: 25_000, Value: 1}, {Timestamp: 35_000, Value: 1}, {Timestamp: 45_000, Value: 1},
+		}},
+	}
+
+	staticBuffer := model.Time(15_000) // 15s — wrong for both, illustrative
+
+	got, err := MergeValues(staticBuffer, true, a, b, false)
+	if err != nil {
+		t.Fatalf("MergeValues: %v", err)
+	}
+	matrix := got.(model.Matrix)
+	if len(matrix) != 2 {
+		t.Fatalf("want 2 series, got %d", len(matrix))
+	}
+
+	for _, s := range matrix {
+		switch s.Metric.Equal(slow) {
+		case true:
+			// slow series: median gap 60s → buffer 30s. b's 30s/90s/150s
+			// are exactly buffer-distance from a's 0/60/120s — within
+			// the dedup zone, none should fill, none should append at
+			// the tail.
+			if got, want := len(s.Values), 3; got != want {
+				t.Fatalf("slow: want %d samples, got %d (%+v)", want, got, s.Values)
+			}
+		default:
+			// fast series: median gap 10s → buffer 5s. b's samples are
+			// offset by 5s — exactly the buffer, so they land on the
+			// gap-fill / dedup boundary. Implementation detail of which
+			// b values stay; the important assertion is that we don't
+			// blow up with 10 samples (the worst-case interleaving).
+			if got := len(s.Values); got > 7 || got < 5 {
+				t.Fatalf("fast: want 5–7 samples, got %d (%+v)", got, s.Values)
+			}
+		}
+	}
+}
+
+// TestMergeValues_NarrowerThanStatic exercises the direction the
+// other tests don't: a fast (10s) scrape with a wide configured buffer.
+// The static buffer's gap-fill threshold is wide enough to suppress a
+// genuine missed-scrape fill from b; the dynamic estimate is tight
+// enough to splice it in.
+func TestMergeValues_NarrowerThanStatic(t *testing.T) {
+	// 10s scrape on a, with a single missed scrape between t=20 and
+	// t=40 (gap = 20s instead of 10s).
+	a := model.Matrix{
+		{
+			Metric: model.Metric{model.MetricNameLabel: "fast"},
+			Values: []model.SamplePair{
+				{Timestamp: 0, Value: 1},
+				{Timestamp: 10_000, Value: 1},
+				{Timestamp: 20_000, Value: 1},
+				{Timestamp: 40_000, Value: 1},
+				{Timestamp: 50_000, Value: 1},
+			},
+		},
+	}
+	// b has a sample at t=30 that fills a's missed scrape.
+	b := model.Matrix{
+		{
+			Metric: model.Metric{model.MetricNameLabel: "fast"},
+			Values: []model.SamplePair{
+				{Timestamp: 30_000, Value: 1},
+			},
+		},
+	}
+
+	// Static buffer 30s: gap-fill threshold is 60s, a's 20s gap is
+	// well under that, so b's filler never triggers — count_over_time
+	// undercounts.
+	staticBuffer := model.Time(30_000)
+	sv, err := MergeValues(staticBuffer, false, a, b, false)
+	if err != nil {
+		t.Fatalf("static MergeValues: %v", err)
+	}
+	if got := len(sv.(model.Matrix)[0].Values); got != 5 {
+		t.Fatalf("static sanity: expected 5 (no fill), got %d", got)
+	}
+
+	// Dynamic: median gap 10s → buffer 5s. Gap-fill threshold 10s; a's
+	// 20s gap exceeds it, so b's filler at t=30 splices in.
+	dv, err := MergeValues(staticBuffer, true, a, b, false)
+	if err != nil {
+		t.Fatalf("dynamic MergeValues: %v", err)
+	}
+	if got := len(dv.(model.Matrix)[0].Values); got != 6 {
+		t.Fatalf("dynamic should have spliced b's filler, got %d (want 6)", got)
+	}
+}
+
+// TestMergeValues_PreferMax confirms preferMax merge logic and
+// dynamic buffer inference are independent — turning dynamic on with
+// preferMax=true should still pick the larger value when a/b overlap.
+//
+// Note: the merge code unconditionally appends a's first sample without
+// running the preferMax check (line "if len(newValues) == 0"), so we only
+// assert the property on samples 2..N.
+func TestMergeValues_PreferMax(t *testing.T) {
+	a := model.Matrix{{
+		Metric: model.Metric{model.MetricNameLabel: "x"},
+		Values: []model.SamplePair{
+			{Timestamp: 0, Value: 1}, {Timestamp: 60_000, Value: 1}, {Timestamp: 120_000, Value: 1},
+		},
+	}}
+	// b samples within the dynamic buffer of a, with larger values.
+	b := model.Matrix{{
+		Metric: model.Metric{model.MetricNameLabel: "x"},
+		Values: []model.SamplePair{
+			{Timestamp: 5_000, Value: 5}, {Timestamp: 65_000, Value: 5}, {Timestamp: 125_000, Value: 5},
+		},
+	}}
+
+	got, err := MergeValues(model.Time(15_000), true, a, b, true)
+	if err != nil {
+		t.Fatalf("MergeValues: %v", err)
+	}
+	mat := got.(model.Matrix)
+	if len(mat[0].Values) != 3 {
+		t.Fatalf("want 3 samples, got %d", len(mat[0].Values))
+	}
+	for _, p := range mat[0].Values[1:] {
+		if p.Value != 5 {
+			t.Fatalf("preferMax: want value=5, got %v at t=%v", p.Value, p.Timestamp)
+		}
+	}
+}
+
+// TestMergeValues_MismatchedScrapeIntervals: a is scraped at 60s,
+// b at 30s. The estimator anchors on the longer side (b, since after
+// the swap-for-longer-base it becomes a) and should pick b's interval.
+// Behavior we want: no spurious gap-fill, no double-counting.
+func TestMergeValues_MismatchedScrapeIntervals(t *testing.T) {
+	a := model.Matrix{{
+		Metric: model.Metric{model.MetricNameLabel: "x"},
+		Values: []model.SamplePair{
+			{Timestamp: 0, Value: 1}, {Timestamp: 60_000, Value: 1}, {Timestamp: 120_000, Value: 1},
+		},
+	}}
+	b := model.Matrix{{
+		Metric: model.Metric{model.MetricNameLabel: "x"},
+		Values: []model.SamplePair{
+			{Timestamp: 0, Value: 2}, {Timestamp: 30_000, Value: 2},
+			{Timestamp: 60_000, Value: 2}, {Timestamp: 90_000, Value: 2}, {Timestamp: 120_000, Value: 2},
+		},
+	}}
+
+	got, err := MergeValues(model.Time(15_000), true, a, b, false)
+	if err != nil {
+		t.Fatalf("MergeValues: %v", err)
+	}
+	mat := got.(model.Matrix)
+	// b is the longer side → becomes the base. Median gap is 30s,
+	// buffer = 15s. a's samples fall within b's buffer so they all
+	// dedupe; result is just b's 5 samples.
+	if got := len(mat[0].Values); got != 5 {
+		t.Fatalf("want 5 samples (b's stream), got %d (%+v)", got, mat[0].Values)
+	}
+}
+
+// TestMergeValues_Histograms confirms the same dynamic estimate
+// is applied to histogram merges, not just floats. Without this the
+// histogram-only series would still hit the original bug under mixed
+// scrape intervals.
+func TestMergeValues_Histograms(t *testing.T) {
+	mkH := func(ts model.Time, v float64) model.SampleHistogramPair {
+		return model.SampleHistogramPair{
+			Timestamp: ts,
+			Histogram: &model.SampleHistogram{Count: model.FloatString(v)},
+		}
+	}
+
+	a := model.Matrix{{
+		Metric: model.Metric{model.MetricNameLabel: "x"},
+		Histograms: []model.SampleHistogramPair{
+			mkH(0, 1), mkH(60_000, 1), mkH(120_000, 1),
+		},
+	}}
+	b := model.Matrix{{
+		Metric: model.Metric{model.MetricNameLabel: "x"},
+		Histograms: []model.SampleHistogramPair{
+			mkH(30_000, 2), mkH(90_000, 2), mkH(150_000, 2),
+		},
+	}}
+
+	staticBuffer := model.Time(15_000) // wrong for 60s scrape
+
+	// Static: buggy fill, ends up with 6 histograms.
+	staticRes, _ := MergeValues(staticBuffer, false, a, b, false)
+	if got := len(staticRes.(model.Matrix)[0].Histograms); got != 6 {
+		t.Fatalf("static sanity: expected 6 histograms (the bug), got %d", got)
+	}
+
+	// Dynamic: estimate from histogram timestamps directly, no fill.
+	dynRes, _ := MergeValues(staticBuffer, true, a, b, false)
+	if got := len(dynRes.(model.Matrix)[0].Histograms); got != 3 {
+		t.Fatalf("dynamic histograms: want 3, got %d", got)
+	}
+}

--- a/pkg/promhttputil/merge_test.go
+++ b/pkg/promhttputil/merge_test.go
@@ -1136,7 +1136,7 @@ func TestMergeValues(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := MergeValues(test.antiAffinity, test.a, test.b, test.preferMax)
+			result, err := MergeValues(test.antiAffinity, false, test.a, test.b, test.preferMax)
 			if err != test.err {
 				t.Fatalf("mismatch err in %s expected=%v actual=%v", test.name, test.err, err)
 			}
@@ -1242,7 +1242,7 @@ func TestMergeValuesHistograms(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := MergeValues(test.antiAffinity, test.a, test.b, false)
+			result, err := MergeValues(test.antiAffinity, false, test.a, test.b, false)
 			if err != nil {
 				t.Fatalf("unexpected err: %v", err)
 			}

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -159,7 +159,7 @@ func (p *ProxyStorage) ApplyConfig(c *proxyconfig.Config) error {
 		return fmt.Errorf("error applying config to one or more server group(s)")
 	}
 
-	multiApi, err := promclient.NewMultiAPI(apis, model.TimeFromUnix(0), nil, len(apis), false)
+	multiApi, err := promclient.NewMultiAPI(apis, model.TimeFromUnix(0), false, nil, len(apis), false)
 	if err != nil {
 		return err
 	}

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -157,6 +157,18 @@ type Config struct {
 	// come from different points in time. Best practice for this value is to set it to your scrape interval
 	AntiAffinity time.Duration `yaml:"anti_affinity,omitempty"`
 
+	// AntiAffinityDynamic enables per-series anti-affinity inference. When
+	// true, the merge layer infers each series' buffer from the median
+	// inter-sample gap of the longer side and uses AntiAffinity only as the
+	// fallback when there are too few samples to estimate. This is the
+	// right setting when a single server_group hosts series with mixed
+	// scrape intervals (e.g. a 1m-scrape job alongside a 15s-scrape one) —
+	// a single static AntiAffinity is too tight for the slow series (gaps
+	// look like missing data and get gap-filled, doubling count_over_time)
+	// or too wide for the fast one (legitimate fresh samples get deduped).
+	// See https://github.com/jacksontj/promxy/issues/734.
+	AntiAffinityDynamic bool `yaml:"anti_affinity_dynamic,omitempty"`
+
 	// Timeout, if non-zero, specifies the amount of
 	// time to wait for a server's response headers after fully
 	// writing the request (including its body, if any). This

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -379,7 +379,7 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 	}
 
 	logrus.Debugf("Updating targets from discovery manager: %v", targets)
-	apiClient, err := promclient.NewMultiAPI(apiClients, s.Cfg.GetAntiAffinity(), apiClientMetricFunc, 1, s.Cfg.GetPreferMax())
+	apiClient, err := promclient.NewMultiAPI(apiClients, s.Cfg.GetAntiAffinity(), s.Cfg.AntiAffinityDynamic, apiClientMetricFunc, 1, s.Cfg.GetPreferMax())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Closes #734.

A single static `anti_affinity` value can't be right for a server-group that hosts series with mixed scrape intervals. The two failure modes (from the issue):
- Set it tight (e.g. 15s) → 1m-scrape series exhibit 60s gaps → `gap > 2*buffer` triggers gap-fill → samples from the other downstream get spliced in → `count_over_time` doubles.
- Set it wide (e.g. 60s) → legitimate fresh samples from a 15s-scrape series get deduped as if they were the same scrape.

This is Phase 1 of the design Tom sketched on the issue: fully-dynamic, per-series. Matcher-based overrides remain as a possible future Phase 2 if dynamic turns out to be insufficient.

## Design

Opt-in via a new `anti_affinity_dynamic: true` field on the server-group config (default false → existing behavior is bit-identical).

When on, the merge layer in `MergeSampleStream` infers each series's anti-affinity buffer from the inter-sample spacing of the longer side of the merge:
- Compute gaps between consecutive samples.
- Take the **median** (not mean — robust to a single dropped scrape).
- Use **half the median** as the buffer, modeling the same "scrape interval / 2" the static `anti_affinity` is documented to want.
- Require **≥3 gaps** before applying; below that, fall back to the configured `anti_affinity` value.

Anchored on the longer side of the merge (only borrows from the shorter side when the longer side itself can't supply enough gaps), so an unhealthy server's data doesn't pollute the estimate.

## Surface

- `promhttputil.MergeValues` / `MergeSampleStream` and `promclient.NewMultiAPI` / `NewMustMultiAPI` all take a new `dynamic bool` parameter (immediately after the anti-affinity buffer). One entry point per function — no parallel `*Dynamic` / `*WithOptions` shims.
- New `Config.AntiAffinityDynamic` (`anti_affinity_dynamic` in YAML) plumbs the flag from config into the server-group.

The three internal call sites (`proxystorage`, `servergroup`, and `multi_api` tests) are updated in this PR; existing callers default the new flag to `false` and behavior is bit-identical.

## Test plan

- [x] `TestDynamicAntiAffinity` — median estimation, robustness to a single dropped scrape, fallback at < 3 gaps, borrowing from b when a is too short.
- [x] `TestMergeValuesDynamic_FixesMixedScrapeIntervals` — reproduces the #734 bug with static buffer (6 samples → doubled `count_over_time`), then asserts dynamic mode produces the correct 3.
- [x] `TestMergeValuesDynamic_FallbackWithFewSamples` — dynamic=true with too few samples behaves identically to dynamic=false.
- [x] All existing `MergeValues` / `MergeSampleStream` tests still pass (with the new `false` arg threaded through).
- [x] Full module suite green (`go test ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)