### PR TITLE
feat(servergroup): add inject_matchers to scope a downstream by label

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -183,6 +183,22 @@ promxy:
           __name__:
             - up
 
+      # inject_matchers is a list of label matchers that are injected into every selector
+      # of every request sent to this server_group. This effectively scopes the server_group
+      # to the subset of downstream data matching these matchers -- even for queries that
+      # never reference the labels being injected (e.g. with `cluster="A"` configured,
+      # `count(up)` is sent downstream as `count(up{cluster="A"})`).
+      # Each entry is a single matcher in promql syntax (no enclosing braces).
+      # Unlike `labels` (which only adds labels to responses) and `label_filter` (which only
+      # drops queries that can't match), `inject_matchers` always adds the matchers to the
+      # queries themselves. A common use-case is presenting a per-tenant view of a merged
+      # downstream (e.g. a single Mimir/Thanos/Prometheus holding many clusters) by running a
+      # promxy per tenant -- see https://github.com/jacksontj/promxy/issues/698
+      # NOTE: this is not a "secure" mechanism; it only mutates the request matchers and
+      #       relies on the downstream honoring them.
+      inject_matchers:
+        - 'cluster="A"'
+
       # Map of HTTP headers to add to remote read HTTP calls made to this downstream
       # the main use-case for this is to support the X-Scope-OrgID header required by Mimir and Cortex
       # in multi-tenancy mode.

--- a/pkg/promclient/inject_matchers.go
+++ b/pkg/promclient/inject_matchers.go
@@ -1,0 +1,180 @@
+package promclient
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/jacksontj/promxy/pkg/promhttputil"
+)
+
+// InjectMatchersClient wraps an API and injects a static set of label matchers into
+// every selector of every request sent downstream. This effectively scopes the
+// downstream to the subset of data matching those matchers -- even for queries that
+// never reference the labels being injected (e.g. `count(up)` becomes
+// `count(up{cluster="A"})`).
+//
+// This differs from the other label mechanisms in promxy:
+//   - `labels` only *adds* labels to the responses coming back from the downstream
+//   - `label_filter` only *drops* queries whose matchers can't match the downstream
+//   - `inject_matchers` always *adds* the configured matchers to the queries themselves
+//
+// NOTE: this is not a "secure" mechanism. It only mutates the matchers in the request
+// and does not (and cannot) prevent a downstream from returning data outside of the
+// injected scope if the downstream ignores the matchers. As with `label_filter`, a way
+// to use this more securely is to pair it with a trusted label proxy.
+type InjectMatchersClient struct {
+	API
+	matchers []*labels.Matcher
+}
+
+// NewInjectMatchersClient returns an InjectMatchersClient that injects the given
+// matchers into all requests sent to the downstream API.
+func NewInjectMatchersClient(a API, matchers []*labels.Matcher) (*InjectMatchersClient, error) {
+	return &InjectMatchersClient{API: a, matchers: matchers}, nil
+}
+
+// injectIntoQuery parses the given promql query, injects the configured matchers into
+// every selector and returns the rewritten query string.
+func (c *InjectMatchersClient) injectIntoQuery(ctx context.Context, query string) (string, error) {
+	e, err := parser.ParseExpr(query)
+	if err != nil {
+		return "", err
+	}
+
+	visitor := &injectMatchersVisitor{matchers: c.matchers}
+	if _, err := parser.Walk(ctx, visitor, &parser.EvalStmt{Expr: e}, e, nil, nil); err != nil {
+		return "", err
+	}
+
+	return e.String(), nil
+}
+
+// injectIntoMatch injects the configured matchers into a single match[] selector
+// string (e.g. `up{job="foo"}`) and returns the rewritten selector.
+func (c *InjectMatchersClient) injectIntoMatch(match string) (string, error) {
+	selectors, err := parser.ParseMetricSelector(match)
+	if err != nil {
+		return "", err
+	}
+	return promhttputil.MatcherToString(appendMatchers(selectors, c.matchers))
+}
+
+// injectIntoMatches injects the configured matchers into every match[] selector. When
+// no matchers are supplied we add a single selector consisting solely of the injected
+// matchers so the downstream is still scoped (rather than returning everything).
+func (c *InjectMatchersClient) injectIntoMatches(matches []string) ([]string, error) {
+	if len(matches) == 0 {
+		match, err := promhttputil.MatcherToString(c.matchers)
+		if err != nil {
+			return nil, err
+		}
+		return []string{match}, nil
+	}
+
+	ret := make([]string, 0, len(matches))
+	for _, match := range matches {
+		injected, err := c.injectIntoMatch(match)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, injected)
+	}
+	return ret, nil
+}
+
+// LabelNames returns all the unique label names present in the block in sorted order.
+func (c *InjectMatchersClient) LabelNames(ctx context.Context, matchers []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error) {
+	matchers, err := c.injectIntoMatches(matchers)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.API.LabelNames(ctx, matchers, startTime, endTime)
+}
+
+// LabelValues performs a query for the values of the given label.
+func (c *InjectMatchersClient) LabelValues(ctx context.Context, label string, matchers []string, startTime time.Time, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	matchers, err := c.injectIntoMatches(matchers)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.API.LabelValues(ctx, label, matchers, startTime, endTime)
+}
+
+// Query performs a query for the given time.
+func (c *InjectMatchersClient) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
+	query, err := c.injectIntoQuery(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.API.Query(ctx, query, ts)
+}
+
+// QueryRange performs a query for the given range.
+func (c *InjectMatchersClient) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, v1.Warnings, error) {
+	query, err := c.injectIntoQuery(ctx, query)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.API.QueryRange(ctx, query, r)
+}
+
+// Series finds series by label matchers.
+func (c *InjectMatchersClient) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	matches, err := c.injectIntoMatches(matches)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.API.Series(ctx, matches, startTime, endTime)
+}
+
+// GetValue loads the raw data for a given set of matchers in the time range
+func (c *InjectMatchersClient) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (model.Value, v1.Warnings, error) {
+	return c.API.GetValue(ctx, start, end, appendMatchers(matchers, c.matchers))
+}
+
+// injectMatchersVisitor implements the parser.Visitor interface to inject a static set
+// of matchers into every selector of a promql expression.
+type injectMatchersVisitor struct {
+	l        sync.Mutex
+	matchers []*labels.Matcher
+}
+
+// Visit injects the configured matchers into every VectorSelector. The parser descends
+// into the VectorSelector contained in a MatrixSelector, so handling VectorSelector is
+// sufficient to cover both instant and range selectors.
+func (v *injectMatchersVisitor) Visit(node parser.Node, path []parser.Node) (parser.Visitor, error) {
+	if nodeTyped, ok := node.(*parser.VectorSelector); ok {
+		v.l.Lock()
+		nodeTyped.LabelMatchers = appendMatchers(nodeTyped.LabelMatchers, v.matchers)
+		v.l.Unlock()
+	}
+	return v, nil
+}
+
+// appendMatchers returns matchers with toAdd appended, skipping any matcher that is
+// already present (same type, name and value) to keep the rewritten selector clean and
+// the operation idempotent.
+func appendMatchers(matchers []*labels.Matcher, toAdd []*labels.Matcher) []*labels.Matcher {
+	ret := make([]*labels.Matcher, len(matchers), len(matchers)+len(toAdd))
+	copy(ret, matchers)
+
+	for _, m := range toAdd {
+		exists := false
+		for _, existing := range ret {
+			if existing.Type == m.Type && existing.Name == m.Name && existing.Value == m.Value {
+				exists = true
+				break
+			}
+		}
+		if !exists {
+			ret = append(ret, m)
+		}
+	}
+	return ret
+}

--- a/pkg/promclient/inject_matchers_test.go
+++ b/pkg/promclient/inject_matchers_test.go
@@ -1,0 +1,237 @@
+package promclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// recordingAPI captures the query/matchers it is called with so tests can assert what
+// would have been sent to the downstream.
+type recordingAPI struct {
+	query   string
+	matches []string
+	getVal  []*labels.Matcher
+}
+
+func (a *recordingAPI) LabelNames(ctx context.Context, matchers []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error) {
+	a.matches = matchers
+	return nil, nil, nil
+}
+
+func (a *recordingAPI) LabelValues(ctx context.Context, label string, matchers []string, startTime time.Time, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	a.matches = matchers
+	return nil, nil, nil
+}
+
+func (a *recordingAPI) Query(ctx context.Context, query string, ts time.Time) (model.Value, v1.Warnings, error) {
+	a.query = query
+	return nil, nil, nil
+}
+
+func (a *recordingAPI) QueryRange(ctx context.Context, query string, r v1.Range) (model.Value, v1.Warnings, error) {
+	a.query = query
+	return nil, nil, nil
+}
+
+func (a *recordingAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	a.matches = matches
+	return nil, nil, nil
+}
+
+func (a *recordingAPI) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) (model.Value, v1.Warnings, error) {
+	a.getVal = matchers
+	return nil, nil, nil
+}
+
+func (a *recordingAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	return nil, nil
+}
+
+// mustMatchers parses a comma-separated set of bare matchers into label matchers.
+func mustMatchers(t *testing.T, s string) []*labels.Matcher {
+	t.Helper()
+	matchers, err := parser.ParseMetricSelector("{" + s + "}")
+	if err != nil {
+		t.Fatalf("error parsing matchers %q: %v", s, err)
+	}
+	return matchers
+}
+
+func TestInjectMatchersQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		inject   string
+		query    string
+		expected string
+	}{
+		{
+			name:     "aggregation without the injected label",
+			inject:   `cluster="A"`,
+			query:    `count(up) by (job)`,
+			expected: `count by (job) (up{cluster="A"})`,
+		},
+		{
+			name:     "selector already referencing a different label",
+			inject:   `cluster="A"`,
+			query:    `up{job="foo"}`,
+			expected: `up{cluster="A",job="foo"}`,
+		},
+		{
+			name:     "matrix selector inside a function",
+			inject:   `cluster="A"`,
+			query:    `rate(http_requests_total[5m])`,
+			expected: `rate(http_requests_total{cluster="A"}[5m])`,
+		},
+		{
+			name:     "binary expression injects into both sides",
+			inject:   `cluster="A"`,
+			query:    `up / on() node_up`,
+			expected: `up{cluster="A"} / on () node_up{cluster="A"}`,
+		},
+		{
+			name:     "multiple matchers",
+			inject:   `cluster="A",region=~"us-.*"`,
+			query:    `up`,
+			expected: `up{cluster="A",region=~"us-.*"}`,
+		},
+		{
+			name:     "idempotent when matcher already present",
+			inject:   `cluster="A"`,
+			query:    `up{cluster="A"}`,
+			expected: `up{cluster="A"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := &recordingAPI{}
+			c, err := NewInjectMatchersClient(rec, mustMatchers(t, test.inject))
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+
+			if _, _, err := c.Query(context.TODO(), test.query, time.Time{}); err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if rec.query != test.expected {
+				t.Fatalf("Query mismatch\nexpected=%s\nactual=%s", test.expected, rec.query)
+			}
+
+			// QueryRange should rewrite identically
+			rec.query = ""
+			if _, _, err := c.QueryRange(context.TODO(), test.query, v1.Range{}); err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if rec.query != test.expected {
+				t.Fatalf("QueryRange mismatch\nexpected=%s\nactual=%s", test.expected, rec.query)
+			}
+		})
+	}
+}
+
+func TestInjectMatchersMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		inject   string
+		matches  []string
+		expected []string
+	}{
+		{
+			name:     "empty matches scopes to the injected matchers",
+			inject:   `cluster="A"`,
+			matches:  nil,
+			expected: []string{`{cluster="A"}`},
+		},
+		{
+			name:     "injects into each provided selector",
+			inject:   `cluster="A"`,
+			matches:  []string{`up{job="foo"}`, `node_up`},
+			expected: []string{`{job="foo",__name__="up",cluster="A"}`, `{__name__="node_up",cluster="A"}`},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rec := &recordingAPI{}
+			c, err := NewInjectMatchersClient(rec, mustMatchers(t, test.inject))
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+
+			t.Run("Series", func(t *testing.T) {
+				rec.matches = nil
+				if _, _, err := c.Series(context.TODO(), test.matches, time.Time{}, time.Time{}); err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				assertMatchesEqual(t, test.expected, rec.matches)
+			})
+
+			t.Run("LabelValues", func(t *testing.T) {
+				rec.matches = nil
+				if _, _, err := c.LabelValues(context.TODO(), "job", test.matches, time.Time{}, time.Time{}); err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				assertMatchesEqual(t, test.expected, rec.matches)
+			})
+
+			t.Run("LabelNames", func(t *testing.T) {
+				rec.matches = nil
+				if _, _, err := c.LabelNames(context.TODO(), test.matches, time.Time{}, time.Time{}); err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				assertMatchesEqual(t, test.expected, rec.matches)
+			})
+		})
+	}
+}
+
+func TestInjectMatchersGetValue(t *testing.T) {
+	rec := &recordingAPI{}
+	c, err := NewInjectMatchersClient(rec, mustMatchers(t, `cluster="A"`))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	in := mustMatchers(t, `__name__="up",job="foo"`)
+	if _, _, err := c.GetValue(context.TODO(), time.Time{}, time.Time{}, in); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	got, err := selectorString(rec.getVal)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	expected := `{__name__="up",job="foo",cluster="A"}`
+	if got != expected {
+		t.Fatalf("GetValue mismatch\nexpected=%s\nactual=%s", expected, got)
+	}
+}
+
+func assertMatchesEqual(t *testing.T, expected, actual []string) {
+	t.Helper()
+	if len(expected) != len(actual) {
+		t.Fatalf("len mismatch\nexpected=%v\nactual=%v", expected, actual)
+	}
+	for i := range expected {
+		if expected[i] != actual[i] {
+			t.Fatalf("mismatch at %d\nexpected=%v\nactual=%v", i, expected, actual)
+		}
+	}
+}
+
+func selectorString(matchers []*labels.Matcher) (string, error) {
+	ret := "{"
+	for i, m := range matchers {
+		if i > 0 {
+			ret += ","
+		}
+		ret += m.String()
+	}
+	return ret + "}", nil
+}

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -2,6 +2,7 @@ package servergroup
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	config_util "github.com/prometheus/common/config"
@@ -11,7 +12,9 @@ import (
 	"github.com/jacksontj/promxy/pkg/promclient"
 
 	"github.com/prometheus/prometheus/discovery"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
+	"github.com/prometheus/prometheus/promql/parser"
 )
 
 var (
@@ -209,6 +212,27 @@ type Config struct {
 
 	LabelFilterConfig *promclient.LabelFilterConfig `yaml:"label_filter"`
 
+	// InjectMatchers is a list of label matchers that are injected into every selector
+	// of every request sent to this servergroup. This effectively scopes the servergroup
+	// to the subset of downstream data matching these matchers -- even for queries that
+	// never reference the labels being injected (e.g. with `cluster="A"` configured,
+	// `count(up)` is sent downstream as `count(up{cluster="A"})`).
+	//
+	// Each entry is a single matcher in promql syntax (no enclosing braces), e.g.:
+	//
+	//    inject_matchers:
+	//      - 'cluster="A"'
+	//      - 'region=~"us-.*"'
+	//
+	// Unlike `labels` (which only adds labels to responses) and `label_filter` (which only
+	// drops queries that can't match), `inject_matchers` always adds the matchers to the
+	// queries themselves. A common use-case is presenting a per-tenant view of a merged
+	// downstream (e.g. a single Mimir/Thanos/Prometheus holding many clusters) -- see
+	// https://github.com/jacksontj/promxy/issues/698
+	// NOTE: this is not a "secure" mechanism; it only mutates the request matchers and
+	// relies on the downstream honoring them.
+	InjectMatchers []string `yaml:"inject_matchers,omitempty"`
+
 	PreferMax bool `yaml:"prefer_max,omitempty"`
 
 	// HTTPClientHeaders are a map of HTTP headers to add to remote read HTTP calls made to this downstream
@@ -233,6 +257,21 @@ func (c *Config) GetPreferMax() bool {
 	return c.PreferMax
 }
 
+// GetInjectMatchers parses the configured InjectMatchers entries into label matchers.
+// It returns nil if no matchers are configured.
+func (c *Config) GetInjectMatchers() ([]*labels.Matcher, error) {
+	if len(c.InjectMatchers) == 0 {
+		return nil, nil
+	}
+	// Join the individual matcher entries into a single selector and parse it. Each entry
+	// is expected to be a bare matcher (e.g. `cluster="A"`) without enclosing braces.
+	matchers, err := parser.ParseMetricSelector("{" + strings.Join(c.InjectMatchers, ",") + "}")
+	if err != nil {
+		return nil, fmt.Errorf("error parsing inject_matchers: %w", err)
+	}
+	return matchers, nil
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultConfig
@@ -242,6 +281,12 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	if err := c.validateAuthConfig(); err != nil {
+		return err
+	}
+
+	// Validate inject_matchers parses at config-load time rather than failing later
+	// during a discovery sync.
+	if _, err := c.GetInjectMatchers(); err != nil {
 		return err
 	}
 

--- a/pkg/servergroup/config_test.go
+++ b/pkg/servergroup/config_test.go
@@ -140,6 +140,89 @@ http_client:
 	}
 }
 
+func TestInjectMatchersConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		wantErr  bool
+		errMsg   string
+		expected []string // expected matcher.String() values from GetInjectMatchers
+	}{
+		{
+			name: "no inject_matchers",
+			config: `
+static_configs:
+  - targets:
+      - localhost:9090
+`,
+			expected: nil,
+		},
+		{
+			name: "single matcher",
+			config: `
+static_configs:
+  - targets:
+      - localhost:9090
+inject_matchers:
+  - 'cluster="A"'
+`,
+			expected: []string{`cluster="A"`},
+		},
+		{
+			name: "multiple matchers including a regex",
+			config: `
+inject_matchers:
+  - 'cluster="A"'
+  - 'region=~"us-.*"'
+`,
+			expected: []string{`cluster="A"`, `region=~"us-.*"`},
+		},
+		{
+			name: "invalid matcher fails at config load",
+			config: `
+inject_matchers:
+  - 'this is not a matcher'
+`,
+			wantErr: true,
+			errMsg:  "error parsing inject_matchers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Config
+			err := yaml.Unmarshal([]byte(tt.config), &cfg)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+					t.Fatalf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			matchers, err := cfg.GetInjectMatchers()
+			if err != nil {
+				t.Fatalf("unexpected error from GetInjectMatchers: %v", err)
+			}
+			if len(matchers) != len(tt.expected) {
+				t.Fatalf("len mismatch\nexpected=%v\nactual=%v", tt.expected, matchers)
+			}
+			for i, m := range matchers {
+				if m.String() != tt.expected[i] {
+					t.Fatalf("matcher %d mismatch\nexpected=%s\nactual=%s", i, tt.expected[i], m.String())
+				}
+			}
+		})
+	}
+}
+
 // contains checks if a string contains a substring
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -315,6 +315,19 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 					}
 				})
 
+				// Inject static matchers into all requests sent to this target. This is
+				// applied beneath the label-manipulation wrappers below so the matchers
+				// reach the downstream verbatim, without interacting with label_filter's
+				// query filtering or metrics_relabel's matcher reversal.
+				if injectMatchers, err := s.Cfg.GetInjectMatchers(); err != nil {
+					return err
+				} else if len(injectMatchers) > 0 {
+					apiClient, err = promclient.NewInjectMatchersClient(apiClient, injectMatchers)
+					if err != nil {
+						return err
+					}
+				}
+
 				// Add labels
 				apiClient = &promclient.AddLabelClient{apiClient, modelLabelSet.Merge(s.Cfg.Labels)}
 


### PR DESCRIPTION
## Summary

Adds an `inject_matchers` `server_group` option that injects a static set of label matchers into **every selector of every request** sent to that downstream (query, query_range, series, label_names, label_values, and remote-read).

For example, with:

```yaml
server_groups:
  - targets: [promAB:9090]
    inject_matchers:
      - 'cluster="A"'
```

a query of `count(up)` is sent downstream as `count(up{cluster="A"})` — scoping the server_group to a slice of the data **even for queries that never reference `cluster`**.

## Why

This fills the gap between the existing mechanisms (as worked out in the issue discussion):

| option | behavior |
| --- | --- |
| `labels` | only *adds* labels to responses |
| `label_filter` | only *drops* queries that can't match |
| **`inject_matchers`** | always *adds* the matchers to the queries themselves |

The motivating use-case from #698 is presenting a **per-tenant view of a merged downstream** — e.g. you consolidated many Prometheus instances into a single Mimir/Thanos/Prometheus (`PrometheusAB`) but existing Grafana datasources/dashboards/alerts still expect to see only "their" cluster. Running a promxy per tenant with `inject_matchers: ['cluster="A"']` reproduces the old per-datasource scoping without rewriting any dashboards. This is the same idea as prom-label-proxy's `injectproxy`, but native to promxy (so it composes with auth, remote-read, etc.).

## Implementation notes

- New `InjectMatchersClient` (`pkg/promclient/inject_matchers.go`) wraps the downstream API. PromQL queries are rewritten by walking the AST and appending the matchers to every `VectorSelector` (the parser descends into a `MatrixSelector`'s inner selector, so this covers range selectors too). `match[]`-style endpoints and remote-read have the matchers appended to each selector; when no matchers are supplied, a single selector of just the injected matchers is used so the downstream is still scoped.
- Appending is idempotent (a matcher already present is not duplicated) and never mutates the shared matcher slice.
- Wired in `loadTargetGroupMap` **beneath** the existing label-manipulation wrappers, so the injected matchers reach the downstream verbatim and don't interact with `label_filter`'s query filtering or `metrics_relabel`'s matcher reversal.
- Config entries are parsed/validated at config-load time (bad matchers fail fast rather than during a discovery sync).

## Naming

`inject_matchers` was chosen (over `static_matchers` / `enforce_matchers` / `query_matchers`) as it best conveys the mechanism.

## Tests

- `pkg/promclient/inject_matchers_test.go` — verifies injection into Query/QueryRange (aggregations, existing matchers, matrix selectors, binary expressions, multiple matchers, idempotency), Series/LabelValues/LabelNames (including the empty-`match[]` case), and GetValue.
- `pkg/servergroup/config_test.go` — verifies YAML parsing, multi-matcher/regex support, and config-load validation of bad matchers.

`go build ./...` and `go test ./pkg/...` pass.

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)