### PR TITLE
fix: lower remote_write max_samples_per_send default to keep requests under 32 MiB (#781)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,23 +15,77 @@ import (
 // is loaded into
 var DefaultPromxyConfig = PromxyConfig{}
 
+// DefaultMaxSamplesPerSend is promxy's default remote_write batch size when the
+// user does not set queue_config.max_samples_per_send explicitly.
+//
+// Upstream Prometheus defaults this to 2000. promxy historically (in its old
+// vendored remote_write fork) used 100, and shipping recording-rule output with
+// large/high-cardinality series in 2000-sample batches can decompress to more
+// than the 32 MiB snappy limit that Prometheus 3.5.3+ enforces on the
+// remote-write receiver (GHSA-8rm2-7qqf-34qm). When that happens the receiver
+// rejects the request with "snappy: decoded length N exceeds limit 33554432"
+// and the queue manager drops the batch. Restoring the historical default keeps
+// promxy's requests comfortably under that limit. See issue #781.
+const DefaultMaxSamplesPerSend = 100
+
 // ConfigFromFile loads a config file at path
 func ConfigFromFile(path string) (*Config, error) {
-	// load the config file
-	cfg := &Config{
-		PromConfig:   config.DefaultConfig,
-		PromxyConfig: DefaultPromxyConfig,
-	}
 	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("error loading config: %v", err)
 	}
-	err = yaml.Unmarshal([]byte(configBytes), &cfg)
-	if err != nil {
+	return ConfigFromBytes(configBytes)
+}
+
+// ConfigFromBytes loads a config from raw YAML bytes.
+func ConfigFromBytes(configBytes []byte) (*Config, error) {
+	cfg := &Config{
+		PromConfig:   config.DefaultConfig,
+		PromxyConfig: DefaultPromxyConfig,
+	}
+	if err := yaml.Unmarshal(configBytes, cfg); err != nil {
 		return nil, fmt.Errorf("error unmarshaling config: %v", err)
 	}
 
+	if err := applyRemoteWriteDefaults(cfg, configBytes); err != nil {
+		return nil, fmt.Errorf("error applying remote_write defaults: %v", err)
+	}
+
 	return cfg, nil
+}
+
+// applyRemoteWriteDefaults lowers the remote_write max_samples_per_send default
+// from upstream's 2000 to promxy's DefaultMaxSamplesPerSend, but only for
+// remote_write entries where the user did not set it explicitly. The base
+// unmarshal always populates QueueConfig from Prometheus' DefaultQueueConfig, so
+// an explicit value is indistinguishable from the upstream default after the
+// fact; we re-parse the raw YAML to detect which entries set it.
+func applyRemoteWriteDefaults(cfg *Config, configBytes []byte) error {
+	if len(cfg.PromConfig.RemoteWriteConfigs) == 0 {
+		return nil
+	}
+
+	var probe struct {
+		RemoteWrite []struct {
+			QueueConfig *struct {
+				MaxSamplesPerSend *int `yaml:"max_samples_per_send"`
+			} `yaml:"queue_config"`
+		} `yaml:"remote_write"`
+	}
+	if err := yaml.Unmarshal(configBytes, &probe); err != nil {
+		return err
+	}
+
+	for i, rwcfg := range cfg.PromConfig.RemoteWriteConfigs {
+		explicit := i < len(probe.RemoteWrite) &&
+			probe.RemoteWrite[i].QueueConfig != nil &&
+			probe.RemoteWrite[i].QueueConfig.MaxSamplesPerSend != nil
+		if !explicit {
+			rwcfg.QueueConfig.MaxSamplesPerSend = DefaultMaxSamplesPerSend
+		}
+	}
+
+	return nil
 }
 
 // Config is the entire config file. This includes both the Prometheus Config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -39,3 +39,84 @@ tls_server_config:
 		t.Errorf("Invalid ClientCAs. Expected 'tls-ca-chain.pem', Got '%s'", cfg.WebConfig.ClientCAs)
 	}
 }
+
+// TestRemoteWriteMaxSamplesPerSendDefault is a regression test for
+// https://github.com/jacksontj/promxy/issues/781. Upstream's default
+// max_samples_per_send (2000) can produce remote_write requests that decompress
+// past the 32 MiB snappy limit Prometheus 3.5.3+ enforces on the receiver, so
+// promxy lowers the default to DefaultMaxSamplesPerSend when the user does not
+// set it explicitly -- while still honoring an explicit value.
+func TestRemoteWriteMaxSamplesPerSendDefault(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []int
+	}{
+		{
+			name: "unset uses promxy default",
+			raw: `
+remote_write:
+  - url: http://localhost:1/api/v1/write
+`,
+			want: []int{DefaultMaxSamplesPerSend},
+		},
+		{
+			name: "explicit value honored",
+			raw: `
+remote_write:
+  - url: http://localhost:1/api/v1/write
+    queue_config:
+      max_samples_per_send: 2000
+`,
+			want: []int{2000},
+		},
+		{
+			name: "explicit value matching promxy default honored",
+			raw: `
+remote_write:
+  - url: http://localhost:1/api/v1/write
+    queue_config:
+      max_samples_per_send: 100
+`,
+			want: []int{100},
+		},
+		{
+			name: "per-entry: only unset entries get the default",
+			raw: `
+remote_write:
+  - url: http://localhost:1/api/v1/write
+  - url: http://localhost:2/api/v1/write
+    queue_config:
+      max_samples_per_send: 1500
+`,
+			want: []int{DefaultMaxSamplesPerSend, 1500},
+		},
+		{
+			name: "queue_config set without max_samples_per_send still gets default",
+			raw: `
+remote_write:
+  - url: http://localhost:1/api/v1/write
+    queue_config:
+      max_shards: 10
+`,
+			want: []int{DefaultMaxSamplesPerSend},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ConfigFromBytes([]byte(tc.raw))
+			if err != nil {
+				t.Fatalf("ConfigFromBytes: %v", err)
+			}
+			if got := len(cfg.PromConfig.RemoteWriteConfigs); got != len(tc.want) {
+				t.Fatalf("got %d remote_write configs, want %d", got, len(tc.want))
+			}
+			for i, want := range tc.want {
+				if got := cfg.PromConfig.RemoteWriteConfigs[i].QueueConfig.MaxSamplesPerSend; got != want {
+					t.Errorf("remote_write[%d] MaxSamplesPerSend = %d, want %d", i, got, want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/proxystorage/remote_write_test.go
+++ b/pkg/proxystorage/remote_write_test.go
@@ -6,10 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	yaml "gopkg.in/yaml.v2"
 
 	proxyconfig "github.com/jacksontj/promxy/pkg/config"
 )
@@ -18,12 +16,9 @@ func noStepSubqueryInterval(int64) int64 { return 0 }
 
 func loadConfig(t *testing.T, raw string) *proxyconfig.Config {
 	t.Helper()
-	cfg := &proxyconfig.Config{
-		PromConfig:   config.DefaultConfig,
-		PromxyConfig: proxyconfig.DefaultPromxyConfig,
-	}
-	if err := yaml.Unmarshal([]byte(raw), cfg); err != nil {
-		t.Fatalf("error unmarshaling config: %v", err)
+	cfg, err := proxyconfig.ConfigFromBytes([]byte(raw))
+	if err != nil {
+		t.Fatalf("error loading config: %v", err)
 	}
 	return cfg
 }


### PR DESCRIPTION
## Problem

Fixes #781.

After upgrading promxy, downstream Prometheus **3.5.3** instances reject promxy's remote-write requests with:

```
snappy: decoded length 34811443 exceeds limit 33554432   (write_handler.go:179)
```

and promxy logs `http2: stream closed` on ~half of concurrent `/federation` requests.

## Root cause

- **Receiver:** Prometheus 3.5.3 / 3.11.3 shipped the fix for [GHSA-8rm2-7qqf-34qm / CVE-2026-42154](https://github.com/prometheus/prometheus/security/advisories/GHSA-8rm2-7qqf-34qm) ([PR #18585](https://github.com/prometheus/prometheus/pull/18585)), which now **rejects any remote-write request whose snappy-decoded length exceeds 32 MiB** (`33554432 = 2^25`).
- **Sender:** Commit `01b9e338` ("Replace pkg/remote/ fork with upstream prometheus/storage/remote") swapped promxy's old vendored queue manager (`MaxSamplesPerSend: 100`) for the upstream one (`MaxSamplesPerSend: 2000`) — a 20x larger default batch. The upstream queue manager batches **by sample count only, with no byte cap**, so recording-rule output with large/high-cardinality series (`34811443 / 2000 ~ 17 KB/series`) crosses 32 MiB. The queue manager treats the resulting 4xx as non-recoverable and **drops the batch**, silently losing samples.
- The `/federation` `http2: stream closed` failures are collateral damage from the downstream resetting the HTTP/2 connection shared with the failing write POSTs.

Rolling promxy back restored the old 100-sample default, so requests stayed under the limit. Upstream Prometheus v1 has no byte-based batch splitting (`max_batch_size_bytes` is an OTel-collector feature), so the fix belongs in promxy.

## Fix

Restore promxy's historical default of `max_samples_per_send: 100` **only when the user hasn't set it explicitly**. Because `RemoteWriteConfig.UnmarshalYAML` always populates `QueueConfig` from Prometheus' `DefaultQueueConfig`, an explicit value is indistinguishable from the upstream default after unmarshal — so we re-parse the raw YAML to detect which `remote_write` entries set `queue_config.max_samples_per_send` and override only the unset ones (index-aligned, per entry).

Config loading is refactored into `ConfigFromBytes` so startup and reload (both via `ConfigFromFile`) and tests share one path.

## Tests

- New `TestRemoteWriteMaxSamplesPerSendDefault` (table): unset->100, explicit honored, explicit-matching-default honored, mixed per-entry, and `queue_config` present without `max_samples_per_send`.
- `pkg/proxystorage` test helper routed through `ConfigFromBytes`; existing WAL + end-to-end remote_write tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)