### PR TITLE
fix: keep serving legacy flat web.config TLS schema (#771)

### DIFF
--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -2,14 +2,18 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 
 	"github.com/jacksontj/promxy/pkg/logging"
 )
@@ -17,8 +21,20 @@ import (
 func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Duration, accessLogOut io.Writer, router http.Handler, webConfigFile string) (*http.Server, error) {
 	handler := createHandler(accessLogOut, router, logFormat)
 
-	if err := web.Validate(webConfigFile); err != nil {
+	// Prior to delegating the web server to exporter-toolkit, promxy parsed
+	// --web.config.file directly into web.TLSConfig, so TLS keys (cert_file,
+	// key_file, ...) lived at the top level of the file. exporter-toolkit
+	// instead expects them nested under tls_server_config. To avoid breaking
+	// existing deployments we transparently keep serving the legacy flat schema.
+	legacyTLS, err := legacyTLSConfig(webConfigFile)
+	if err != nil {
 		return nil, err
+	}
+
+	if legacyTLS == nil {
+		if err := web.Validate(webConfigFile); err != nil {
+			return nil, err
+		}
 	}
 
 	ln, err := net.Listen("tcp", bindAddr)
@@ -29,6 +45,18 @@ func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Durat
 		Addr:        ln.Addr().String(),
 		Handler:     handler,
 		ReadTimeout: webReadTimeout,
+	}
+
+	if legacyTLS != nil {
+		srv.TLSConfig = legacyTLS
+		go func() {
+			logrus.Warnf("--web.config.file %q uses the deprecated flat TLS schema; nest these keys under 'tls_server_config:'. Support for the flat schema will be removed in a future release.", webConfigFile)
+			logrus.Infof("promxy starting with TLS (legacy web config %s)...", webConfigFile)
+			if err := srv.ServeTLS(ln, "", ""); err != nil && err != http.ErrServerClosed {
+				logrus.Errorf("Error listening: %v", err)
+			}
+		}()
+		return srv, nil
 	}
 
 	flags := &web.FlagConfig{WebConfigFile: &webConfigFile}
@@ -45,6 +73,54 @@ func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Durat
 		}
 	}()
 	return srv, nil
+}
+
+// legacyTLSConfig detects the pre-exporter-toolkit web config schema, in which
+// TLS settings lived at the top level of the file instead of nested under
+// tls_server_config. It returns a ready-to-use *tls.Config when the file uses
+// that legacy schema, or nil when the file is empty, uses the current
+// exporter-toolkit schema, or otherwise should be handled by exporter-toolkit.
+func legacyTLSConfig(webConfigFile string) (*tls.Config, error) {
+	if webConfigFile == "" {
+		return nil, nil
+	}
+
+	content, err := os.ReadFile(webConfigFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// A top-level map with any exporter-toolkit section is, by definition, the
+	// current schema; anything else with content is treated as the legacy flat
+	// schema. Empty files fall through to exporter-toolkit, which serves plain
+	// HTTP, matching the original behavior.
+	var top map[string]interface{}
+	if err := yaml.Unmarshal(content, &top); err != nil {
+		// Let exporter-toolkit surface the parse error in its own terms.
+		return nil, nil
+	}
+	if len(top) == 0 {
+		return nil, nil
+	}
+	for _, section := range []string{"tls_server_config", "http_server_config", "basic_auth_users"} {
+		if _, ok := top[section]; ok {
+			return nil, nil
+		}
+	}
+
+	tlsStruct := &web.TLSConfig{
+		MinVersion:               tls.VersionTLS12,
+		MaxVersion:               tls.VersionTLS13,
+		PreferServerCipherSuites: true,
+	}
+	if err := yaml.UnmarshalStrict(content, tlsStruct); err != nil {
+		return nil, err
+	}
+	// Resolve relative cert/key paths against the config file's directory, the
+	// same as exporter-toolkit does for the current schema.
+	tlsStruct.SetDirectory(filepath.Dir(webConfigFile))
+
+	return web.ConfigToTLSConfig(tlsStruct)
 }
 
 func createHandler(accessLogOut io.Writer, router http.Handler, logFormat string) http.Handler {

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -172,6 +172,45 @@ func TestMutualTLSClientCanConnectToAuthenticatedServerWithCerts(t *testing.T) {
 	server.Close()
 }
 
+// TestLegacyFlatTLSConfigStillServesTLS ensures the pre-exporter-toolkit web
+// config schema, where TLS keys live at the top level instead of nested under
+// tls_server_config, continues to bring up a working TLS server. See #771.
+func TestLegacyFlatTLSConfigStillServesTLS(t *testing.T) {
+	freePort, err := getFreePort()
+	if err != nil {
+		t.Fatalf("could not get a free port to run test: %s", err.Error())
+	}
+	bindAddr := fmt.Sprintf("localhost:%d", freePort)
+	router := httprouter.New()
+	router.HandlerFunc("GET", "/metrics", promhttp.Handler().ServeHTTP)
+
+	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, "testdata/legacy-tls-server-config.yml")
+	if err != nil {
+		t.Fatalf("an error occurred during creation of server: %s", err.Error())
+	}
+	defer server.Close()
+
+	client := setupAuthenticatedClient(t)
+
+	resp, err := client.Get(fmt.Sprintf("https://%s/metrics", bindAddr))
+	if err != nil {
+		t.Fatalf("could not make request to metrics endpoint: %s", err.Error())
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("could not read response body: %s", err.Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated client was unable to make a request to the legacy-config server. Response body: %s", body)
+	}
+
+	if !strings.Contains(string(body), "go_goroutines") {
+		t.Fatalf("could not find metric name 'go_goroutines' in response")
+	}
+}
+
 func getFreePort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {

--- a/pkg/server/testdata/legacy-tls-server-config.yml
+++ b/pkg/server/testdata/legacy-tls-server-config.yml
@@ -1,0 +1,7 @@
+# Legacy (pre-exporter-toolkit) flat web config schema, where TLS keys live at
+# the top level instead of nested under tls_server_config. Kept for backward
+# compatibility; see legacyTLSConfig in api.go.
+cert_file: "server.crt"
+key_file: "server.key"
+client_auth_type: "RequireAndVerifyClientCert"
+client_ca_file: "test-ca.crt"


### PR DESCRIPTION
## Problem

Follow-up to the last comment on #771. After the web server was delegated to exporter-toolkit (0cabe7fc), `--web.config.file` is parsed as the exporter-toolkit `web.Config` schema, whose TLS settings live under `tls_server_config:`. Before that change promxy unmarshaled the file *directly* into `web.TLSConfig`, so TLS keys (`cert_file`, `key_file`, `client_auth_type`, `client_ca_file`, …) sat at the **top level**.

This silently broke every existing deployment's web config. Reproduced with a legacy flat config:

```
yaml: unmarshal errors:
  line 1: field cert_file not found in type web.Config
  line 2: field key_file not found in type web.Config
```

The reporter worked around it by manually nesting their keys under `tls_server_config:`.

## Fix

Detect the legacy flat schema before handing the listener to exporter-toolkit and serve it directly — exactly as promxy did before the migration — while logging a deprecation warning that points users at `tls_server_config`.

Detection is conservative: a file is treated as legacy only when it has content and contains **none** of the exporter-toolkit sections (`tls_server_config`, `http_server_config`, `basic_auth_users`). Current-schema files, empty files, and parse errors all flow through exporter-toolkit unchanged. Relative cert/key paths resolve against the config file's directory, matching exporter-toolkit's behavior.

## Test

Adds `TestLegacyFlatTLSConfigStillServesTLS`, which brings up a TLS server from a legacy flat config and verifies an authenticated mTLS client can reach `/metrics`.

```
--- PASS: TestLegacyFlatTLSConfigStillServesTLS (0.00s)
```

> Note: based on `fix/issue-771-remote-write-wal` (the in-flight #771 branch), so this PR targets that branch. Retarget to `master` once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)