### PR TITLE
fix: set web.Options.ListenAddresses to avoid startup panic (#767)

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -421,6 +421,12 @@ func main() {
 
 		EnableLifecycle: opts.EnableLifecycle,
 
+		// Prometheus' web.New() indexes ListenAddresses[0] unconditionally when
+		// constructing GlobalURLOptions; promxy doesn't use the embedded
+		// listeners (it has its own server), but the slice still must be set
+		// or startup panics.
+		ListenAddresses: []string{opts.BindAddr},
+
 		Flags:       opts.ToFlags(),
 		RoutePrefix: opts.RoutePrefix,
 		ExternalURL: externalUrl,


### PR DESCRIPTION
## Summary
- Fixes #767. Prometheus' `web.New()` unconditionally dereferences `o.ListenAddresses[0]` when building `GlobalURLOptions` (vendored `web/web.go:367`), so promxy panicked at startup with `index out of range [0] with length 0`.
- Promxy doesn't use the embedded Prometheus listeners (it runs its own server in `pkg/server`), so the slice only affects the listen address reported through the API. Populating it with `opts.BindAddr` makes the reported value accurate and avoids the panic.

## Test plan
- [x] `go build ./cmd/promxy/` succeeds
- [x] `go run ./cmd/promxy/ --config=<empty-config> --bind-addr=:18099` starts cleanly and `/-/ready` returns 200 (previously paniced before reaching this point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)