### PR TITLE
Delegate web server to exporter-toolkit for full web.config support

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -82,7 +82,7 @@ type cliOpts struct {
 	LogFormat        string `long:"log-format" description:"Log format(text|json)" default:"text"`
 	LogMaxFormPrefix int    `long:"log-max-form-prefix" description:"Max prefix for form values in log entries" default:"256"`
 
-	WebConfigFile      string        `long:"web.config.file" description:"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication."`
+	WebConfigFile      string        `long:"web.config.file" description:"[EXPERIMENTAL] Path to a Prometheus-format web config file (TLS, HTTP headers, basic auth users). See https://prometheus.io/docs/prometheus/latest/configuration/https/ for the schema."`
 	WebCORSOriginRegex string        `long:"web.cors.origin" description:"Regex for CORS origin. It is fully anchored." default:".*"`
 	WebReadTimeout     time.Duration `long:"web.read-timeout" description:"Maximum duration before timing out read of the request, and closing idle connections." default:"5m"`
 

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -1,22 +1,25 @@
 package server
 
 import (
-	"crypto/tls"
+	"context"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 
 	"github.com/jacksontj/promxy/pkg/logging"
 )
 
-func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Duration, accessLogOut io.Writer, router http.Handler, tlsConfigFile string) (*http.Server, error) {
+func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Duration, accessLogOut io.Writer, router http.Handler, webConfigFile string) (*http.Server, error) {
 	handler := createHandler(accessLogOut, router, logFormat)
+
+	if err := web.Validate(webConfigFile); err != nil {
+		return nil, err
+	}
 
 	ln, err := net.Listen("tcp", bindAddr)
 	if err != nil {
@@ -28,11 +31,20 @@ func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Durat
 		ReadTimeout: webReadTimeout,
 	}
 
-	if tlsConfigFile == "" {
-		return createAndStartHTTP(srv, ln)
-	}
+	flags := &web.FlagConfig{WebConfigFile: &webConfigFile}
+	logger := slog.New(&logrusSlogHandler{})
 
-	return createAndStartHTTPS(srv, ln, tlsConfigFile)
+	go func() {
+		if webConfigFile == "" {
+			logrus.Infof("promxy starting with HTTP...")
+		} else {
+			logrus.Infof("promxy starting with web config %s...", webConfigFile)
+		}
+		if err := web.Serve(ln, srv, flags, logger); err != nil && err != http.ErrServerClosed {
+			logrus.Errorf("Error listening: %v", err)
+		}
+	}()
+	return srv, nil
 }
 
 func createHandler(accessLogOut io.Writer, router http.Handler, logFormat string) http.Handler {
@@ -51,60 +63,42 @@ func createHandler(accessLogOut io.Writer, router http.Handler, logFormat string
 	return handler
 }
 
-func createAndStartHTTP(srv *http.Server, ln net.Listener) (*http.Server, error) {
-	srv.TLSConfig = nil
-
-	go func() {
-		logrus.Infof("promxy starting with HTTP...")
-		if err := srv.Serve(ln); err != nil {
-			if err == http.ErrServerClosed {
-				return
-			}
-			logrus.Errorf("Error listening: %v", err)
-		}
-	}()
-	return srv, nil
+// logrusSlogHandler forwards exporter-toolkit's slog output to logrus so promxy
+// has a single log stream.
+type logrusSlogHandler struct {
+	attrs []slog.Attr
 }
 
-func createAndStartHTTPS(srv *http.Server, ln net.Listener, tlsConfigFile string) (*http.Server, error) {
-	tlsConfig, err := parseConfigFile(tlsConfigFile)
-	if err != nil {
-		return nil, err
+func (h *logrusSlogHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *logrusSlogHandler) Handle(_ context.Context, r slog.Record) error {
+	fields := logrus.Fields{}
+	for _, a := range h.attrs {
+		fields[a.Key] = a.Value.Any()
 	}
-
-	srv.TLSConfig = tlsConfig
-
-	go func() {
-		logrus.Infof("promxy starting with TLS...")
-		if err := srv.ServeTLS(ln, "", ""); err != nil {
-			if err == http.ErrServerClosed {
-				return
-			}
-			logrus.Errorf("Error listening: %v", err)
-		}
-	}()
-	return srv, nil
+	r.Attrs(func(a slog.Attr) bool {
+		fields[a.Key] = a.Value.Any()
+		return true
+	})
+	entry := logrus.WithFields(fields)
+	switch {
+	case r.Level >= slog.LevelError:
+		entry.Error(r.Message)
+	case r.Level >= slog.LevelWarn:
+		entry.Warn(r.Message)
+	case r.Level >= slog.LevelInfo:
+		entry.Info(r.Message)
+	default:
+		entry.Debug(r.Message)
+	}
+	return nil
 }
 
-func parseConfigFile(tlsConfigFile string) (*tls.Config, error) {
-	content, err := os.ReadFile(tlsConfigFile)
-	if err != nil {
-		return nil, err
-	}
-	tlsStruct := &web.TLSConfig{
-		MinVersion:               tls.VersionTLS12,
-		MaxVersion:               tls.VersionTLS13,
-		PreferServerCipherSuites: true,
-	}
-	err = yaml.UnmarshalStrict(content, tlsStruct)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsConfig, err := web.ConfigToTLSConfig(tlsStruct)
-	if err != nil {
-		return nil, err
-	}
-
-	return tlsConfig, err
+func (h *logrusSlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	merged := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	merged = append(merged, h.attrs...)
+	merged = append(merged, attrs...)
+	return &logrusSlogHandler{attrs: merged}
 }
+
+func (h *logrusSlogHandler) WithGroup(_ string) slog.Handler { return h }

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -55,6 +55,38 @@ func TestUnauthenticatedServerFunctions(t *testing.T) {
 	server.Close()
 }
 
+func TestServerEmitsConfiguredHeaders(t *testing.T) {
+	freePort, err := getFreePort()
+	if err != nil {
+		t.Fatalf("could not get a free port to run test: %s", err.Error())
+	}
+	bindAddr := fmt.Sprintf("localhost:%d", freePort)
+	router := httprouter.New()
+	router.HandlerFunc("GET", "/metrics", promhttp.Handler().ServeHTTP)
+
+	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, "testdata/http-server-config.yml")
+	if err != nil {
+		t.Fatalf("an error occurred during creation of server: %s", err.Error())
+	}
+	defer server.Close()
+
+	time.Sleep(time.Millisecond * 5)
+	resp, err := (&http.Client{}).Get(fmt.Sprintf("http://%s/metrics", bindAddr))
+	if err != nil {
+		t.Fatalf("could not make request to metrics endpoint: %s", err.Error())
+	}
+
+	want := map[string]string{
+		"Content-Security-Policy": "default-src 'self';",
+		"X-Frame-Options":         "sameorigin",
+	}
+	for k, v := range want {
+		if got := resp.Header.Get(k); got != v {
+			t.Fatalf("header %s: got %q, want %q", k, got, v)
+		}
+	}
+}
+
 func TestAuthenticatedServerDoesNotStartupWithInvalidConfig(t *testing.T) {
 	freePort, err := getFreePort()
 	if err != nil {

--- a/pkg/server/testdata/http-server-config.yml
+++ b/pkg/server/testdata/http-server-config.yml
@@ -1,0 +1,4 @@
+http_server_config:
+  headers:
+    Content-Security-Policy: "default-src 'self';"
+    X-Frame-Options: "sameorigin"

--- a/pkg/server/testdata/invalid-tls-server-config.yml
+++ b/pkg/server/testdata/invalid-tls-server-config.yml
@@ -1,4 +1,5 @@
-cert_file: ""
-key_file: ""
-client_auth_type: "RequireAndVerifyClientCert"
-client_ca_file: "testdata/test-ca.crt"
+tls_server_config:
+  cert_file: ""
+  key_file: ""
+  client_auth_type: "RequireAndVerifyClientCert"
+  client_ca_file: "test-ca.crt"

--- a/pkg/server/testdata/tls-server-config.yml
+++ b/pkg/server/testdata/tls-server-config.yml
@@ -1,4 +1,5 @@
-cert_file: "../../pkg/server/testdata/server.crt"
-key_file: "../../pkg/server/testdata/server.key"
-client_auth_type: "RequireAndVerifyClientCert"
-client_ca_file: "../../pkg/server/testdata/test-ca.crt"
+tls_server_config:
+  cert_file: "server.crt"
+  key_file: "server.key"
+  client_auth_type: "RequireAndVerifyClientCert"
+  client_ca_file: "test-ca.crt"


### PR DESCRIPTION
## Summary
- Hands the listener off to `github.com/prometheus/exporter-toolkit/web.Serve` via a `web.FlagConfig`, the same path Prometheus itself uses. This drops the bespoke TLS parsing in `pkg/server/api.go` (~110 → ~100 lines, mostly net change is the slog/logrus bridge).
- `--web.config.file` now accepts the full Prometheus [web.config schema](https://prometheus.io/docs/prometheus/latest/configuration/https/) — TLS, response headers (`http_server_config.headers`), and basic auth users (`basic_auth_users`). No new flag.
- Pre-validates the config with `web.Validate` so a bad file still fails startup, preserving current behavior.
- Small `slog.Handler` forwards exporter-toolkit's startup messages into promxy's logrus stream so we still get one log format.

## Background
This is an alternative to #744, which added a second `--prometheus.web.config.file` flag alongside the existing one to get the same features. That approach predated the move to exporter-toolkit v0.14 and would no longer compile (`web.TLSStruct` removed, `web.Serve` signature changed, references a nonexistent `logging.NewLogger`). Since upstream Prometheus delegates everything to `exporter-toolkit/web`, that's the cleaner shape to adopt here — one flag, one parser, future fixes inherited.

## Breaking change
The flag is marked `[EXPERIMENTAL]`, but for anyone using it today: existing configs in the flat schema need to be wrapped under `tls_server_config:`.

Before:
```yaml
cert_file: "server.crt"
key_file: "server.key"
client_auth_type: "RequireAndVerifyClientCert"
client_ca_file: "test-ca.crt"
```

After:
```yaml
tls_server_config:
  cert_file: "server.crt"
  key_file: "server.key"
  client_auth_type: "RequireAndVerifyClientCert"
  client_ca_file: "test-ca.crt"
```

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/server/...` — existing TLS / mTLS / invalid-config tests updated to the new schema; new `TestServerEmitsConfiguredHeaders` exercises `http_server_config.headers`.
- [ ] Manual: start promxy with a `tls_server_config` + `http_server_config.headers` config, hit `/metrics`, confirm response headers and TLS handshake.

Closes #744 (replaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)