### PR TITLE
fix: write remote_write WAL via agent DB so queue managers can tail it (#771)

### DIFF
--- a/pkg/proxystorage/appender_stub.go
+++ b/pkg/proxystorage/appender_stub.go
@@ -1,6 +1,7 @@
 package proxystorage
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -12,6 +13,14 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/sirupsen/logrus"
 )
+
+// appendableStub is the storage.Appendable used when no remote_write endpoint
+// is configured. Its appender warns (rate-limited) and discards samples.
+type appendableStub struct{}
+
+func (appendableStub) Appender(context.Context) storage.Appender {
+	return &appenderStub{}
+}
 
 type appenderStub struct{}
 

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/agent"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/sirupsen/logrus"
 
@@ -47,11 +48,16 @@ func (noopScrapeManager) Get() (*scrape.Manager, error) {
 const metricNameWorkaroundLabel = "__name"
 
 type proxyStorageState struct {
-	sgs            []*servergroup.ServerGroup
-	client         promclient.API
-	cfg            *proxyconfig.Config
-	remoteStorage  *remote.Storage
-	appender       storage.Appender
+	sgs           []*servergroup.ServerGroup
+	client        promclient.API
+	cfg           *proxyconfig.Config
+	remoteStorage *remote.Storage
+	// agentDB writes the remote_write WAL that remoteStorage's queue managers
+	// tail. It is nil when no remote_write endpoint is configured.
+	agentDB *agent.DB
+	// appendable hands out appenders for the rule manager. Backed by agentDB
+	// when remote_write is configured, otherwise by a no-op stub.
+	appendable     storage.Appendable
 	appenderCloser func() error
 }
 
@@ -76,11 +82,10 @@ func (p *proxyStorageState) Cancel(n *proxyStorageState) {
 			sg.Cancel()
 		}
 	}
-	// We call close if the new one is nil, or if the appenders don't match
-	if n == nil || p.appender != n.appender {
-		if p.appenderCloser != nil {
-			p.appenderCloser()
-		}
+	// Close the remote_write storage (agent WAL + queue managers) unless the
+	// new state is reusing the same instance.
+	if p.appenderCloser != nil && (n == nil || p.remoteStorage != n.remoteStorage) {
+		p.appenderCloser()
 	}
 }
 
@@ -162,6 +167,9 @@ func (p *ProxyStorage) ApplyConfig(c *proxyconfig.Config) error {
 				return err
 			}
 			newState.remoteStorage = oldState.remoteStorage
+			newState.agentDB = oldState.agentDB
+			newState.appendable = oldState.appendable
+			newState.appenderCloser = oldState.appenderCloser
 		} else {
 			walDir := p.localStoragePath
 			ephemeral := walDir == ""
@@ -172,36 +180,53 @@ func (p *ProxyStorage) ApplyConfig(c *proxyconfig.Config) error {
 				}
 				walDir = dir
 			}
+			rwLogger := logging.NewLogger(logrus.WithField("component", "remote_write").Logger)
 			rs := remote.NewStorage(
-				logging.NewLogger(logrus.WithField("component", "remote_write").Logger),
+				rwLogger,
 				prometheus.DefaultRegisterer,
 				func() (int64, error) { return 0, nil },
 				walDir,
 				1*time.Second,
 				noopScrapeManager{},
 			)
+			// promxy has no local TSDB writing a WAL, so remote.Storage's queue
+			// managers have nothing to tail. Run an agent-mode WAL-only DB whose
+			// appender writes the WAL that those queue managers consume. Without
+			// this the WAL watcher fails with "error tailing WAL ... no such file
+			// or directory" and no samples are ever shipped (see issue #771).
+			db, err := agent.Open(rwLogger, prometheus.DefaultRegisterer, rs, walDir, agent.DefaultOptions())
+			if err != nil {
+				if ephemeral {
+					os.RemoveAll(walDir)
+				}
+				return fmt.Errorf("creating remote_write WAL: %w", err)
+			}
+			// Wake the queue managers' WAL watchers as soon as samples are committed.
+			db.SetWriteNotified(rs)
 			if err := rs.ApplyConfig(&c.PromConfig); err != nil {
+				db.Close()
 				if ephemeral {
 					os.RemoveAll(walDir)
 				}
 				return err
 			}
 			newState.remoteStorage = rs
+			newState.agentDB = db
+			newState.appendable = db
 			newState.appenderCloser = func() error {
-				closeErr := rs.Close()
+				dbErr := db.Close()
+				rsErr := rs.Close()
 				if ephemeral {
 					os.RemoveAll(walDir)
 				}
-				return closeErr
+				if dbErr != nil {
+					return dbErr
+				}
+				return rsErr
 			}
 		}
-
-		// Whether old or new, update the appender. The remote.Storage Appender
-		// implementation does not actually use the context.
-		newState.appender = newState.remoteStorage.Appender(context.Background())
-
 	} else {
-		newState.appender = &appenderStub{}
+		newState.appendable = appendableStub{}
 	}
 
 	newState.Ready()        // Wait for the newstate to be ready
@@ -313,9 +338,11 @@ func (p *ProxyStorage) StartTime() (int64, error) {
 	return 0, nil
 }
 
-// Appender returns a new appender against the storage.
-func (p *ProxyStorage) Appender(context.Context) storage.Appender {
-	return p.GetState().appender
+// Appender returns a new appender against the storage. When remote_write is
+// configured this is backed by the agent WAL (single-use, pooled appender), so
+// a fresh appender is returned on every call rather than a shared instance.
+func (p *ProxyStorage) Appender(ctx context.Context) storage.Appender {
+	return p.GetState().appendable.Appender(ctx)
 }
 
 // Close releases the resources of the Querier.

--- a/pkg/proxystorage/remote_write_test.go
+++ b/pkg/proxystorage/remote_write_test.go
@@ -1,0 +1,104 @@
+package proxystorage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	yaml "gopkg.in/yaml.v2"
+
+	proxyconfig "github.com/jacksontj/promxy/pkg/config"
+)
+
+func noStepSubqueryInterval(int64) int64 { return 0 }
+
+func loadConfig(t *testing.T, raw string) *proxyconfig.Config {
+	t.Helper()
+	cfg := &proxyconfig.Config{
+		PromConfig:   config.DefaultConfig,
+		PromxyConfig: proxyconfig.DefaultPromxyConfig,
+	}
+	if err := yaml.Unmarshal([]byte(raw), cfg); err != nil {
+		t.Fatalf("error unmarshaling config: %v", err)
+	}
+	return cfg
+}
+
+// TestRemoteWriteWAL is a regression test for
+// https://github.com/jacksontj/promxy/issues/771. With remote_write configured,
+// promxy must run a WAL-only agent DB so the remote.Storage queue managers have
+// a WAL to tail. Before the fix the WAL subdir never existed (the watcher failed
+// with "error tailing WAL ... no such file or directory") and samples appended by
+// the rule manager were silently discarded by the upstream timestampTracker.
+func TestRemoteWriteWAL(t *testing.T) {
+	dir := t.TempDir()
+
+	ps, err := NewProxyStorage(noStepSubqueryInterval, dir)
+	if err != nil {
+		t.Fatalf("NewProxyStorage: %v", err)
+	}
+
+	cfg := loadConfig(t, `
+remote_write:
+  - url: http://localhost:1/api/v1/write
+`)
+
+	if err := ps.ApplyConfig(cfg); err != nil {
+		t.Fatalf("ApplyConfig: %v", err)
+	}
+	defer ps.GetState().Cancel(nil)
+
+	// The agent DB must have created the WAL subdir that the queue managers tail.
+	walDir := filepath.Join(dir, "wal")
+	if _, err := os.Stat(walDir); err != nil {
+		t.Fatalf("expected WAL dir %q to exist, got: %v", walDir, err)
+	}
+
+	// An append+commit must succeed and be accepted by the WAL-backed appender
+	// (not silently discarded). The agent appender is single-use, so this also
+	// exercises that ProxyStorage.Appender hands out a fresh appender per call.
+	app := ps.Appender(context.Background())
+	if _, err := app.Append(0, labels.FromStrings(labels.MetricName, "promxy_test_metric"), 1, 1); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := app.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// A second Appender call must return a distinct instance; the first one was
+	// returned to the agent's pool on Commit. Reusing a shared instance would be
+	// a use-after-return bug.
+	if a, b := ps.Appender(context.Background()), ps.Appender(context.Background()); a == b {
+		t.Fatalf("expected distinct appenders from the WAL-backed appendable, got identical instances")
+	}
+}
+
+// TestNoRemoteWriteAppender verifies that without remote_write the appendable is
+// the no-op stub and appends are accepted (and discarded) without error.
+func TestNoRemoteWriteAppender(t *testing.T) {
+	ps, err := NewProxyStorage(noStepSubqueryInterval, "")
+	if err != nil {
+		t.Fatalf("NewProxyStorage: %v", err)
+	}
+
+	if err := ps.ApplyConfig(loadConfig(t, "")); err != nil {
+		t.Fatalf("ApplyConfig: %v", err)
+	}
+
+	app := ps.Appender(context.Background())
+	if _, ok := app.(*appenderStub); !ok {
+		t.Fatalf("expected *appenderStub when no remote_write is configured, got %T", app)
+	}
+	if _, err := app.Append(0, labels.FromStrings(labels.MetricName, "x"), 1, 1); err != nil {
+		t.Fatalf("stub Append should not error: %v", err)
+	}
+	if err := app.Commit(); err != nil {
+		t.Fatalf("stub Commit should not error: %v", err)
+	}
+}
+
+var _ storage.Appendable = appendableStub{}

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -2,14 +2,18 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 
 	"github.com/jacksontj/promxy/pkg/logging"
 )
@@ -17,8 +21,20 @@ import (
 func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Duration, accessLogOut io.Writer, router http.Handler, webConfigFile string) (*http.Server, error) {
 	handler := createHandler(accessLogOut, router, logFormat)
 
-	if err := web.Validate(webConfigFile); err != nil {
+	// Prior to delegating the web server to exporter-toolkit, promxy parsed
+	// --web.config.file directly into web.TLSConfig, so TLS keys (cert_file,
+	// key_file, ...) lived at the top level of the file. exporter-toolkit
+	// instead expects them nested under tls_server_config. To avoid breaking
+	// existing deployments we transparently keep serving the legacy flat schema.
+	legacyTLS, err := legacyTLSConfig(webConfigFile)
+	if err != nil {
 		return nil, err
+	}
+
+	if legacyTLS == nil {
+		if err := web.Validate(webConfigFile); err != nil {
+			return nil, err
+		}
 	}
 
 	ln, err := net.Listen("tcp", bindAddr)
@@ -29,6 +45,18 @@ func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Durat
 		Addr:        ln.Addr().String(),
 		Handler:     handler,
 		ReadTimeout: webReadTimeout,
+	}
+
+	if legacyTLS != nil {
+		srv.TLSConfig = legacyTLS
+		go func() {
+			logrus.Warnf("--web.config.file %q uses the deprecated flat TLS schema; nest these keys under 'tls_server_config:'. Support for the flat schema will be removed in a future release.", webConfigFile)
+			logrus.Infof("promxy starting with TLS (legacy web config %s)...", webConfigFile)
+			if err := srv.ServeTLS(ln, "", ""); err != nil && err != http.ErrServerClosed {
+				logrus.Errorf("Error listening: %v", err)
+			}
+		}()
+		return srv, nil
 	}
 
 	flags := &web.FlagConfig{WebConfigFile: &webConfigFile}
@@ -45,6 +73,54 @@ func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Durat
 		}
 	}()
 	return srv, nil
+}
+
+// legacyTLSConfig detects the pre-exporter-toolkit web config schema, in which
+// TLS settings lived at the top level of the file instead of nested under
+// tls_server_config. It returns a ready-to-use *tls.Config when the file uses
+// that legacy schema, or nil when the file is empty, uses the current
+// exporter-toolkit schema, or otherwise should be handled by exporter-toolkit.
+func legacyTLSConfig(webConfigFile string) (*tls.Config, error) {
+	if webConfigFile == "" {
+		return nil, nil
+	}
+
+	content, err := os.ReadFile(webConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// A top-level map with any exporter-toolkit section is, by definition, the
+	// current schema; anything else with content is treated as the legacy flat
+	// schema. Empty files fall through to exporter-toolkit, which serves plain
+	// HTTP, matching the original behavior.
+	var top map[string]interface{}
+	if err := yaml.Unmarshal(content, &top); err != nil {
+		// Let exporter-toolkit surface the parse error in its own terms.
+		return nil, nil
+	}
+	if len(top) == 0 {
+		return nil, nil
+	}
+	for _, section := range []string{"tls_server_config", "http_server_config", "basic_auth_users"} {
+		if _, ok := top[section]; ok {
+			return nil, nil
+		}
+	}
+
+	tlsStruct := &web.TLSConfig{
+		MinVersion:               tls.VersionTLS12,
+		MaxVersion:               tls.VersionTLS13,
+		PreferServerCipherSuites: true,
+	}
+	if err := yaml.UnmarshalStrict(content, tlsStruct); err != nil {
+		return nil, err
+	}
+	// Resolve relative cert/key paths against the config file's directory, the
+	// same as exporter-toolkit does for the current schema.
+	tlsStruct.SetDirectory(filepath.Dir(webConfigFile))
+
+	return web.ConfigToTLSConfig(tlsStruct)
 }
 
 func createHandler(accessLogOut io.Writer, router http.Handler, logFormat string) http.Handler {

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -172,6 +172,45 @@ func TestMutualTLSClientCanConnectToAuthenticatedServerWithCerts(t *testing.T) {
 	server.Close()
 }
 
+// TestLegacyFlatTLSConfigStillServesTLS ensures the pre-exporter-toolkit web
+// config schema, where TLS keys live at the top level instead of nested under
+// tls_server_config, continues to bring up a working TLS server. See #771.
+func TestLegacyFlatTLSConfigStillServesTLS(t *testing.T) {
+	freePort, err := getFreePort()
+	if err != nil {
+		t.Fatalf("could not get a free port to run test: %s", err.Error())
+	}
+	bindAddr := fmt.Sprintf("localhost:%d", freePort)
+	router := httprouter.New()
+	router.HandlerFunc("GET", "/metrics", promhttp.Handler().ServeHTTP)
+
+	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, "testdata/legacy-tls-server-config.yml")
+	if err != nil {
+		t.Fatalf("an error occurred during creation of server: %s", err.Error())
+	}
+	defer server.Close()
+
+	client := setupAuthenticatedClient(t)
+
+	resp, err := client.Get(fmt.Sprintf("https://%s/metrics", bindAddr))
+	if err != nil {
+		t.Fatalf("could not make request to metrics endpoint: %s", err.Error())
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("could not read response body: %s", err.Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated client was unable to make a request to the legacy-config server. Response body: %s", body)
+	}
+
+	if !strings.Contains(string(body), "go_goroutines") {
+		t.Fatalf("could not find metric name 'go_goroutines' in response")
+	}
+}
+
 func getFreePort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {

--- a/pkg/server/testdata/legacy-tls-server-config.yml
+++ b/pkg/server/testdata/legacy-tls-server-config.yml
@@ -1,0 +1,7 @@
+# Legacy (pre-exporter-toolkit) flat web config schema, where TLS keys live at
+# the top level instead of nested under tls_server_config. Kept for backward
+# compatibility; see legacyTLSConfig in api.go.
+cert_file: "server.crt"
+key_file: "server.key"
+client_auth_type: "RequireAndVerifyClientCert"
+client_ca_file: "test-ca.crt"

--- a/test/remote_write_test.go
+++ b/test/remote_write_test.go
@@ -1,0 +1,166 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/storage/remote"
+	yaml "gopkg.in/yaml.v2"
+
+	proxyconfig "github.com/jacksontj/promxy/pkg/config"
+	"github.com/jacksontj/promxy/pkg/proxystorage"
+)
+
+// rwReceiver is a minimal remote_write endpoint that decodes incoming
+// (snappy-compressed protobuf) write requests and records the samples it sees,
+// keyed by series. It is used to assert that promxy actually ships samples
+// end-to-end over the remote_write path (regression for issue #771).
+type rwReceiver struct {
+	mu      sync.Mutex
+	samples map[string][]float64
+	posts   int
+}
+
+func newRWReceiver() *rwReceiver {
+	return &rwReceiver{samples: map[string][]float64{}}
+}
+
+func (r *rwReceiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	wr, err := remote.DecodeWriteRequest(req.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	r.mu.Lock()
+	r.posts++
+	for _, ts := range wr.Timeseries {
+		b := labels.NewScratchBuilder(len(ts.Labels))
+		for _, l := range ts.Labels {
+			b.Add(l.Name, l.Value)
+		}
+		b.Sort()
+		key := b.Labels().String()
+		for _, s := range ts.Samples {
+			r.samples[key] = append(r.samples[key], s.Value)
+		}
+	}
+	r.mu.Unlock()
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// valuesFor returns the values received for the series matching lbls (exact
+// label-set match).
+func (r *rwReceiver) valuesFor(lbls labels.Labels) []float64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]float64, len(r.samples[lbls.String()]))
+	copy(out, r.samples[lbls.String()])
+	return out
+}
+
+// rawRemoteWriteConfig points promxy's remote_write at the receiver and tunes
+// the queue so samples flush quickly (the default batch_send_deadline is 5s).
+// It intentionally has no server_groups -- this exercises the remote_write
+// (appender/WAL) path in isolation.
+const rawRemoteWriteConfig = `
+remote_write:
+  - url: %s
+    queue_config:
+      batch_send_deadline: 200ms
+      min_shards: 1
+      max_shards: 1
+      capacity: 1000
+`
+
+// TestRemoteWriteEndToEnd is an end-to-end regression test for issue #771: with
+// remote_write configured, samples appended through promxy's storage (as the
+// rule manager does) must actually be shipped to the remote endpoint. Before the
+// fix promxy never wrote a WAL for the queue managers to tail, so the watcher
+// errored every tick and zero samples were ever delivered.
+func TestRemoteWriteEndToEnd(t *testing.T) {
+	recv := newRWReceiver()
+	srv := httptest.NewServer(recv)
+	defer srv.Close()
+
+	cfg := &proxyconfig.Config{}
+	if err := yaml.Unmarshal([]byte(fmt.Sprintf(rawRemoteWriteConfig, srv.URL)), cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+
+	ps, err := proxystorage.NewProxyStorage(func(int64) int64 { return 0 }, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewProxyStorage: %v", err)
+	}
+	if err := ps.ApplyConfig(cfg); err != nil {
+		t.Fatalf("ApplyConfig: %v", err)
+	}
+	defer ps.GetState().Cancel(nil)
+
+	series := labels.FromStrings(labels.MetricName, "promxy_e2e_metric", "src", "issue771")
+
+	// The WAL watcher only ships samples with a timestamp newer than when it
+	// started, and a single write notification can race and be dropped (falling
+	// back to a 15s read timer). Mirror the rule manager by appending on an
+	// interval with current-time timestamps until the receiver observes the
+	// series (or we time out).
+	const wantValue = 42.0
+	stopAppending := make(chan struct{})
+	var appendErr error
+	var appendOnce sync.Once
+	go func() {
+		ticker := time.NewTicker(200 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopAppending:
+				return
+			case <-ticker.C:
+				app := ps.Appender(context.Background())
+				if _, err := app.Append(0, series, timestamp.FromTime(time.Now()), wantValue); err != nil {
+					appendOnce.Do(func() { appendErr = fmt.Errorf("append: %w", err) })
+					return
+				}
+				if err := app.Commit(); err != nil {
+					appendOnce.Do(func() { appendErr = fmt.Errorf("commit: %w", err) })
+					return
+				}
+			}
+		}
+	}()
+
+	deadline := time.After(30 * time.Second)
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-deadline:
+			close(stopAppending)
+			t.Fatalf("timed out waiting for remote_write samples; receiver got %d POST(s), no matching series", recv.posts)
+		case <-tick.C:
+			if appendErr != nil {
+				close(stopAppending)
+				t.Fatalf("error while appending: %v", appendErr)
+			}
+			vals := recv.valuesFor(series)
+			if len(vals) > 0 {
+				for _, v := range vals {
+					if v != wantValue {
+						close(stopAppending)
+						t.Fatalf("received unexpected sample value: got %v want %v", v, wantValue)
+					}
+				}
+				close(stopAppending)
+				return // success: samples made it end-to-end
+			}
+		}
+	}
+}

--- a/vendor/github.com/prometheus/prometheus/tsdb/agent/db.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/agent/db.go
@@ -1,0 +1,1288 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"path/filepath"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"go.uber.org/atomic"
+
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"github.com/prometheus/prometheus/tsdb/record"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+	"github.com/prometheus/prometheus/tsdb/wlog"
+	"github.com/prometheus/prometheus/util/compression"
+	"github.com/prometheus/prometheus/util/zeropool"
+)
+
+const (
+	sampleMetricTypeFloat     = "float"
+	sampleMetricTypeHistogram = "histogram"
+)
+
+var ErrUnsupported = errors.New("unsupported operation with WAL-only storage")
+
+// Default values for options.
+var (
+	DefaultTruncateFrequency = 2 * time.Hour
+	DefaultMinWALTime        = int64(5 * time.Minute / time.Millisecond)
+	DefaultMaxWALTime        = int64(4 * time.Hour / time.Millisecond)
+)
+
+// Options of the WAL storage.
+type Options struct {
+	// Segments (wal files) max size.
+	// WALSegmentSize <= 0, segment size is default size.
+	// WALSegmentSize > 0, segment size is WALSegmentSize.
+	WALSegmentSize int
+
+	// WALCompression configures the compression type to use on records in the WAL.
+	WALCompression compression.Type
+
+	// StripeSize is the size (power of 2) in entries of the series hash map. Reducing the size will save memory but impact performance.
+	StripeSize int
+
+	// TruncateFrequency determines how frequently to truncate data from the WAL.
+	TruncateFrequency time.Duration
+
+	// Shortest and longest amount of time data can exist in the WAL before being
+	// deleted.
+	MinWALTime, MaxWALTime int64
+
+	// NoLockfile disables creation and consideration of a lock file.
+	NoLockfile bool
+
+	// OutOfOrderTimeWindow specifies how much out of order is allowed, if any.
+	OutOfOrderTimeWindow int64
+}
+
+// DefaultOptions used for the WAL storage. They are reasonable for setups using
+// millisecond-precision timestamps.
+func DefaultOptions() *Options {
+	return &Options{
+		WALSegmentSize:       wlog.DefaultSegmentSize,
+		WALCompression:       compression.None,
+		StripeSize:           tsdb.DefaultStripeSize,
+		TruncateFrequency:    DefaultTruncateFrequency,
+		MinWALTime:           DefaultMinWALTime,
+		MaxWALTime:           DefaultMaxWALTime,
+		NoLockfile:           false,
+		OutOfOrderTimeWindow: 0,
+	}
+}
+
+type dbMetrics struct {
+	r prometheus.Registerer
+
+	numActiveSeries             prometheus.Gauge
+	numWALSeriesPendingDeletion prometheus.Gauge
+	totalAppendedSamples        *prometheus.CounterVec
+	totalAppendedExemplars      prometheus.Counter
+	totalOutOfOrderSamples      prometheus.Counter
+	walTruncateDuration         prometheus.Summary
+	walCorruptionsTotal         prometheus.Counter
+	walTotalReplayDuration      prometheus.Gauge
+	checkpointDeleteFail        prometheus.Counter
+	checkpointDeleteTotal       prometheus.Counter
+	checkpointCreationFail      prometheus.Counter
+	checkpointCreationTotal     prometheus.Counter
+}
+
+func newDBMetrics(r prometheus.Registerer) *dbMetrics {
+	m := dbMetrics{r: r}
+	m.numActiveSeries = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_agent_active_series",
+		Help: "Number of active series being tracked by the WAL storage",
+	})
+
+	m.numWALSeriesPendingDeletion = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_agent_deleted_series",
+		Help: "Number of series pending deletion from the WAL",
+	})
+
+	m.totalAppendedSamples = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_agent_samples_appended_total",
+		Help: "Total number of samples appended to the storage",
+	}, []string{"type"})
+
+	m.totalAppendedExemplars = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_agent_exemplars_appended_total",
+		Help: "Total number of exemplars appended to the storage",
+	})
+
+	m.totalOutOfOrderSamples = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_agent_out_of_order_samples_total",
+		Help: "Total number of out of order samples ingestion failed attempts.",
+	})
+
+	m.walTruncateDuration = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "prometheus_agent_truncate_duration_seconds",
+		Help: "Duration of WAL truncation.",
+	})
+
+	m.walCorruptionsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_agent_corruptions_total",
+		Help: "Total number of WAL corruptions.",
+	})
+
+	m.walTotalReplayDuration = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_agent_data_replay_duration_seconds",
+		Help: "Time taken to replay the data on disk.",
+	})
+
+	m.checkpointDeleteFail = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_agent_checkpoint_deletions_failed_total",
+		Help: "Total number of checkpoint deletions that failed.",
+	})
+
+	m.checkpointDeleteTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_agent_checkpoint_deletions_total",
+		Help: "Total number of checkpoint deletions attempted.",
+	})
+
+	m.checkpointCreationFail = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_agent_checkpoint_creations_failed_total",
+		Help: "Total number of checkpoint creations that failed.",
+	})
+
+	m.checkpointCreationTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_agent_checkpoint_creations_total",
+		Help: "Total number of checkpoint creations attempted.",
+	})
+
+	if r != nil {
+		r.MustRegister(
+			m.numActiveSeries,
+			m.numWALSeriesPendingDeletion,
+			m.totalAppendedSamples,
+			m.totalAppendedExemplars,
+			m.totalOutOfOrderSamples,
+			m.walTruncateDuration,
+			m.walCorruptionsTotal,
+			m.walTotalReplayDuration,
+			m.checkpointDeleteFail,
+			m.checkpointDeleteTotal,
+			m.checkpointCreationFail,
+			m.checkpointCreationTotal,
+		)
+	}
+
+	return &m
+}
+
+func (m *dbMetrics) Unregister() {
+	if m.r == nil {
+		return
+	}
+	cs := []prometheus.Collector{
+		m.numActiveSeries,
+		m.numWALSeriesPendingDeletion,
+		m.totalAppendedSamples,
+		m.totalAppendedExemplars,
+		m.totalOutOfOrderSamples,
+		m.walTruncateDuration,
+		m.walCorruptionsTotal,
+		m.walTotalReplayDuration,
+		m.checkpointDeleteFail,
+		m.checkpointDeleteTotal,
+		m.checkpointCreationFail,
+		m.checkpointCreationTotal,
+	}
+	for _, c := range cs {
+		m.r.Unregister(c)
+	}
+}
+
+// DB represents a WAL-only storage. It implements storage.DB.
+type DB struct {
+	mtx    sync.RWMutex
+	logger *slog.Logger
+	opts   *Options
+	rs     *remote.Storage
+
+	wal    *wlog.WL
+	locker *tsdbutil.DirLocker
+
+	appenderPool sync.Pool
+	bufPool      sync.Pool
+
+	// These pools are only used during WAL replay and are reset at the end.
+	// NOTE: Adjust resetWALReplayResources() upon changes to the pools.
+	walReplaySeriesPool          zeropool.Pool[[]record.RefSeries]
+	walReplaySamplesPool         zeropool.Pool[[]record.RefSample]
+	walReplayHistogramsPool      zeropool.Pool[[]record.RefHistogramSample]
+	walReplayFloatHistogramsPool zeropool.Pool[[]record.RefFloatHistogramSample]
+
+	nextRef *atomic.Uint64
+	series  *stripeSeries
+	// deleted is a map of (ref IDs that should be deleted from WAL) to (the WAL segment they
+	// must be kept around to).
+	deleted map[chunks.HeadSeriesRef]int
+
+	donec chan struct{}
+	stopc chan struct{}
+
+	writeNotified wlog.WriteNotified
+
+	metrics *dbMetrics
+}
+
+// Open returns a new agent.DB in the given directory.
+func Open(l *slog.Logger, reg prometheus.Registerer, rs *remote.Storage, dir string, opts *Options) (*DB, error) {
+	opts = validateOptions(opts)
+
+	locker, err := tsdbutil.NewDirLocker(dir, "agent", l, reg)
+	if err != nil {
+		return nil, err
+	}
+	if !opts.NoLockfile {
+		if err := locker.Lock(); err != nil {
+			return nil, err
+		}
+	}
+
+	// remote_write expects WAL to be stored in a "wal" subdirectory of the main storage.
+	dir = filepath.Join(dir, "wal")
+
+	w, err := wlog.NewSize(l, reg, dir, opts.WALSegmentSize, opts.WALCompression)
+	if err != nil {
+		return nil, fmt.Errorf("creating WAL: %w", err)
+	}
+
+	db := &DB{
+		logger: l,
+		opts:   opts,
+		rs:     rs,
+
+		wal:    w,
+		locker: locker,
+
+		nextRef: atomic.NewUint64(0),
+		series:  newStripeSeries(opts.StripeSize),
+		deleted: make(map[chunks.HeadSeriesRef]int),
+
+		donec: make(chan struct{}),
+		stopc: make(chan struct{}),
+
+		metrics: newDBMetrics(reg),
+	}
+
+	db.bufPool.New = func() interface{} {
+		return make([]byte, 0, 1024)
+	}
+
+	db.appenderPool.New = func() interface{} {
+		return &appender{
+			DB:                     db,
+			pendingSeries:          make([]record.RefSeries, 0, 100),
+			pendingSamples:         make([]record.RefSample, 0, 100),
+			pendingHistograms:      make([]record.RefHistogramSample, 0, 100),
+			pendingFloatHistograms: make([]record.RefFloatHistogramSample, 0, 100),
+			pendingExamplars:       make([]record.RefExemplar, 0, 10),
+		}
+	}
+
+	if err := db.replayWAL(); err != nil {
+		db.logger.Warn("encountered WAL read error, attempting repair", "err", err)
+		if err := w.Repair(err); err != nil {
+			return nil, fmt.Errorf("repair corrupted WAL: %w", err)
+		}
+		db.logger.Info("successfully repaired WAL")
+	}
+
+	go db.run()
+	return db, nil
+}
+
+// SetWriteNotified allows to set an instance to notify when a write happens.
+// It must be used during initialization. It is not safe to use it during execution.
+func (db *DB) SetWriteNotified(wn wlog.WriteNotified) {
+	db.writeNotified = wn
+}
+
+func validateOptions(opts *Options) *Options {
+	if opts == nil {
+		opts = DefaultOptions()
+	}
+	if opts.WALSegmentSize <= 0 {
+		opts.WALSegmentSize = wlog.DefaultSegmentSize
+	}
+
+	if opts.WALCompression == "" {
+		opts.WALCompression = compression.None
+	}
+
+	// Revert StripeSize to DefaultStripeSize if StripeSize is either 0 or not a power of 2.
+	if opts.StripeSize <= 0 || ((opts.StripeSize & (opts.StripeSize - 1)) != 0) {
+		opts.StripeSize = tsdb.DefaultStripeSize
+	}
+	if opts.TruncateFrequency <= 0 {
+		opts.TruncateFrequency = DefaultTruncateFrequency
+	}
+	if opts.MinWALTime <= 0 {
+		opts.MinWALTime = DefaultMinWALTime
+	}
+	if opts.MaxWALTime <= 0 {
+		opts.MaxWALTime = DefaultMaxWALTime
+	}
+	if opts.MinWALTime > opts.MaxWALTime {
+		opts.MaxWALTime = opts.MinWALTime
+	}
+
+	if t := int64(opts.TruncateFrequency / time.Millisecond); opts.MaxWALTime < t {
+		opts.MaxWALTime = t
+	}
+	return opts
+}
+
+func (db *DB) replayWAL() error {
+	db.logger.Info("replaying WAL, this may take a while", "dir", db.wal.Dir())
+	defer db.resetWALReplayResources()
+	start := time.Now()
+
+	dir, startFrom, err := wlog.LastCheckpoint(db.wal.Dir())
+	if err != nil && !errors.Is(err, record.ErrNotFound) {
+		return fmt.Errorf("find last checkpoint: %w", err)
+	}
+
+	multiRef := map[chunks.HeadSeriesRef]chunks.HeadSeriesRef{}
+
+	if err == nil {
+		sr, err := wlog.NewSegmentsReader(dir)
+		if err != nil {
+			return fmt.Errorf("open checkpoint: %w", err)
+		}
+		defer func() {
+			if err := sr.Close(); err != nil {
+				db.logger.Warn("error while closing the wal segments reader", "err", err)
+			}
+		}()
+
+		// A corrupted checkpoint is a hard error for now and requires user
+		// intervention. There's likely little data that can be recovered anyway.
+		if err := db.loadWAL(wlog.NewReader(sr), multiRef); err != nil {
+			return fmt.Errorf("backfill checkpoint: %w", err)
+		}
+		startFrom++
+		db.logger.Info("WAL checkpoint loaded")
+	}
+
+	// Find the last segment.
+	_, last, err := wlog.Segments(db.wal.Dir())
+	if err != nil {
+		return fmt.Errorf("finding WAL segments: %w", err)
+	}
+
+	// Backfill segments from the most recent checkpoint onwards.
+	for i := startFrom; i <= last; i++ {
+		seg, err := wlog.OpenReadSegment(wlog.SegmentName(db.wal.Dir(), i))
+		if err != nil {
+			return fmt.Errorf("open WAL segment: %d: %w", i, err)
+		}
+
+		sr := wlog.NewSegmentBufReader(seg)
+		err = db.loadWAL(wlog.NewReader(sr), multiRef)
+		if err := sr.Close(); err != nil {
+			db.logger.Warn("error while closing the wal segments reader", "err", err)
+		}
+		if err != nil {
+			return err
+		}
+		db.logger.Info("WAL segment loaded", "segment", i, "maxSegment", last)
+	}
+
+	walReplayDuration := time.Since(start)
+	db.metrics.walTotalReplayDuration.Set(walReplayDuration.Seconds())
+
+	return nil
+}
+
+func (db *DB) resetWALReplayResources() {
+	db.walReplaySeriesPool = zeropool.Pool[[]record.RefSeries]{}
+	db.walReplaySamplesPool = zeropool.Pool[[]record.RefSample]{}
+	db.walReplayHistogramsPool = zeropool.Pool[[]record.RefHistogramSample]{}
+	db.walReplayFloatHistogramsPool = zeropool.Pool[[]record.RefFloatHistogramSample]{}
+}
+
+func (db *DB) loadWAL(r *wlog.Reader, multiRef map[chunks.HeadSeriesRef]chunks.HeadSeriesRef) (err error) {
+	var (
+		syms    = labels.NewSymbolTable() // One table for the whole WAL.
+		dec     = record.NewDecoder(syms)
+		lastRef = chunks.HeadSeriesRef(db.nextRef.Load())
+
+		decoded = make(chan interface{}, 10)
+		errCh   = make(chan error, 1)
+	)
+
+	go func() {
+		defer close(decoded)
+		var err error
+		for r.Next() {
+			rec := r.Record()
+			switch dec.Type(rec) {
+			case record.Series:
+				series := db.walReplaySeriesPool.Get()[:0]
+				series, err = dec.Series(rec, series)
+				if err != nil {
+					errCh <- &wlog.CorruptionErr{
+						Err:     fmt.Errorf("decode series: %w", err),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- series
+			case record.Samples:
+				samples := db.walReplaySamplesPool.Get()[:0]
+				samples, err = dec.Samples(rec, samples)
+				if err != nil {
+					errCh <- &wlog.CorruptionErr{
+						Err:     fmt.Errorf("decode samples: %w", err),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- samples
+			case record.HistogramSamples, record.CustomBucketsHistogramSamples:
+				histograms := db.walReplayHistogramsPool.Get()[:0]
+				histograms, err = dec.HistogramSamples(rec, histograms)
+				if err != nil {
+					errCh <- &wlog.CorruptionErr{
+						Err:     fmt.Errorf("decode histogram samples: %w", err),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- histograms
+			case record.FloatHistogramSamples, record.CustomBucketsFloatHistogramSamples:
+				floatHistograms := db.walReplayFloatHistogramsPool.Get()[:0]
+				floatHistograms, err = dec.FloatHistogramSamples(rec, floatHistograms)
+				if err != nil {
+					errCh <- &wlog.CorruptionErr{
+						Err:     fmt.Errorf("decode float histogram samples: %w", err),
+						Segment: r.Segment(),
+						Offset:  r.Offset(),
+					}
+					return
+				}
+				decoded <- floatHistograms
+			case record.Tombstones, record.Exemplars:
+				// We don't care about tombstones or exemplars during replay.
+				// TODO: If decide to decode exemplars, we should make sure to prepopulate
+				// stripeSeries.exemplars in the next block by using setLatestExemplar.
+				continue
+			default:
+				errCh <- &wlog.CorruptionErr{
+					Err:     fmt.Errorf("invalid record type %v", dec.Type(rec)),
+					Segment: r.Segment(),
+					Offset:  r.Offset(),
+				}
+			}
+		}
+	}()
+
+	var nonExistentSeriesRefs atomic.Uint64
+
+	for d := range decoded {
+		switch v := d.(type) {
+		case []record.RefSeries:
+			for _, entry := range v {
+				// If this is a new series, create it in memory. If we never read in a
+				// sample for this series, its timestamp will remain at 0 and it will
+				// be deleted at the next GC.
+				if db.series.GetByID(entry.Ref) == nil {
+					series := &memSeries{ref: entry.Ref, lset: entry.Labels, lastTs: 0}
+					db.series.Set(entry.Labels.Hash(), series)
+					multiRef[entry.Ref] = series.ref
+					db.metrics.numActiveSeries.Inc()
+					if entry.Ref > lastRef {
+						lastRef = entry.Ref
+					}
+				}
+			}
+			db.walReplaySeriesPool.Put(v)
+		case []record.RefSample:
+			for _, entry := range v {
+				// Update the lastTs for the series based
+				ref, ok := multiRef[entry.Ref]
+				if !ok {
+					nonExistentSeriesRefs.Inc()
+					continue
+				}
+				series := db.series.GetByID(ref)
+				if entry.T > series.lastTs {
+					series.lastTs = entry.T
+				}
+			}
+			db.walReplaySamplesPool.Put(v)
+		case []record.RefHistogramSample:
+			for _, entry := range v {
+				// Update the lastTs for the series based
+				ref, ok := multiRef[entry.Ref]
+				if !ok {
+					nonExistentSeriesRefs.Inc()
+					continue
+				}
+				series := db.series.GetByID(ref)
+				if entry.T > series.lastTs {
+					series.lastTs = entry.T
+				}
+			}
+			db.walReplayHistogramsPool.Put(v)
+		case []record.RefFloatHistogramSample:
+			for _, entry := range v {
+				// Update the lastTs for the series based
+				ref, ok := multiRef[entry.Ref]
+				if !ok {
+					nonExistentSeriesRefs.Inc()
+					continue
+				}
+				series := db.series.GetByID(ref)
+				if entry.T > series.lastTs {
+					series.lastTs = entry.T
+				}
+			}
+			db.walReplayFloatHistogramsPool.Put(v)
+		default:
+			panic(fmt.Errorf("unexpected decoded type: %T", d))
+		}
+	}
+
+	if v := nonExistentSeriesRefs.Load(); v > 0 {
+		db.logger.Warn("found sample referencing non-existing series", "skipped_series", v)
+	}
+
+	db.nextRef.Store(uint64(lastRef))
+
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		if r.Err() != nil {
+			return fmt.Errorf("read records: %w", r.Err())
+		}
+		return nil
+	}
+}
+
+func (db *DB) run() {
+	defer close(db.donec)
+
+Loop:
+	for {
+		select {
+		case <-db.stopc:
+			break Loop
+		case <-time.After(db.opts.TruncateFrequency):
+			// The timestamp ts is used to determine which series are not receiving
+			// samples and may be deleted from the WAL. Their most recent append
+			// timestamp is compared to ts, and if that timestamp is older then ts,
+			// they are considered inactive and may be deleted.
+			//
+			// Subtracting a duration from ts will add a buffer for when series are
+			// considered inactive and safe for deletion.
+			ts := max(db.rs.LowestSentTimestamp()-db.opts.MinWALTime, 0)
+
+			// Network issues can prevent the result of getRemoteWriteTimestamp from
+			// changing. We don't want data in the WAL to grow forever, so we set a cap
+			// on the maximum age data can be. If our ts is older than this cutoff point,
+			// we'll shift it forward to start deleting very stale data.
+			if maxTS := timestamp.FromTime(time.Now()) - db.opts.MaxWALTime; ts < maxTS {
+				ts = maxTS
+			}
+
+			db.logger.Debug("truncating the WAL", "ts", ts)
+			if err := db.truncate(ts); err != nil {
+				db.logger.Warn("failed to truncate WAL", "err", err)
+			}
+		}
+	}
+}
+
+// keepSeriesInWALCheckpoint is used to determine whether a series record should be kept in the checkpoint
+// last is the last WAL segment that was considered for checkpointing.
+func (db *DB) keepSeriesInWALCheckpoint(id chunks.HeadSeriesRef, last int) bool {
+	// Keep the record if the series exists in the db.
+	if db.series.GetByID(id) != nil {
+		return true
+	}
+
+	// Keep the record if the series was recently deleted.
+	seg, ok := db.deleted[id]
+	return ok && seg > last
+}
+
+func (db *DB) truncate(mint int64) error {
+	db.mtx.RLock()
+	defer db.mtx.RUnlock()
+
+	start := time.Now()
+
+	db.gc(mint)
+	db.logger.Info("series GC completed", "duration", time.Since(start))
+
+	first, last, err := wlog.Segments(db.wal.Dir())
+	if err != nil {
+		return fmt.Errorf("get segment range: %w", err)
+	}
+
+	// Start a new segment so low ingestion volume instances don't have more WAL
+	// than needed.
+	if _, err := db.wal.NextSegment(); err != nil {
+		return fmt.Errorf("next segment: %w", err)
+	}
+
+	last-- // Never consider most recent segment for checkpoint
+	if last < 0 {
+		return nil // no segments yet
+	}
+
+	// The lower two-thirds of segments should contain mostly obsolete samples.
+	// If we have less than two segments, it's not worth checkpointing yet.
+	last = first + (last-first)*2/3
+	if last <= first {
+		return nil
+	}
+
+	db.metrics.checkpointCreationTotal.Inc()
+
+	if _, err = wlog.Checkpoint(db.logger, db.wal, first, last, db.keepSeriesInWALCheckpoint, mint); err != nil {
+		db.metrics.checkpointCreationFail.Inc()
+		var cerr *wlog.CorruptionErr
+		if errors.As(err, &cerr) {
+			db.metrics.walCorruptionsTotal.Inc()
+		}
+		return fmt.Errorf("create checkpoint: %w", err)
+	}
+	if err := db.wal.Truncate(last + 1); err != nil {
+		// If truncating fails, we'll just try it again at the next checkpoint.
+		// Leftover segments will still just be ignored in the future if there's a
+		// checkpoint that supersedes them.
+		db.logger.Error("truncating segments failed", "err", err)
+	}
+
+	// The checkpoint is written and segments before it are truncated, so we
+	// no longer need to track deleted series that were being kept around.
+	for ref, segment := range db.deleted {
+		if segment <= last {
+			delete(db.deleted, ref)
+		}
+	}
+	db.metrics.checkpointDeleteTotal.Inc()
+	db.metrics.numWALSeriesPendingDeletion.Set(float64(len(db.deleted)))
+
+	if err := wlog.DeleteCheckpoints(db.wal.Dir(), last); err != nil {
+		// Leftover old checkpoints do not cause problems down the line beyond
+		// occupying disk space. They will just be ignored since a newer checkpoint
+		// exists.
+		db.logger.Error("delete old checkpoints", "err", err)
+		db.metrics.checkpointDeleteFail.Inc()
+	}
+
+	db.metrics.walTruncateDuration.Observe(time.Since(start).Seconds())
+
+	db.logger.Info("WAL checkpoint complete", "first", first, "last", last, "duration", time.Since(start))
+	return nil
+}
+
+// gc marks ref IDs that have not received a sample since mint as deleted in
+// s.deleted, along with the segment where they originally got deleted.
+func (db *DB) gc(mint int64) {
+	deleted := db.series.GC(mint)
+	db.metrics.numActiveSeries.Sub(float64(len(deleted)))
+
+	_, last, _ := wlog.Segments(db.wal.Dir())
+
+	// We want to keep series records for any newly deleted series
+	// until we've passed the last recorded segment. This prevents
+	// the WAL having samples for series records that no longer exist.
+	for ref := range deleted {
+		db.deleted[ref] = last
+	}
+
+	db.metrics.numWALSeriesPendingDeletion.Set(float64(len(db.deleted)))
+}
+
+// StartTime implements the Storage interface.
+func (db *DB) StartTime() (int64, error) {
+	return int64(model.Latest), nil
+}
+
+// Querier implements the Storage interface.
+func (db *DB) Querier(int64, int64) (storage.Querier, error) {
+	return nil, ErrUnsupported
+}
+
+// ChunkQuerier implements the Storage interface.
+func (db *DB) ChunkQuerier(int64, int64) (storage.ChunkQuerier, error) {
+	return nil, ErrUnsupported
+}
+
+// ExemplarQuerier implements the Storage interface.
+func (db *DB) ExemplarQuerier(context.Context) (storage.ExemplarQuerier, error) {
+	return nil, ErrUnsupported
+}
+
+// Appender implements storage.Storage.
+func (db *DB) Appender(context.Context) storage.Appender {
+	return db.appenderPool.Get().(storage.Appender)
+}
+
+// Close implements the Storage interface.
+func (db *DB) Close() error {
+	db.mtx.Lock()
+	defer db.mtx.Unlock()
+
+	close(db.stopc)
+	<-db.donec
+
+	db.metrics.Unregister()
+
+	return tsdb_errors.NewMulti(db.locker.Release(), db.wal.Close()).Err()
+}
+
+type appender struct {
+	*DB
+	hints *storage.AppendOptions
+
+	pendingSeries          []record.RefSeries
+	pendingSamples         []record.RefSample
+	pendingHistograms      []record.RefHistogramSample
+	pendingFloatHistograms []record.RefFloatHistogramSample
+	pendingExamplars       []record.RefExemplar
+
+	// Pointers to the series referenced by each element of pendingSamples.
+	// Series lock is not held on elements.
+	sampleSeries []*memSeries
+
+	// Pointers to the series referenced by each element of pendingHistograms.
+	// Series lock is not held on elements.
+	histogramSeries []*memSeries
+
+	// Pointers to the series referenced by each element of pendingFloatHistograms.
+	// Series lock is not held on elements.
+	floatHistogramSeries []*memSeries
+}
+
+func (a *appender) SetOptions(opts *storage.AppendOptions) {
+	a.hints = opts
+}
+
+func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v float64) (storage.SeriesRef, error) {
+	// series references and chunk references are identical for agent mode.
+	headRef := chunks.HeadSeriesRef(ref)
+
+	series := a.series.GetByID(headRef)
+	if series == nil {
+		// Ensure no empty or duplicate labels have gotten through. This mirrors the
+		// equivalent validation code in the TSDB's headAppender.
+		l = l.WithoutEmpty()
+		if l.IsEmpty() {
+			return 0, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
+		}
+
+		if lbl, dup := l.HasDuplicateLabelNames(); dup {
+			return 0, fmt.Errorf(`label name "%s" is not unique: %w`, lbl, tsdb.ErrInvalidSample)
+		}
+
+		var created bool
+		series, created = a.getOrCreate(l)
+		if created {
+			a.pendingSeries = append(a.pendingSeries, record.RefSeries{
+				Ref:    series.ref,
+				Labels: l,
+			})
+
+			a.metrics.numActiveSeries.Inc()
+		}
+	}
+
+	series.Lock()
+	defer series.Unlock()
+
+	if t <= a.minValidTime(series.lastTs) {
+		a.metrics.totalOutOfOrderSamples.Inc()
+		return 0, storage.ErrOutOfOrderSample
+	}
+
+	// NOTE: always modify pendingSamples and sampleSeries together.
+	a.pendingSamples = append(a.pendingSamples, record.RefSample{
+		Ref: series.ref,
+		T:   t,
+		V:   v,
+	})
+	a.sampleSeries = append(a.sampleSeries, series)
+
+	a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
+	return storage.SeriesRef(series.ref), nil
+}
+
+func (a *appender) getOrCreate(l labels.Labels) (series *memSeries, created bool) {
+	hash := l.Hash()
+
+	series = a.series.GetByHash(hash, l)
+	if series != nil {
+		return series, false
+	}
+
+	ref := chunks.HeadSeriesRef(a.nextRef.Inc())
+	series = &memSeries{ref: ref, lset: l, lastTs: math.MinInt64}
+	a.series.Set(hash, series)
+	return series, true
+}
+
+func (a *appender) AppendExemplar(ref storage.SeriesRef, _ labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+	// Series references and chunk references are identical for agent mode.
+	headRef := chunks.HeadSeriesRef(ref)
+
+	s := a.series.GetByID(headRef)
+	if s == nil {
+		return 0, fmt.Errorf("unknown series ref when trying to add exemplar: %d", ref)
+	}
+
+	// Ensure no empty labels have gotten through.
+	e.Labels = e.Labels.WithoutEmpty()
+
+	if lbl, dup := e.Labels.HasDuplicateLabelNames(); dup {
+		return 0, fmt.Errorf(`label name "%s" is not unique: %w`, lbl, tsdb.ErrInvalidExemplar)
+	}
+
+	// Exemplar label length does not include chars involved in text rendering such as quotes
+	// equals sign, or commas. See definition of const ExemplarMaxLabelLength.
+	labelSetLen := 0
+	err := e.Labels.Validate(func(l labels.Label) error {
+		labelSetLen += utf8.RuneCountInString(l.Name)
+		labelSetLen += utf8.RuneCountInString(l.Value)
+
+		if labelSetLen > exemplar.ExemplarMaxLabelSetLength {
+			return storage.ErrExemplarLabelLength
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Check for duplicate vs last stored exemplar for this series, and discard those.
+	// Otherwise, record the current exemplar as the latest.
+	// Prometheus' TSDB returns 0 when encountering duplicates, so we do the same here.
+	prevExemplar := a.series.GetLatestExemplar(s.ref)
+	if prevExemplar != nil && prevExemplar.Equals(e) {
+		// Duplicate, don't return an error but don't accept the exemplar.
+		return 0, nil
+	}
+	a.series.SetLatestExemplar(s.ref, &e)
+
+	a.pendingExamplars = append(a.pendingExamplars, record.RefExemplar{
+		Ref:    s.ref,
+		T:      e.Ts,
+		V:      e.Value,
+		Labels: e.Labels,
+	})
+
+	a.metrics.totalAppendedExemplars.Inc()
+	return storage.SeriesRef(s.ref), nil
+}
+
+func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	if h != nil {
+		if err := h.Validate(); err != nil {
+			return 0, err
+		}
+	}
+
+	if fh != nil {
+		if err := fh.Validate(); err != nil {
+			return 0, err
+		}
+	}
+
+	// series references and chunk references are identical for agent mode.
+	headRef := chunks.HeadSeriesRef(ref)
+
+	series := a.series.GetByID(headRef)
+	if series == nil {
+		// Ensure no empty or duplicate labels have gotten through. This mirrors the
+		// equivalent validation code in the TSDB's headAppender.
+		l = l.WithoutEmpty()
+		if l.IsEmpty() {
+			return 0, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
+		}
+
+		if lbl, dup := l.HasDuplicateLabelNames(); dup {
+			return 0, fmt.Errorf(`label name "%s" is not unique: %w`, lbl, tsdb.ErrInvalidSample)
+		}
+
+		var created bool
+		series, created = a.getOrCreate(l)
+		if created {
+			a.pendingSeries = append(a.pendingSeries, record.RefSeries{
+				Ref:    series.ref,
+				Labels: l,
+			})
+
+			a.metrics.numActiveSeries.Inc()
+		}
+	}
+
+	series.Lock()
+	defer series.Unlock()
+
+	if t <= a.minValidTime(series.lastTs) {
+		a.metrics.totalOutOfOrderSamples.Inc()
+		return 0, storage.ErrOutOfOrderSample
+	}
+
+	switch {
+	case h != nil:
+		// NOTE: always modify pendingHistograms and histogramSeries together
+		a.pendingHistograms = append(a.pendingHistograms, record.RefHistogramSample{
+			Ref: series.ref,
+			T:   t,
+			H:   h,
+		})
+		a.histogramSeries = append(a.histogramSeries, series)
+	case fh != nil:
+		// NOTE: always modify pendingFloatHistograms and floatHistogramSeries together
+		a.pendingFloatHistograms = append(a.pendingFloatHistograms, record.RefFloatHistogramSample{
+			Ref: series.ref,
+			T:   t,
+			FH:  fh,
+		})
+		a.floatHistogramSeries = append(a.floatHistogramSeries, series)
+	}
+
+	a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
+	return storage.SeriesRef(series.ref), nil
+}
+
+func (a *appender) UpdateMetadata(storage.SeriesRef, labels.Labels, metadata.Metadata) (storage.SeriesRef, error) {
+	// TODO: Wire metadata in the Agent's appender.
+	return 0, nil
+}
+
+func (a *appender) AppendHistogramCTZeroSample(ref storage.SeriesRef, l labels.Labels, t, ct int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+	if h != nil {
+		if err := h.Validate(); err != nil {
+			return 0, err
+		}
+	}
+	if fh != nil {
+		if err := fh.Validate(); err != nil {
+			return 0, err
+		}
+	}
+	if ct >= t {
+		return 0, storage.ErrCTNewerThanSample
+	}
+
+	series := a.series.GetByID(chunks.HeadSeriesRef(ref))
+	if series == nil {
+		// Ensure no empty labels have gotten through.
+		l = l.WithoutEmpty()
+		if l.IsEmpty() {
+			return 0, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
+		}
+
+		if lbl, dup := l.HasDuplicateLabelNames(); dup {
+			return 0, fmt.Errorf(`label name "%s" is not unique: %w`, lbl, tsdb.ErrInvalidSample)
+		}
+
+		var created bool
+		series, created = a.getOrCreate(l)
+		if created {
+			a.pendingSeries = append(a.pendingSeries, record.RefSeries{
+				Ref:    series.ref,
+				Labels: l,
+			})
+			a.metrics.numActiveSeries.Inc()
+		}
+	}
+
+	series.Lock()
+	defer series.Unlock()
+
+	if ct <= a.minValidTime(series.lastTs) {
+		return 0, storage.ErrOutOfOrderCT
+	}
+
+	if ct <= series.lastTs {
+		// discard the sample if it's out of order.
+		return 0, storage.ErrOutOfOrderCT
+	}
+	series.lastTs = ct
+
+	switch {
+	case h != nil:
+		zeroHistogram := &histogram.Histogram{}
+		a.pendingHistograms = append(a.pendingHistograms, record.RefHistogramSample{
+			Ref: series.ref,
+			T:   ct,
+			H:   zeroHistogram,
+		})
+		a.histogramSeries = append(a.histogramSeries, series)
+	case fh != nil:
+		a.pendingFloatHistograms = append(a.pendingFloatHistograms, record.RefFloatHistogramSample{
+			Ref: series.ref,
+			T:   ct,
+			FH:  &histogram.FloatHistogram{},
+		})
+		a.floatHistogramSeries = append(a.floatHistogramSeries, series)
+	}
+
+	a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeHistogram).Inc()
+	return storage.SeriesRef(series.ref), nil
+}
+
+func (a *appender) AppendCTZeroSample(ref storage.SeriesRef, l labels.Labels, t, ct int64) (storage.SeriesRef, error) {
+	if ct >= t {
+		return 0, storage.ErrCTNewerThanSample
+	}
+
+	series := a.series.GetByID(chunks.HeadSeriesRef(ref))
+	if series == nil {
+		l = l.WithoutEmpty()
+		if l.IsEmpty() {
+			return 0, fmt.Errorf("empty labelset: %w", tsdb.ErrInvalidSample)
+		}
+
+		if lbl, dup := l.HasDuplicateLabelNames(); dup {
+			return 0, fmt.Errorf(`label name "%s" is not unique: %w`, lbl, tsdb.ErrInvalidSample)
+		}
+
+		newSeries, created := a.getOrCreate(l)
+		if created {
+			a.pendingSeries = append(a.pendingSeries, record.RefSeries{
+				Ref:    newSeries.ref,
+				Labels: l,
+			})
+			a.metrics.numActiveSeries.Inc()
+		}
+
+		series = newSeries
+	}
+
+	series.Lock()
+	defer series.Unlock()
+
+	if t <= a.minValidTime(series.lastTs) {
+		a.metrics.totalOutOfOrderSamples.Inc()
+		return 0, storage.ErrOutOfOrderSample
+	}
+
+	if ct <= series.lastTs {
+		// discard the sample if it's out of order.
+		return 0, storage.ErrOutOfOrderCT
+	}
+	series.lastTs = ct
+
+	// NOTE: always modify pendingSamples and sampleSeries together.
+	a.pendingSamples = append(a.pendingSamples, record.RefSample{
+		Ref: series.ref,
+		T:   ct,
+		V:   0,
+	})
+	a.sampleSeries = append(a.sampleSeries, series)
+
+	a.metrics.totalAppendedSamples.WithLabelValues(sampleMetricTypeFloat).Inc()
+
+	return storage.SeriesRef(series.ref), nil
+}
+
+// Commit submits the collected samples and purges the batch.
+func (a *appender) Commit() error {
+	if err := a.log(); err != nil {
+		return err
+	}
+
+	a.clearData()
+	a.appenderPool.Put(a)
+
+	if a.writeNotified != nil {
+		a.writeNotified.Notify()
+	}
+	return nil
+}
+
+// log logs all pending data to the WAL.
+func (a *appender) log() error {
+	a.mtx.RLock()
+	defer a.mtx.RUnlock()
+
+	var encoder record.Encoder
+	buf := a.bufPool.Get().([]byte)
+	defer func() {
+		a.bufPool.Put(buf) //nolint:staticcheck
+	}()
+
+	if len(a.pendingSeries) > 0 {
+		buf = encoder.Series(a.pendingSeries, buf)
+		if err := a.wal.Log(buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+	}
+
+	if len(a.pendingSamples) > 0 {
+		buf = encoder.Samples(a.pendingSamples, buf)
+		if err := a.wal.Log(buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+	}
+
+	if len(a.pendingHistograms) > 0 {
+		var customBucketsHistograms []record.RefHistogramSample
+		buf, customBucketsHistograms = encoder.HistogramSamples(a.pendingHistograms, buf)
+		if len(buf) > 0 {
+			if err := a.wal.Log(buf); err != nil {
+				return err
+			}
+			buf = buf[:0]
+		}
+		if len(customBucketsHistograms) > 0 {
+			buf = encoder.CustomBucketsHistogramSamples(customBucketsHistograms, nil)
+			if err := a.wal.Log(buf); err != nil {
+				return err
+			}
+			buf = buf[:0]
+		}
+	}
+
+	if len(a.pendingFloatHistograms) > 0 {
+		var customBucketsFloatHistograms []record.RefFloatHistogramSample
+		buf, customBucketsFloatHistograms = encoder.FloatHistogramSamples(a.pendingFloatHistograms, buf)
+		if len(buf) > 0 {
+			if err := a.wal.Log(buf); err != nil {
+				return err
+			}
+			buf = buf[:0]
+		}
+		if len(customBucketsFloatHistograms) > 0 {
+			buf = encoder.CustomBucketsFloatHistogramSamples(customBucketsFloatHistograms, nil)
+			if err := a.wal.Log(buf); err != nil {
+				return err
+			}
+			buf = buf[:0]
+		}
+	}
+
+	if len(a.pendingExamplars) > 0 {
+		buf = encoder.Exemplars(a.pendingExamplars, buf)
+		if err := a.wal.Log(buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+	}
+
+	var series *memSeries
+	for i, s := range a.pendingSamples {
+		series = a.sampleSeries[i]
+		if !series.updateTimestamp(s.T) {
+			a.metrics.totalOutOfOrderSamples.Inc()
+		}
+	}
+	for i, s := range a.pendingHistograms {
+		series = a.histogramSeries[i]
+		if !series.updateTimestamp(s.T) {
+			a.metrics.totalOutOfOrderSamples.Inc()
+		}
+	}
+	for i, s := range a.pendingFloatHistograms {
+		series = a.floatHistogramSeries[i]
+		if !series.updateTimestamp(s.T) {
+			a.metrics.totalOutOfOrderSamples.Inc()
+		}
+	}
+
+	return nil
+}
+
+// clearData clears all pending data.
+func (a *appender) clearData() {
+	a.pendingSeries = a.pendingSeries[:0]
+	a.pendingSamples = a.pendingSamples[:0]
+	a.pendingHistograms = a.pendingHistograms[:0]
+	a.pendingFloatHistograms = a.pendingFloatHistograms[:0]
+	a.pendingExamplars = a.pendingExamplars[:0]
+	a.sampleSeries = a.sampleSeries[:0]
+	a.histogramSeries = a.histogramSeries[:0]
+	a.floatHistogramSeries = a.floatHistogramSeries[:0]
+}
+
+func (a *appender) Rollback() error {
+	// Series are created in-memory regardless of rollback. This means we must
+	// log them to the WAL, otherwise subsequent commits may reference a series
+	// which was never written to the WAL.
+	if err := a.logSeries(); err != nil {
+		return err
+	}
+
+	a.clearData()
+	a.appenderPool.Put(a)
+	return nil
+}
+
+// logSeries logs only pending series records to the WAL.
+func (a *appender) logSeries() error {
+	a.mtx.RLock()
+	defer a.mtx.RUnlock()
+
+	if len(a.pendingSeries) > 0 {
+		buf := a.bufPool.Get().([]byte)
+		defer func() {
+			a.bufPool.Put(buf) //nolint:staticcheck
+		}()
+
+		var encoder record.Encoder
+		buf = encoder.Series(a.pendingSeries, buf)
+		if err := a.wal.Log(buf); err != nil {
+			return err
+		}
+		buf = buf[:0]
+	}
+
+	return nil
+}
+
+// minValidTime returns the minimum timestamp that a sample can have
+// and is needed for preventing underflow.
+func (a *appender) minValidTime(lastTs int64) int64 {
+	if lastTs < math.MinInt64+a.opts.OutOfOrderTimeWindow {
+		return math.MinInt64
+	}
+
+	return lastTs - a.opts.OutOfOrderTimeWindow
+}

--- a/vendor/github.com/prometheus/prometheus/tsdb/agent/series.go
+++ b/vendor/github.com/prometheus/prometheus/tsdb/agent/series.go
@@ -1,0 +1,276 @@
+// Copyright 2021 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"sync"
+
+	"github.com/prometheus/prometheus/model/exemplar"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+)
+
+// memSeries is a chunkless version of tsdb.memSeries.
+type memSeries struct {
+	sync.Mutex
+
+	ref  chunks.HeadSeriesRef
+	lset labels.Labels
+
+	// Last recorded timestamp. Used by Storage.gc to determine if a series is
+	// stale.
+	lastTs int64
+}
+
+// updateTimestamp obtains the lock on s and will attempt to update lastTs.
+// fails if newTs < lastTs.
+func (m *memSeries) updateTimestamp(newTs int64) bool {
+	m.Lock()
+	defer m.Unlock()
+	if newTs >= m.lastTs {
+		m.lastTs = newTs
+		return true
+	}
+	return false
+}
+
+// seriesHashmap lets agent find a memSeries by its label set, via a 64-bit hash.
+// There is one map for the common case where the hash value is unique, and a
+// second map for the case that two series have the same hash value.
+// Each series is in only one of the maps. Its methods require the hash to be submitted
+// with the label set to avoid re-computing hash throughout the code.
+type seriesHashmap struct {
+	unique    map[uint64]*memSeries
+	conflicts map[uint64][]*memSeries
+}
+
+func (m *seriesHashmap) Get(hash uint64, lset labels.Labels) *memSeries {
+	if s, found := m.unique[hash]; found {
+		if labels.Equal(s.lset, lset) {
+			return s
+		}
+	}
+	for _, s := range m.conflicts[hash] {
+		if labels.Equal(s.lset, lset) {
+			return s
+		}
+	}
+	return nil
+}
+
+func (m *seriesHashmap) Set(hash uint64, s *memSeries) {
+	if existing, found := m.unique[hash]; !found || labels.Equal(existing.lset, s.lset) {
+		m.unique[hash] = s
+		return
+	}
+	if m.conflicts == nil {
+		m.conflicts = make(map[uint64][]*memSeries)
+	}
+	seriesSet := m.conflicts[hash]
+	for i, prev := range seriesSet {
+		if labels.Equal(prev.lset, s.lset) {
+			seriesSet[i] = s
+			return
+		}
+	}
+	m.conflicts[hash] = append(seriesSet, s)
+}
+
+func (m *seriesHashmap) Delete(hash uint64, ref chunks.HeadSeriesRef) {
+	var rem []*memSeries
+	unique, found := m.unique[hash]
+	switch {
+	case !found: // Supplied hash is not stored.
+		return
+	case unique.ref == ref:
+		conflicts := m.conflicts[hash]
+		if len(conflicts) == 0 { // Exactly one series with this hash was stored
+			delete(m.unique, hash)
+			return
+		}
+		m.unique[hash] = conflicts[0] // First remaining series goes in 'unique'.
+		rem = conflicts[1:]           // Keep the rest.
+	default: // The series to delete is somewhere in 'conflicts'. Keep all the ones that don't match.
+		for _, s := range m.conflicts[hash] {
+			if s.ref != ref {
+				rem = append(rem, s)
+			}
+		}
+	}
+	if len(rem) == 0 {
+		delete(m.conflicts, hash)
+	} else {
+		m.conflicts[hash] = rem
+	}
+}
+
+// stripeSeries locks modulo ranges of IDs and hashes to reduce lock
+// contention. The locks are padded to not be on the same cache line.
+// Filling the padded space with the maps was profiled to be slower -
+// likely due to the additional pointer dereferences.
+type stripeSeries struct {
+	size      int
+	series    []map[chunks.HeadSeriesRef]*memSeries
+	hashes    []seriesHashmap
+	exemplars []map[chunks.HeadSeriesRef]*exemplar.Exemplar
+	locks     []stripeLock
+
+	gcMut sync.Mutex
+}
+
+type stripeLock struct {
+	sync.RWMutex
+	// Padding to avoid multiple locks being on the same cache line.
+	_ [40]byte
+}
+
+func newStripeSeries(stripeSize int) *stripeSeries {
+	s := &stripeSeries{
+		size:      stripeSize,
+		series:    make([]map[chunks.HeadSeriesRef]*memSeries, stripeSize),
+		hashes:    make([]seriesHashmap, stripeSize),
+		exemplars: make([]map[chunks.HeadSeriesRef]*exemplar.Exemplar, stripeSize),
+		locks:     make([]stripeLock, stripeSize),
+	}
+	for i := range s.series {
+		s.series[i] = map[chunks.HeadSeriesRef]*memSeries{}
+	}
+	for i := range s.hashes {
+		s.hashes[i] = seriesHashmap{
+			unique:    map[uint64]*memSeries{},
+			conflicts: nil, // Initialized on demand in set().
+		}
+	}
+	for i := range s.exemplars {
+		s.exemplars[i] = map[chunks.HeadSeriesRef]*exemplar.Exemplar{}
+	}
+	return s
+}
+
+// GC garbage collects old series that have not received a sample after mint
+// and will fully delete them.
+func (s *stripeSeries) GC(mint int64) map[chunks.HeadSeriesRef]struct{} {
+	// NOTE(rfratto): GC will grab two locks, one for the hash and the other for
+	// series. It's not valid for any other function to grab both locks,
+	// otherwise a deadlock might occur when running GC in parallel with
+	// appending.
+	s.gcMut.Lock()
+	defer s.gcMut.Unlock()
+
+	deleted := map[chunks.HeadSeriesRef]struct{}{}
+
+	// For one series, truncate old chunks and check if any chunks left. If not, mark as deleted and collect the ID.
+	check := func(hashLock int, hash uint64, series *memSeries) {
+		series.Lock()
+
+		// Any series that has received a write since mint is still alive.
+		if series.lastTs >= mint {
+			series.Unlock()
+			return
+		}
+
+		// The series is stale. We need to obtain a second lock for the
+		// ref if it's different than the hash lock.
+		refLock := int(series.ref) & (s.size - 1)
+		if hashLock != refLock {
+			s.locks[refLock].Lock()
+		}
+
+		deleted[series.ref] = struct{}{}
+		delete(s.series[refLock], series.ref)
+		s.hashes[hashLock].Delete(hash, series.ref)
+
+		// Since the series is gone, we'll also delete
+		// the latest stored exemplar.
+		delete(s.exemplars[refLock], series.ref)
+
+		if hashLock != refLock {
+			s.locks[refLock].Unlock()
+		}
+		series.Unlock()
+	}
+
+	for hashLock := 0; hashLock < s.size; hashLock++ {
+		s.locks[hashLock].Lock()
+
+		for hash, all := range s.hashes[hashLock].conflicts {
+			for _, series := range all {
+				check(hashLock, hash, series)
+			}
+		}
+		for hash, series := range s.hashes[hashLock].unique {
+			check(hashLock, hash, series)
+		}
+
+		s.locks[hashLock].Unlock()
+	}
+
+	return deleted
+}
+
+func (s *stripeSeries) GetByID(id chunks.HeadSeriesRef) *memSeries {
+	refLock := uint64(id) & uint64(s.size-1)
+	s.locks[refLock].RLock()
+	defer s.locks[refLock].RUnlock()
+	return s.series[refLock][id]
+}
+
+func (s *stripeSeries) GetByHash(hash uint64, lset labels.Labels) *memSeries {
+	hashLock := hash & uint64(s.size-1)
+
+	s.locks[hashLock].RLock()
+	defer s.locks[hashLock].RUnlock()
+	return s.hashes[hashLock].Get(hash, lset)
+}
+
+func (s *stripeSeries) Set(hash uint64, series *memSeries) {
+	var (
+		hashLock = hash & uint64(s.size-1)
+		refLock  = uint64(series.ref) & uint64(s.size-1)
+	)
+
+	// We can't hold both locks at once otherwise we might deadlock with a
+	// simultaneous call to GC.
+	//
+	// We update s.series first because GC expects anything in s.hashes to
+	// already exist in s.series.
+	s.locks[refLock].Lock()
+	s.series[refLock][series.ref] = series
+	s.locks[refLock].Unlock()
+
+	s.locks[hashLock].Lock()
+	s.hashes[hashLock].Set(hash, series)
+	s.locks[hashLock].Unlock()
+}
+
+func (s *stripeSeries) GetLatestExemplar(ref chunks.HeadSeriesRef) *exemplar.Exemplar {
+	i := uint64(ref) & uint64(s.size-1)
+
+	s.locks[i].RLock()
+	exemplar := s.exemplars[i][ref]
+	s.locks[i].RUnlock()
+
+	return exemplar
+}
+
+func (s *stripeSeries) SetLatestExemplar(ref chunks.HeadSeriesRef, exemplar *exemplar.Exemplar) {
+	i := uint64(ref) & uint64(s.size-1)
+
+	// Make sure that's a valid series id and record its latest exemplar
+	s.locks[i].Lock()
+	if s.series[i][ref] != nil {
+		s.exemplars[i][ref] = exemplar
+	}
+	s.locks[i].Unlock()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -826,6 +826,7 @@ github.com/prometheus/prometheus/storage/remote/googleiam
 github.com/prometheus/prometheus/storage/remote/otlptranslator/prometheusremotewrite
 github.com/prometheus/prometheus/template
 github.com/prometheus/prometheus/tsdb
+github.com/prometheus/prometheus/tsdb/agent
 github.com/prometheus/prometheus/tsdb/chunkenc
 github.com/prometheus/prometheus/tsdb/chunks
 github.com/prometheus/prometheus/tsdb/encoding


### PR DESCRIPTION
## Problem

Fixes #771. After the Prometheus 3.5 migration, running promxy with `remote_write` configured floods the log with:

```
level=error msg="error tailing WAL" err="Segments: open /tmp/promxy-remote-wal-XXXX/wal: no such file or directory"
```

and **no samples are ever sent to the remote_write endpoint**.

## Root cause

The 3.5 migration (`01b9e338`) replaced promxy's `pkg/remote/` fork with upstream `storage/remote`. The two designs move data differently:

- **Old fork**: `Storage.Append()` pushed samples *directly* into each `QueueManager` (in-memory), no WAL.
- **Upstream**: `Storage.Appender()` returns a `timestampTracker` that **discards** sample values. The real data path is a TSDB/agent writing samples to `<dir>/wal`, which each `QueueManager`'s WAL watcher *tails*.

promxy has no local TSDB writing a WAL, so the migration only wired up half of upstream's model:

1. The `wal` subdir is never created → the watcher fails every tick with `error tailing WAL ... no such file or directory`.
2. Even if it existed, the `timestampTracker` appender throws the samples away, so alert/recording-rule data never reaches the endpoint.

This is why removing `rule_files`/`alerting`/`remote_write` makes it run, and why the reporter's pre-3.5 fork worked.

## Fix

Run an agent-mode (WAL-only) `tsdb/agent.DB` alongside `remote.Storage`, pointed at the same dir. Its appender writes the WAL records the queue managers consume, and it owns series management, checkpointing, and WAL truncation — the upstream-blessed way to do remote_write without a full TSDB (Prometheus Agent mode).

Because the agent appender is single-use (returns itself to a pool on `Commit`), `ProxyStorage.Appender` now stores the `Appendable` and hands out a fresh appender per call rather than a single shared instance. The agent DB and `remote.Storage` are reused across config reloads (as before) and closed together on shutdown.

No `go.mod`/`go.sum` changes — the `tsdb/agent` package was already a module dependency, just not vendored.

## Verification

- **Before**: reproduced the exact issue error; 0 remote_write POSTs received by a local sink over 20s.
- **After**: no WAL errors; WAL is created and replayed; actual remote_write POSTs reach the sink.
- Config reload (2× SIGHUP): no panic / double metrics-registration; single WAL dir reused.
- Added `pkg/proxystorage/remote_write_test.go` asserting the WAL dir is created, appends are accepted by the WAL-backed appender, and successive `Appender()` calls return distinct instances.
- Full package suite + `go build ./...` pass.

Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)