### PR TITLE
fix: synthesize step matrix for @-pinned pushdowns to dodge pre-epoch JSON decode bug

### DIFF
--- a/pkg/promclient/util.go
+++ b/pkg/promclient/util.go
@@ -113,6 +113,41 @@ func (f *BooleanFinder) Visit(node parser.Node, _ []parser.Node) (parser.Visitor
 	return f, nil
 }
 
+// TimestampFinder records the first @-modifier timestamp it encounters on a
+// VectorSelector / MatrixSelector / SubqueryExpr in the subtree. Found is set
+// once a timestamp is captured; subsequent matches are ignored. Used by the
+// NodeReplacer when subtreeHasAt is true: knowing one safe pinning timestamp
+// lets us issue an instant query rather than a range query whose start may
+// land on a pre-epoch sub-second time and trip the upstream
+// prometheus/common Time.UnmarshalJSON bug.
+type TimestampFinder struct {
+	l         sync.Mutex
+	Found     bool
+	Timestamp int64
+}
+
+// Visit runs on each node in the tree.
+func (f *TimestampFinder) Visit(node parser.Node, _ []parser.Node) (parser.Visitor, error) {
+	f.l.Lock()
+	defer f.l.Unlock()
+	if f.Found {
+		return f, nil
+	}
+	switch n := node.(type) {
+	case *parser.VectorSelector:
+		if n.Timestamp != nil {
+			f.Found = true
+			f.Timestamp = *n.Timestamp
+		}
+	case *parser.SubqueryExpr:
+		if n.Timestamp != nil {
+			f.Found = true
+			f.Timestamp = *n.Timestamp
+		}
+	}
+	return f, nil
+}
+
 // CloneExp returns a cloned copy of `expr`
 func CloneExpr(expr parser.Expr) (newExpr parser.Expr) {
 	newExpr, _ = parser.ParseExpr(expr.String())

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -15,20 +15,25 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/agent"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/tsdb/index"
 	"github.com/sirupsen/logrus"
 
 	"github.com/jacksontj/promxy/pkg/logging"
 
 	proxyconfig "github.com/jacksontj/promxy/pkg/config"
+	"github.com/jacksontj/promxy/pkg/promapi"
 	"github.com/jacksontj/promxy/pkg/promclient"
 	"github.com/jacksontj/promxy/pkg/proxyquerier"
 	"github.com/jacksontj/promxy/pkg/servergroup"
@@ -370,6 +375,70 @@ func (p *ProxyStorage) WALReplayStatus() (tsdb.WALReplayStatus, error) {
 	return tsdb.WALReplayStatus{}, errors.New("not implemented")
 }
 
+// vectorToStepMatrix converts an instant-query SeriesSet (one sample per
+// series at the @ time) into a range-query-shaped SeriesSet: each input
+// series' single sample is replicated at every step time in [start, end]
+// (inclusive of start, inclusive of end when (end-start) is a multiple of
+// step). Histograms are replicated the same way. This is only valid when the
+// underlying expression is step-invariant — currently used by the NodeReplacer
+// when the subtree below has an @ modifier.
+//
+// The replicated FloatHistogram pointer is shared across steps; that is safe
+// because promapi.NewSeries hands out copy-on-read iterators, so the engine
+// can't observe an aliased histogram.
+func vectorToStepMatrix(vec storage.SeriesSet, start, end time.Time, step time.Duration) storage.SeriesSet {
+	if step <= 0 {
+		return promapi.NewSeriesSet(nil, vec.Warnings(), vec.Err())
+	}
+	startMs := timestamp.FromTime(start)
+	endMs := timestamp.FromTime(end)
+	stepMs := int64(step / time.Millisecond)
+	if stepMs <= 0 || endMs < startMs {
+		return promapi.NewSeriesSet(nil, vec.Warnings(), vec.Err())
+	}
+	n := int((endMs-startMs)/stepMs) + 1
+	var out []storage.Series
+	for vec.Next() {
+		src := vec.At()
+		lbls := src.Labels().Copy()
+
+		// Instant query → at most one sample per series. Read it (the last
+		// one wins if, defensively, more than one is present).
+		var (
+			haveFloat bool
+			fval      float64
+			fh        *histogram.FloatHistogram
+		)
+		it := src.Iterator(nil)
+		for vt := it.Next(); vt != chunkenc.ValNone; vt = it.Next() {
+			switch vt {
+			case chunkenc.ValFloat:
+				_, fval = it.At()
+				haveFloat, fh = true, nil
+			case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
+				_, fh = it.AtFloatHistogram(nil)
+				haveFloat = false
+			}
+		}
+		if err := it.Err(); err != nil {
+			return promapi.NewSeriesSet(nil, vec.Warnings(), err)
+		}
+
+		samples := make([]chunks.Sample, 0, n)
+		for i := 0; i < n; i++ {
+			ts := startMs + int64(i)*stepMs
+			switch {
+			case fh != nil:
+				samples = append(samples, promapi.HistogramSample(ts, fh))
+			case haveFloat:
+				samples = append(samples, promapi.FloatSample(ts, fval))
+			}
+		}
+		out = append(out, promapi.NewSeries(lbls, samples))
+	}
+	return promapi.NewSeriesSet(out, vec.Warnings(), vec.Err())
+}
+
 // NodeReplacer replaces promql Nodes with more efficient-to-fetch ones. This works by taking lower-layer
 // chunks of the query, farming them out to prometheus hosts, then stitching the results back together.
 // An example would be a sum, we can sum multiple sums and come up with the same result -- so we do.
@@ -405,6 +474,20 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *parser.EvalStmt, nod
 		return false
 	}
 
+	// isAtModifierUnsafeCall flags Call nodes whose result is NOT
+	// step-invariant even when an inner @ modifier pins the input — e.g.
+	// timestamp() returns the evaluation-time timestamp, predict_linear
+	// extrapolates from evalTime, etc. Their presence in the subtree
+	// disqualifies the instant-query optimization in queryRangeAt below.
+	isAtModifierUnsafeCall := func(node parser.Node) bool {
+		c, ok := node.(*parser.Call)
+		if !ok {
+			return false
+		}
+		_, unsafe := promql.AtModifierUnsafeFunctions[c.Func.Name]
+		return unsafe
+	}
+
 	// If we are a child of a subquery; we just skip replacement (since it already did a nodereplacer for those)
 	for _, n := range path {
 		if isSubQuery(n) {
@@ -418,6 +501,14 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *parser.EvalStmt, nod
 	offsetFinder := &promclient.OffsetFinder{}
 	vecFinder := &promclient.BooleanFinder{Func: isVectorSelector}
 	timestampFinder := &promclient.BooleanFinder{Func: hasTimestamp}
+	// atTimestampFinder records the @ timestamp itself (in ms) so we can
+	// issue an instant query at a guaranteed-safe time when pushing down
+	// step-invariant subtrees — see queryRangeAt.
+	atTimestampFinder := &promclient.TimestampFinder{}
+	// atUnsafeFinder counts Call nodes whose result depends on the
+	// evaluation timestamp regardless of any inner @; if any are present
+	// queryRangeAt cannot use the instant-query optimization.
+	atUnsafeFinder := &promclient.BooleanFinder{Func: isAtModifierUnsafeCall}
 	// histFinder rides along on the same tree walk to detect histogram-
 	// bearing subtrees: histogram-only function calls (always) plus
 	// VectorSelectors whose metric name is histogram-typed per the
@@ -425,7 +516,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *parser.EvalStmt, nod
 	// is configured).
 	histFinder := &histogramFinder{isHistogramName: p.histogramNamePredicate()}
 
-	visitor := promclient.NewMultiVisitor([]parser.Visitor{aggFinder, offsetFinder, vecFinder, timestampFinder, histFinder})
+	visitor := promclient.NewMultiVisitor([]parser.Visitor{aggFinder, offsetFinder, vecFinder, timestampFinder, atTimestampFinder, atUnsafeFinder, histFinder})
 
 	if _, err := parser.Walk(ctx, visitor, s, node, nil, nil); err != nil {
 		return nil, err
@@ -518,6 +609,39 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *parser.EvalStmt, nod
 	}
 
 	state := p.GetState()
+
+	// queryRangeAt issues a step-aware downstream request for queryStr. When
+	// the subtree below us pins evaluation to a single timestamp via @, the
+	// result at every step is identical (step-invariant); in that case we
+	// issue a single instant Query at the @ timestamp and replicate the
+	// returned vector across each step in [s.Start, s.End]. This avoids
+	// sending QueryRange with a pre-epoch sub-second start time, which the
+	// upstream prometheus/common model.Time.UnmarshalJSON mis-decodes on
+	// the way back (see api_query.go hasNegativeFractionalSecond). When the
+	// subtree has no @, or it contains a Call whose result depends on the
+	// evaluation timestamp even with @ pinning (timestamp, predict_linear,
+	// time, etc. — see promql.AtModifierUnsafeFunctions), falls back to the
+	// regular QueryRange.
+	queryRangeAt := func(queryStr string) storage.SeriesSet {
+		if subtreeHasAt && atTimestampFinder.Found && atUnsafeFinder.Found == 0 && s.Interval > 0 {
+			at := timestamp.Time(atTimestampFinder.Timestamp)
+			result := state.client.Query(ctx, queryStr, at)
+			if err := result.Err(); err != nil {
+				return result
+			}
+			// The instant query returns one sample per series at the @ time;
+			// replicate each across the request's step grid. (Every series in
+			// a SeriesSet is vector-shaped here — there is no Scalar/Matrix/
+			// String ambiguity left at this layer.)
+			return vectorToStepMatrix(result, s.Start.Add(-reqOffset), s.End.Add(-reqOffset), s.Interval)
+		}
+		return state.client.QueryRange(ctx, queryStr, v1.Range{
+			Start: s.Start.Add(-reqOffset),
+			End:   s.End.Add(-reqOffset),
+			Step:  s.Interval,
+		})
+	}
+
 	switch n := node.(type) {
 	// Some AggregateExprs can be composed (meaning they are "reentrant". If the aggregation op
 	// is reentrant/composable then we'll do so, otherwise we let it fall through to normal query mechanisms
@@ -744,11 +868,7 @@ func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *parser.EvalStmt, nod
 		var result storage.SeriesSet
 		var err error
 		if s.Interval > 0 {
-			result = state.client.QueryRange(ctx, n.String(), v1.Range{
-				Start: s.Start.Add(-reqOffset),
-				End:   s.End.Add(-reqOffset),
-				Step:  s.Interval,
-			})
+			result = queryRangeAt(n.String())
 		} else {
 			result = state.client.Query(ctx, n.String(), s.Start.Add(-reqOffset))
 		}

--- a/pkg/proxystorage/proxy_test.go
+++ b/pkg/proxystorage/proxy_test.go
@@ -13,9 +13,12 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/jacksontj/promxy/pkg/promapi"
 	"github.com/jacksontj/promxy/pkg/promclient"
 )
 
@@ -400,4 +403,73 @@ func TestNodeReplacer(t *testing.T) {
 
 	//func (p *ProxyStorage) NodeReplacer(ctx context.Context, s *parser.EvalStmt, node parser.Node, path []parser.Node) (parser.Node, error) {
 
+}
+
+func TestVectorToStepMatrix(t *testing.T) {
+	// Instant-query result: one sample per series at the @ time. The input
+	// timestamps are irrelevant — vectorToStepMatrix replicates each value
+	// across the step grid.
+	vec := promapi.NewSeriesSet([]storage.Series{
+		promapi.NewSeries(labels.FromStrings("__name__", "foo", "instance", "a"),
+			[]chunks.Sample{promapi.FloatSample(4000, 1.5)}),
+		promapi.NewSeries(labels.FromStrings("__name__", "foo", "instance", "b"),
+			[]chunks.Sample{promapi.FloatSample(4000, 2.5)}),
+	}, nil, nil)
+
+	// Range [-59.2s, 60.8s] step 60s → 3 steps at -59200ms, 800ms, 60800ms.
+	// The synthesized series MUST place samples exactly at those step times
+	// (not at the @ time) so the engine's step-by-step lookup finds the
+	// pinned value at each step within its LookbackDelta window.
+	start := time.Unix(0, 800*int64(time.Millisecond)).Add(-time.Minute)
+	end := time.Unix(0, 800*int64(time.Millisecond)).Add(time.Minute)
+
+	type sample struct {
+		t int64
+		v float64
+	}
+	read := func(ss storage.SeriesSet) [][]sample {
+		var got [][]sample
+		for ss.Next() {
+			var pts []sample
+			it := ss.At().Iterator(nil)
+			for vt := it.Next(); vt != chunkenc.ValNone; vt = it.Next() {
+				ts, v := it.At()
+				pts = append(pts, sample{ts, v})
+			}
+			if err := it.Err(); err != nil {
+				t.Fatalf("iterator error: %v", err)
+			}
+			got = append(got, pts)
+		}
+		return got
+	}
+
+	mat := read(vectorToStepMatrix(vec, start, end, time.Minute))
+	if len(mat) != 2 {
+		t.Fatalf("expected 2 streams, got %d", len(mat))
+	}
+	for i, stream := range mat {
+		if len(stream) != 3 {
+			t.Fatalf("stream %d: expected 3 samples, got %d", i, len(stream))
+		}
+		wantTs := []int64{-59200, 800, 60800}
+		wantVal := []float64{1.5, 2.5}[i]
+		for j, sp := range stream {
+			if sp.t != wantTs[j] {
+				t.Errorf("stream %d sample %d: got ts %d, want %d", i, j, sp.t, wantTs[j])
+			}
+			if sp.v != wantVal {
+				t.Errorf("stream %d sample %d: got value %v, want %v", i, j, sp.v, wantVal)
+			}
+		}
+	}
+
+	// Step ≤ 0 → empty set (defensive: caller gates on s.Interval > 0).
+	vec2 := promapi.NewSeriesSet([]storage.Series{
+		promapi.NewSeries(labels.FromStrings("__name__", "foo"),
+			[]chunks.Sample{promapi.FloatSample(4000, 1.5)}),
+	}, nil, nil)
+	if got := read(vectorToStepMatrix(vec2, start, end, 0)); len(got) != 0 {
+		t.Errorf("step=0: expected empty set, got %v", got)
+	}
 }

--- a/test/promql_test.go
+++ b/test/promql_test.go
@@ -292,6 +292,13 @@ func TestUpstreamEvaluations(t *testing.T) {
 				// fall through to non-pushdown in NodeReplacer; the
 				// fidelity loss is in the JSON round-trip, fixed only by
 				// configuring remote_read on the server group.
+				//
+				// functions.test lines 1131, 1134, 1137, 1140, 1143, 1146,
+				// 1149, 1152, 1155, 1158, 1161, 1164 (sum_over_time(metric
+				// [N{,001,002,003}ms]) at evalTime 4s) are now fixed by the
+				// queryRangeAt instant-query optimization in proxystorage
+				// NodeReplacer; keeping the file in the skip set until the
+				// other clusters land too.
 				"functions.test",
 				"limit.test":
 				continue


### PR DESCRIPTION
## Summary

Fixes 12 sub-second-range `sum_over_time` cases at `functions.test` lines 1131, 1134, 1137, 1140, 1143, 1146, 1149, 1152, 1155, 1158, 1161, 1164 (both HTTP-only and remote_read configs — 24 total).

The failures had nothing to do with the millisecond range duration itself — promxy stringifies durations via `model.Duration.String()` which already preserves `ms` precision. The real cause is the promqltest `atModifierTestCases` sweep: every `eval instant at 4s ...` query is re-evaluated at the additional eval times `[-10*ts, 0, ts/5, ts, 10*ts]` plus a range-mode run at `[evalTime-1m, evalTime+1m, 1m]`. For `ts/5 = 0.8s`, range mode runs `[-59.2s, 60.8s, 1m]`, and the response JSON comes back with timestamps like `"-59.200"` — which upstream `prometheus/common` `Time.UnmarshalJSON` mis-decodes (negative sign isn't propagated to the fractional part, so `-59.200` becomes `Time(-58800)` instead of `Time(-59200)`).

Promxy's `api.go` already refuses the pushdown rather than return silently shifted data (`errNegativeFractionalTimestamp`), but the refusal surfaced as a hard error for any `@`-pinned query whose range-mode window crossed the epoch with sub-second precision. That's why all 12 lines (including line 1131 which has range `[1000ms]` = whole second) fail identically.

The fix exploits the fact that when `@` pins evaluation, the result at every range-query step is identical (step-invariant). In `pkg/proxystorage/proxy.go` `NodeReplacer`, a new `queryRangeAt` closure issues a single instant `Query` at the `@` timestamp and replicates the returned `Vector` across each step time via a new `vectorToStepMatrix` helper. The `@` timestamp is always a safe instant-query time, so the response JSON never contains a problematic timestamp.

The optimization is gated on `promql.AtModifierUnsafeFunctions` — `timestamp()`, `predict_linear()`, `time()`, etc. are step-variant even with `@` pinning, so they fall back to the original `QueryRange` path. Without this gate, `timestamp(timestamp(metric @ 10))` and `predict_linear(... @ 3000, 3600)` regressed.

Currently wired into the `*parser.Call` branch where the bucket lives. Other branches (`AggregateExpr`, `BinaryExpr`, `VectorSelector`) keep their existing path; the helper is available if/when later clusters need it.

## Before / after

Before — all 12 lines (`X` ∈ {1000, 1001, 1002, 1003, 2000, 2001, 2002, 2003, 3000, 3001, 3002, 3003}, both configs):

```
error evaluating query "sum_over_time(metric[…ms] @ 4.000)" (line …) in range mode:
  promxy: pushdown not supported for pre-epoch timestamps with sub-second precision
  (https://github.com/prometheus/common model.Time.UnmarshalJSON bug)
```

After — all 12 lines × 2 configs = 24 sub-tests PASS. Total `functions.test` failures drop from 75 → 51; the remaining 51 belong to other clusters (resets/changes/irate/label_join/clamp/delta/etc.) being worked on separately. No regressions in any other `*.test` file.

The skip-list entry for `functions.test` stays in place per the task instructions (other agents own other clusters); a code comment documents which lines this PR fixes.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/...` all pass (incl. new `TestVectorToStepMatrix`)
- [x] With `"functions.test"` temporarily removed from skip, the 24 listed sub-tests all PASS; no new regressions in the rest of `TestUpstreamEvaluations`
- [x] With the skip in place, `go test ./test -run TestUpstreamEvaluations` PASSes overall

🤖 Generated with [Claude Code](https://claude.com/claude-code)