### PR TITLE
fix: add metric and warning for zero-target server groups

### DIFF
--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -37,10 +38,16 @@ var (
 		Name: "server_group_request_duration_seconds",
 		Help: "Summary of calls to servergroup instances",
 	}, []string{"host", "call", "status"})
+
+	serverGroupTargets = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "server_group_targets",
+		Help: "Number of active targets discovered for each server group",
+	}, []string{"ordinal"})
 )
 
 func init() {
 	prometheus.MustRegister(serverGroupSummary)
+	prometheus.MustRegister(serverGroupTargets)
 }
 
 // New creates a new servergroup
@@ -285,6 +292,13 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 				apiClients = append(apiClients, &promclient.ErrorWrap{apiClient, "error in target=" + u.String()})
 			}
 		}
+	}
+
+	ordinalStr := strconv.Itoa(s.Cfg.Ordinal)
+	serverGroupTargets.WithLabelValues(ordinalStr).Set(float64(len(targets)))
+
+	if len(targets) == 0 {
+		logrus.Warnf("ServerGroup ord=%d has zero active targets after discovery", s.Cfg.Ordinal)
 	}
 
 	apiClientMetricFunc := func(i int, api, status string, took float64) {

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -294,13 +294,6 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 		}
 	}
 
-	ordinalStr := strconv.Itoa(s.Cfg.Ordinal)
-	serverGroupTargets.WithLabelValues(ordinalStr).Set(float64(len(targets)))
-
-	if len(targets) == 0 {
-		logrus.Warnf("ServerGroup ord=%d has zero active targets after discovery", s.Cfg.Ordinal)
-	}
-
 	apiClientMetricFunc := func(i int, api, status string, took float64) {
 		serverGroupSummary.WithLabelValues(targets[i], api, status).Observe(took)
 	}
@@ -331,6 +324,13 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 	s.state.Store(newState) // Store new state
 	if oldState != nil {
 		oldState.ctxCancel() // Cancel the old state
+	}
+
+	ordinalStr := strconv.Itoa(s.Cfg.Ordinal)
+	serverGroupTargets.WithLabelValues(ordinalStr).Set(float64(len(targets)))
+
+	if len(targets) == 0 {
+		logrus.Warnf("ServerGroup ord=%d has zero active targets after discovery", s.Cfg.Ordinal)
 	}
 
 	if !s.loaded {

--- a/pkg/servergroup/servergroup_test.go
+++ b/pkg/servergroup/servergroup_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/sigv4"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"gopkg.in/yaml.v2"
 )
 
@@ -448,5 +451,48 @@ func TestSigV4RoundTripperErrorHandling(t *testing.T) {
 
 			t.Logf("SigV4 round tripper configured successfully for test: %s", tt.name)
 		})
+	}
+}
+
+func TestZeroTargetsMetric(t *testing.T) {
+	sg, err := NewServerGroup()
+	if err != nil {
+		t.Fatalf("failed to create servergroup: %v", err)
+	}
+	defer sg.Cancel()
+
+	sg.Cfg = &Config{
+		Ordinal: 42,
+		Scheme:  "http",
+	}
+
+	// Pass an empty target group map to simulate zero discovered targets
+	emptyMap := map[string][]*targetgroup.Group{
+		"test": {},
+	}
+	if err := sg.loadTargetGroupMap(emptyMap); err != nil {
+		t.Fatalf("loadTargetGroupMap returned error: %v", err)
+	}
+
+	// Verify the metric was set to 0
+	gauge, err := serverGroupTargets.GetMetricWithLabelValues("42")
+	if err != nil {
+		t.Fatalf("failed to get metric: %v", err)
+	}
+	m := &dto.Metric{}
+	if err := gauge.(prometheus.Metric).Write(m); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if got := m.GetGauge().GetValue(); got != 0 {
+		t.Errorf("expected server_group_targets{ordinal=\"42\"} = 0, got %v", got)
+	}
+
+	// Verify that state was stored with zero targets
+	state := sg.State()
+	if state == nil {
+		t.Fatal("expected non-nil state after loadTargetGroupMap")
+	}
+	if len(state.Targets) != 0 {
+		t.Errorf("expected 0 targets, got %d", len(state.Targets))
 	}
 }


### PR DESCRIPTION
## Summary
- Add `server_group_targets` gauge metric to expose the number of active targets per server group
- Log a warning when a server group has zero targets after sync, making silent misconfigurations observable
- Update metric after state is stored to avoid stale readings

Fixes #742

## Test plan
- New unit test verifies the metric is updated correctly after sync
- Existing server group tests pass unchanged
<!-- sweep:amend:attestation -->
[Failing tests before](https://github.com/kimjune01/sweep/blob/40312aec45b09ddd9e9974049c09ef5af0cbb1fb/attestations/jacksontj-promxy/issue-765-before.txt) / [Passing tests after](https://github.com/kimjune01/sweep/blob/40312aec45b09ddd9e9974049c09ef5af0cbb1fb/attestations/jacksontj-promxy/issue-765-after.txt) / [How the tests ran](https://github.com/kimjune01/sweep/blob/40312aec45b09ddd9e9974049c09ef5af0cbb1fb/attestations/jacksontj-promxy/issue-765-manifest.json)
<!-- /sweep:amend:attestation -->

<!-- sweep:compose -->
_Sweep attestation `b4d4b1dcc3ba` — see the receipts footer below._
<!-- /sweep:compose -->


