### PR TITLE
servergroup: log + metric when a server group has no targets (#742)

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -33,7 +33,10 @@ promxy:
   server_groups:
     # All upstream prometheus service discovery mechanisms are supported with the same
     # markup, all defined in https://github.com/prometheus/prometheus/blob/master/discovery/config/config.go#L33
-    - static_configs:
+    - # Optional human-readable name for this server group
+      name: primary-cluster
+      
+      static_configs:
         - targets:
           - localhost:9090
 
@@ -191,7 +194,9 @@ promxy:
         X-Promxy-Source: promxy-1
 
     # as many additional server groups as you have
-    - static_configs:
+    - name: secondary-cluster
+      
+      static_configs:
         - targets:
           - localhost:9091
       labels:

--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -33,9 +33,10 @@ promxy:
   server_groups:
     # All upstream prometheus service discovery mechanisms are supported with the same
     # markup, all defined in https://github.com/prometheus/prometheus/blob/master/discovery/config/config.go#L33
-    - # Optional human-readable name for this server group
+    - # Optional human-readable name for this server group; shown in logs and
+      # exposed as the `name` label on the server_group_targets metric. The
+      # group's ordinal is always included regardless of whether a name is set.
       name: primary-cluster
-      
       static_configs:
         - targets:
           - localhost:9090
@@ -195,7 +196,6 @@ promxy:
 
     # as many additional server groups as you have
     - name: secondary-cluster
-      
       static_configs:
         - targets:
           - localhost:9091

--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -33,13 +33,14 @@ promxy:
   server_groups:
     # All upstream prometheus service discovery mechanisms are supported with the same
     # markup, all defined in https://github.com/prometheus/prometheus/blob/master/discovery/config/config.go#L33
-    - # Optional human-readable name for this server group; shown in logs and
+    - static_configs:
+        - targets:
+          - localhost:9090
+
+      # Optional human-readable name for this server group; shown in logs and
       # exposed as the `name` label on the server_group_targets metric. The
       # group's ordinal is always included regardless of whether a name is set.
       name: primary-cluster
-      static_configs:
-        - targets:
-          - localhost:9090
 
       # labels to be added to metrics retrieved from this server_group
       labels:

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -40,6 +40,8 @@ const (
 // This is where the vast majority of options exist.
 type Config struct {
 	Ordinal int `yaml:"-"`
+	// Name is an optional human-readable identifier for this server group.
+	Name string `yaml:"name,omitempty"`
 	// RemoteRead directs promxy to load RAW data (meaning matrix selectors such as `foo[1h]`)
 	// through the RemoteRead API on prom.
 	// Pros:

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -101,6 +101,35 @@ type ServerGroup struct {
 	state atomic.Value
 }
 
+func (s *ServerGroup) groupIdentifier() string {
+	if s.Cfg != nil {
+		if s.Cfg.Name != "" {
+			return s.Cfg.Name
+		}
+		return fmt.Sprintf("ord=%d", s.Cfg.Ordinal)
+	}
+	return "unknown"
+}
+
+func (s *ServerGroup) logTargetTransition(oldCount, newCount int, initial bool) {
+	ident := s.groupIdentifier()
+	fields := logrus.Fields{
+		"server_group": ident,
+		"old_targets":  oldCount,
+		"new_targets":  newCount,
+	}
+	if s.Cfg != nil {
+		fields["ordinal"] = s.Cfg.Ordinal
+	}
+
+	switch {
+	case initial && newCount == 0:
+		logrus.WithFields(fields).Warnf("ServerGroup '%s' started with zero targets; check service discovery configuration and relabel rules", ident)
+	case oldCount > 0 && newCount == 0:
+		logrus.WithFields(fields).Warnf("ServerGroup '%s' transitioned to zero targets; check service discovery configuration and relabel rules", ident)
+	}
+}
+
 // Cancel stops backround processes (e.g. discovery manager)
 func (s *ServerGroup) Cancel() {
 	s.ctxCancel()
@@ -154,6 +183,11 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 	apiClients := make([]promclient.API, 0)
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
+	oldState := s.State()
+	oldCount := 0
+	if oldState != nil {
+		oldCount = len(oldState.Targets)
+	}
 	defer func() {
 		if err != nil {
 			ctxCancel()
@@ -296,7 +330,9 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 		serverGroupSummary.WithLabelValues(targets[i], api, status).Observe(took)
 	}
 
+	currentTargetCount := len(targets)
 	logrus.Debugf("Updating targets from discovery manager: %v", targets)
+
 	apiClient, err := promclient.NewMultiAPI(apiClients, s.Cfg.GetAntiAffinity(), apiClientMetricFunc, 1, s.Cfg.GetPreferMax())
 	if err != nil {
 		return err
@@ -318,7 +354,9 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 		newState.apiClient = &promclient.DowngradeErrorAPI{newState.apiClient}
 	}
 
-	oldState := s.State()   // Fetch the current state (so we can stop it)
+	initialLoad := !s.loaded
+	s.logTargetTransition(oldCount, currentTargetCount, initialLoad)
+
 	s.state.Store(newState) // Store new state
 	if oldState != nil {
 		oldState.ctxCancel() // Cancel the old state

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -38,10 +39,20 @@ var (
 		Name: "server_group_request_duration_seconds",
 		Help: "Summary of calls to servergroup instances",
 	}, []string{"host", "call", "status"})
+
+	// serverGroupTargets tracks the number of targets currently discovered for
+	// each server group, so a zero-target group can be alerted on (e.g.
+	// `server_group_targets == 0`). The ordinal is guaranteed unique; the name
+	// label is the optional, human-readable group name (empty when unset).
+	serverGroupTargets = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "server_group_targets",
+		Help: "Number of targets currently discovered for a server group.",
+	}, []string{"ordinal", "name"})
 )
 
 func init() {
 	prometheus.MustRegister(serverGroupSummary)
+	prometheus.MustRegister(serverGroupTargets)
 }
 
 // New creates a new servergroup
@@ -101,32 +112,37 @@ type ServerGroup struct {
 	state atomic.Value
 }
 
+// groupIdentifier returns a human-readable identifier for this server group for
+// use in logs. The ordinal is always included (it is guaranteed unique); the
+// optional, non-unique name is appended when set.
 func (s *ServerGroup) groupIdentifier() string {
-	if s.Cfg != nil {
-		if s.Cfg.Name != "" {
-			return s.Cfg.Name
-		}
-		return fmt.Sprintf("ord=%d", s.Cfg.Ordinal)
+	if s.Cfg == nil {
+		return "unknown"
 	}
-	return "unknown"
+	if s.Cfg.Name != "" {
+		return fmt.Sprintf("ord=%d name=%s", s.Cfg.Ordinal, s.Cfg.Name)
+	}
+	return fmt.Sprintf("ord=%d", s.Cfg.Ordinal)
 }
 
 func (s *ServerGroup) logTargetTransition(oldCount, newCount int, initial bool) {
-	ident := s.groupIdentifier()
 	fields := logrus.Fields{
-		"server_group": ident,
-		"old_targets":  oldCount,
-		"new_targets":  newCount,
+		"old_targets": oldCount,
+		"new_targets": newCount,
 	}
 	if s.Cfg != nil {
 		fields["ordinal"] = s.Cfg.Ordinal
+		if s.Cfg.Name != "" {
+			fields["name"] = s.Cfg.Name
+		}
 	}
 
+	ident := s.groupIdentifier()
 	switch {
 	case initial && newCount == 0:
-		logrus.WithFields(fields).Warnf("ServerGroup '%s' started with zero targets; check service discovery configuration and relabel rules", ident)
+		logrus.WithFields(fields).Warnf("ServerGroup %s started with zero targets; check service discovery configuration and relabel rules", ident)
 	case oldCount > 0 && newCount == 0:
-		logrus.WithFields(fields).Warnf("ServerGroup '%s' transitioned to zero targets; check service discovery configuration and relabel rules", ident)
+		logrus.WithFields(fields).Warnf("ServerGroup %s transitioned to zero targets; check service discovery configuration and relabel rules", ident)
 	}
 }
 
@@ -330,9 +346,7 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 		serverGroupSummary.WithLabelValues(targets[i], api, status).Observe(took)
 	}
 
-	currentTargetCount := len(targets)
 	logrus.Debugf("Updating targets from discovery manager: %v", targets)
-
 	apiClient, err := promclient.NewMultiAPI(apiClients, s.Cfg.GetAntiAffinity(), apiClientMetricFunc, 1, s.Cfg.GetPreferMax())
 	if err != nil {
 		return err
@@ -354,8 +368,8 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 		newState.apiClient = &promclient.DowngradeErrorAPI{newState.apiClient}
 	}
 
-	initialLoad := !s.loaded
-	s.logTargetTransition(oldCount, currentTargetCount, initialLoad)
+	s.logTargetTransition(oldCount, len(targets), !s.loaded)
+	serverGroupTargets.WithLabelValues(strconv.Itoa(s.Cfg.Ordinal), s.Cfg.Name).Set(float64(len(targets)))
 
 	s.state.Store(newState) // Store new state
 	if oldState != nil {

--- a/pkg/servergroup/zero_targets_test.go
+++ b/pkg/servergroup/zero_targets_test.go
@@ -1,0 +1,95 @@
+package servergroup
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+)
+
+func TestGroupIdentifier(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{
+			name: "no config",
+			cfg:  nil,
+			want: "unknown",
+		},
+		{
+			// The ordinal is always included since it is guaranteed unique.
+			name: "ordinal only",
+			cfg:  &Config{Ordinal: 2},
+			want: "ord=2",
+		},
+		{
+			// The optional name is appended; the ordinal is still present.
+			name: "ordinal and name",
+			cfg:  &Config{Ordinal: 2, Name: "primary-cluster"},
+			want: "ord=2 name=primary-cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sg := &ServerGroup{Cfg: tt.cfg}
+			if got := sg.groupIdentifier(); got != tt.want {
+				t.Fatalf("groupIdentifier() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestServerGroupTargetsMetric verifies that loadTargetGroupMap publishes the
+// discovered target count to the server_group_targets gauge, so a zero-target
+// group (issue #742) can be alerted on.
+func TestServerGroupTargetsMetric(t *testing.T) {
+	tests := []struct {
+		name        string
+		ordinal     int
+		groupName   string
+		targetGroup map[string][]*targetgroup.Group
+		want        float64
+	}{
+		{
+			name:        "zero targets",
+			ordinal:     91,
+			groupName:   "empty-group",
+			targetGroup: map[string][]*targetgroup.Group{},
+			want:        0,
+		},
+		{
+			name:      "one target",
+			ordinal:   92,
+			groupName: "one-target-group",
+			targetGroup: map[string][]*targetgroup.Group{
+				"x": {{Targets: []model.LabelSet{{model.AddressLabel: "localhost:9090"}}}},
+			},
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sg, err := NewServerGroup()
+			if err != nil {
+				t.Fatalf("NewServerGroup: %v", err)
+			}
+			defer sg.Cancel()
+			sg.Cfg = &Config{Ordinal: tt.ordinal, Name: tt.groupName, Scheme: "http"}
+
+			if err := sg.loadTargetGroupMap(tt.targetGroup); err != nil {
+				t.Fatalf("loadTargetGroupMap: %v", err)
+			}
+
+			gauge := serverGroupTargets.WithLabelValues(strconv.Itoa(tt.ordinal), tt.groupName)
+			if got := testutil.ToFloat64(gauge); got != tt.want {
+				t.Fatalf("server_group_targets{ordinal=%d,name=%q} = %v, want %v", tt.ordinal, tt.groupName, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #742. Supersedes #743, incorporating the review feedback from that PR.

This builds on @ramessesii2's work in #743 (their original commit is preserved here for attribution) and applies the requested changes.

## What this does

When a ServerGroup's service discovery yields zero targets (DNS hiccup, misconfigured discovery, over-aggressive relabeling), promxy previously created an empty group silently — Grafana shows "no data", `ignore_error` doesn't help (no targets = no downstream errors), and nothing is logged.

This adds:
- An **optional `name`** field on a server group config (human-readable identifier).
- A **WARNING log** when a group starts with, or transitions to, zero targets.
- A **`server_group_targets` gauge** (labelled by `ordinal` and `name`) set on every discovery update, so the condition is **alertable** (e.g. `server_group_targets == 0`).

## Review feedback from #743 addressed

- `groupIdentifier` now **always includes the ordinal** (guaranteed unique) and appends the optional, non-unique `name` when set, instead of using one or the other. Structured log fields follow the same rule.
- Inlined the `currentTargetCount` / `initialLoad` locals at the `logTargetTransition` call site.
- Added the metric suggested in the issue discussion (a log line alone can't be alerted on).
- Cleaned up trailing whitespace / formatting in the `config.yaml` example.

## Tests

Adds `TestGroupIdentifier` (ordinal-always, name-optional) and `TestServerGroupTargetsMetric` (gauge reflects discovered count for zero- and one-target groups). Full `pkg/servergroup` suite and `go build ./...` pass.

Example log on an empty group:
```
level=warning msg="ServerGroup ord=0 name=primary-cluster started with zero targets; check service discovery configuration and relabel rules" name=primary-cluster new_targets=0 old_targets=0 ordinal=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)