### PR TITLE
docs: add multi-tenant Mimir/Cortex example config

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -180,7 +180,12 @@ promxy:
 
       # Map of HTTP headers to add to remote read HTTP calls made to this downstream
       # the main use-case for this is to support the X-Scope-OrgID header required by Mimir and Cortex
-      # in multi-tenancy mode
+      # in multi-tenancy mode.
+      # NOTE: a server_group represents a set of endpoints holding the *same* data.
+      # When fanning out to several Mimir/Cortex tenants, model each (backend, tenant)
+      # pair as its own server_group rather than listing multiple tenants in a single
+      # X-Scope-OrgID header -- otherwise label-less aggregations (e.g. `count(up)`)
+      # can be under-counted. See `multi_tenant.conf` for a worked example.
       http_headers:
         X-Scope-OrgID: tenant-A
         X-Promxy-Source: promxy-1

--- a/cmd/promxy/multi_tenant.conf
+++ b/cmd/promxy/multi_tenant.conf
@@ -1,0 +1,88 @@
+## Example: multi-tenant downstreams (Mimir / Cortex / GEM)
+##
+## A server_group is a set of endpoints that hold the *same* data; promxy
+## merges/deduplicates within a group. With multi-tenant backends the dataset
+## is identified by (host, X-Scope-OrgID), not host alone -- so each
+## (backend, tenant) pair needs its own server_group, plus a static label
+## (`dc` here) to keep label-less results like `count(up)` distinguishable
+## across groups. See https://github.com/jacksontj/promxy/issues/703.
+##
+## Topology below: `dc1/2/3` each live on one backend; `google-us-dc1/2` are
+## replicated across mimir.dc1 + mimir.dc2; `google-eu-dc1/2` live only on
+## mimir.dc3.
+
+promxy:
+  server_groups:
+    - http_headers:
+        X-Scope-OrgID: dc1
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets:
+            - mimir.dc1.local:8080
+      labels:
+        dc: dc1
+
+    - http_headers:
+        X-Scope-OrgID: dc2
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets:
+            - mimir.dc2.local:8080
+      labels:
+        dc: dc2
+
+    - http_headers:
+        X-Scope-OrgID: dc3
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets:
+            - mimir.dc3.local:8080
+      labels:
+        dc: dc3
+
+    # Replicated tenants: both backends carry the same data, so they belong
+    # in the same server_group and promxy will merge/deduplicate within it.
+    - http_headers:
+        X-Scope-OrgID: google-us-dc1
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets:
+            - mimir.dc1.local:8080
+            - mimir.dc2.local:8080
+      labels:
+        dc: google-us-dc1
+
+    - http_headers:
+        X-Scope-OrgID: google-us-dc2
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets:
+            - mimir.dc1.local:8080
+            - mimir.dc2.local:8080
+      labels:
+        dc: google-us-dc2
+
+    - http_headers:
+        X-Scope-OrgID: google-eu-dc1
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets:
+            - mimir.dc3.local:8080
+      labels:
+        dc: google-eu-dc1
+
+    - http_headers:
+        X-Scope-OrgID: google-eu-dc2
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets:
+            - mimir.dc3.local:8080
+      labels:
+        dc: google-eu-dc2


### PR DESCRIPTION
## Summary
- Adds `cmd/promxy/multi_tenant.conf`, a worked example for multi-tenant downstreams (Mimir, Cortex, GEM) modelled on the scenario from #703
- Each `(backend, tenant)` pair becomes its own server_group with a static `dc` label, so promxy's "same data within a server_group" invariant holds and label-less aggregations (e.g. `count(up)`) aren't under-counted
- Adds a short note next to the `http_headers` docs in `cmd/promxy/config.yaml` pointing users to the new example before they hit the trap

## Why
Issue #703 traced an under-count to a config that listed several `X-Scope-OrgID` tenants (some replicated across backends) inside a single server_group. The backend returned the union, but promxy treated all endpoints in the group as equivalent — so a label-less `count(up)` collapsed N backends' results into one. The fix the reporter confirmed was splitting the group per tenant; this PR captures that as a discoverable example rather than a config-language change.

## Test plan
- [x] `--check-config` passes for the new `multi_tenant.conf`
- [x] `--check-config` still passes for the updated `config.yaml`


Fixes: #703