### PR TITLE
fast /federate encoder to fix perf regression (#784)

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/jacksontj/promxy/pkg/alertbackfill"
 	proxyconfig "github.com/jacksontj/promxy/pkg/config"
+	"github.com/jacksontj/promxy/pkg/federate"
 	"github.com/jacksontj/promxy/pkg/logging"
 	"github.com/jacksontj/promxy/pkg/middleware"
 	"github.com/jacksontj/promxy/pkg/proxystorage"
@@ -460,10 +461,20 @@ func main() {
 	// Register API endpoint with correct route prefix
 	webHandler.Getv1API().Register(webHandler.GetRouter().WithPrefix(apiPrefix))
 
+	// promxy's own /federate handler: a faster encoder for the common
+	// text/plain path (issue #784) that delegates other formats to the vendored
+	// handler. Kept in sync with the configured external_labels on reload.
+	federateHandler := federate.New(ps, opts.QueryLookbackDelta, webHandler.GetRouter())
+	reloadables = append(reloadables, proxyconfig.WrapPromReloadable(&proxyconfig.ApplyConfigFunc{F: func(cfg *config.Config) error {
+		federateHandler.SetExternalLabels(cfg.GlobalConfig.ExternalLabels)
+		return nil
+	}}))
+
 	// Create our router
 	r := httprouter.New()
 
 	r.HandlerFunc("GET", opts.MetricsPath, promhttp.Handler().ServeHTTP)
+	r.HandlerFunc("GET", path.Join(webOptions.RoutePrefix, "/federate"), federateHandler.ServeHTTP)
 
 	stopping := false
 	r.NotFound = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/expfmt/encode.go
+++ b/pkg/expfmt/encode.go
@@ -1,0 +1,290 @@
+// Package expfmt provides a fast, allocation-light encoder for the Prometheus
+// text exposition format.
+//
+// It exists for promxy's /federate endpoint (issue #784). The upstream
+// federation handler builds a full dto.MetricFamily tree per request and hands
+// it to github.com/prometheus/common/expfmt, whose text encoder (since
+// common v0.65 / the Prometheus 3.x UTF-8 name support) re-validates every
+// metric and label name on encode. Together that dominates federation CPU and
+// allocations. promxy already has the data as labels.Labels (it just decoded a
+// downstream response), so it can stream the exposition format directly,
+// skipping the dto tree.
+//
+// The output is byte-for-byte identical to common/expfmt for the subset
+// federation emits: UNTYPED float samples. In particular, name handling
+// (legacy-valid names written bare, otherwise quoted with the metric name moved
+// inside the braces), label-value escaping, and float/timestamp formatting all
+// match common/expfmt exactly, including UTF-8 names. This is verified by
+// byte-equivalence tests against common/expfmt.
+package expfmt
+
+import (
+	"bufio"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// numBufPool holds scratch buffers for formatting floats/ints, mirroring
+// common/expfmt: a per-call stack buffer escapes to the heap once its slice
+// flows into w.Write, so a pool keeps number formatting allocation-free.
+var numBufPool = sync.Pool{New: func() any { b := make([]byte, 0, 24); return &b }}
+
+// Replacers mirror common/expfmt: '\' -> '\\', '\n' -> '\n', and (for quoted
+// strings, i.e. label values and quoted names) '"' -> '\"'.
+var (
+	escaper       = strings.NewReplacer(`\`, `\\`, "\n", `\n`)
+	quotedEscaper = strings.NewReplacer(`\`, `\\`, "\n", `\n`, `"`, `\"`)
+)
+
+// writeName writes a metric or label name: bare if it is a legacy-valid name,
+// otherwise quoted and escaped. Mirrors common/expfmt's writeName.
+func writeName(w *bufio.Writer, name string) {
+	if model.IsValidLegacyMetricName(name) {
+		_, _ = w.WriteString(name)
+		return
+	}
+	_ = w.WriteByte('"')
+	writeEscaped(w, name, true)
+	_ = w.WriteByte('"')
+}
+
+// writeEscaped writes s with the text-format escaping. quote selects whether
+// double quotes are escaped (true for label values and quoted names). A
+// fast-path avoids the Replacer when there is nothing to escape.
+func writeEscaped(w *bufio.Writer, s string, quote bool) {
+	if quote {
+		if !strings.ContainsAny(s, "\\\n\"") {
+			_, _ = w.WriteString(s)
+			return
+		}
+		_, _ = quotedEscaper.WriteString(w, s)
+		return
+	}
+	if !strings.ContainsAny(s, "\\\n") {
+		_, _ = w.WriteString(s)
+		return
+	}
+	_, _ = escaper.WriteString(w, s)
+}
+
+// writeFloat mirrors common/expfmt's writeFloat: hardcoded common cases, then
+// strconv.AppendFloat with a stack buffer to avoid allocation.
+func writeFloat(w *bufio.Writer, f float64) {
+	switch {
+	case f == 1:
+		_ = w.WriteByte('1')
+	case f == 0:
+		_ = w.WriteByte('0')
+	case f == -1:
+		_, _ = w.WriteString("-1")
+	case math.IsNaN(f):
+		_, _ = w.WriteString("NaN")
+	case math.IsInf(f, +1):
+		_, _ = w.WriteString("+Inf")
+	case math.IsInf(f, -1):
+		_, _ = w.WriteString("-Inf")
+	default:
+		bp := numBufPool.Get().(*[]byte)
+		*bp = strconv.AppendFloat((*bp)[:0], f, 'g', -1, 64)
+		_, _ = w.Write(*bp)
+		numBufPool.Put(bp)
+	}
+}
+
+// writeInt writes an int64 (used for timestamps) without allocating.
+func writeInt(w *bufio.Writer, i int64) {
+	bp := numBufPool.Get().(*[]byte)
+	*bp = strconv.AppendInt((*bp)[:0], i, 10)
+	_, _ = w.Write(*bp)
+	numBufPool.Put(bp)
+}
+
+// metricLine writes the "name{labels}" portion of a sample line, replicating
+// common/expfmt's writeNameAndLabelPairs: if the metric name is not
+// legacy-valid it is moved inside the braces as the first (quoted) token.
+type metricLine struct {
+	w         *bufio.Writer
+	separator byte
+	braces    bool // an opening brace has been written
+}
+
+func beginMetric(w *bufio.Writer, name string) metricLine {
+	m := metricLine{w: w, separator: '{'}
+	if name != "" {
+		if !model.IsValidLegacyMetricName(name) {
+			m.braces = true
+			_ = w.WriteByte('{')
+			m.separator = ','
+		}
+		writeName(w, name)
+	}
+	return m
+}
+
+// label writes a single label pair, opening the brace on the first pair.
+func (m *metricLine) label(name, value string) {
+	_ = m.w.WriteByte(m.separator)
+	if m.separator == '{' {
+		m.braces = true
+	}
+	writeName(m.w, name)
+	_, _ = m.w.WriteString(`="`)
+	writeEscaped(m.w, value, true)
+	_ = m.w.WriteByte('"')
+	m.separator = ','
+}
+
+func (m *metricLine) end() {
+	if m.braces {
+		_ = m.w.WriteByte('}')
+	}
+}
+
+// MetricFamilyToText encodes an UNTYPED metric family to the text format,
+// byte-for-byte compatible with common/expfmt for that type. It exists mainly
+// as a testing/benchmarking surface that shares the exact primitives the
+// federation Encoder uses; the federation handler uses Encoder directly.
+func MetricFamilyToText(out io.Writer, mf *dto.MetricFamily) error {
+	w, ok := out.(*bufio.Writer)
+	ownBuf := false
+	if !ok {
+		w = bufio.NewWriter(out)
+		ownBuf = true
+	}
+
+	name := mf.GetName()
+	if mf.Help != nil {
+		_, _ = w.WriteString("# HELP ")
+		writeName(w, name)
+		_ = w.WriteByte(' ')
+		writeEscaped(w, mf.GetHelp(), false)
+		_ = w.WriteByte('\n')
+	}
+	_, _ = w.WriteString("# TYPE ")
+	writeName(w, name)
+	_, _ = w.WriteString(" untyped\n")
+
+	for _, m := range mf.GetMetric() {
+		ml := beginMetric(w, name)
+		for _, lp := range m.GetLabel() {
+			ml.label(lp.GetName(), lp.GetValue())
+		}
+		ml.end()
+		_ = w.WriteByte(' ')
+		writeFloat(w, m.GetUntyped().GetValue())
+		if m.TimestampMs != nil {
+			_ = w.WriteByte(' ')
+			writeInt(w, m.GetTimestampMs())
+		}
+		_ = w.WriteByte('\n')
+	}
+
+	if ownBuf {
+		return w.Flush()
+	}
+	return nil
+}
+
+// Encoder streams federation output (UNTYPED float samples) directly from
+// labels.Labels, without building a dto.MetricFamily. Samples must be supplied
+// grouped by metric name (sorted), matching upstream federation which emits one
+// "# TYPE <name> untyped" line per metric family.
+//
+// scheme is the name-escaping scheme negotiated from the scrape request's
+// Accept header (model.EscapingScheme), applied to every metric and label name
+// exactly as common/expfmt's encoder does via model.EscapeMetricFamily. For the
+// default (UnderscoreEscaping) and legacy-valid names this is allocation-free.
+type Encoder struct {
+	w        *bufio.Writer
+	scheme   model.EscapingScheme
+	lastName string
+	started  bool
+}
+
+func NewEncoder(w io.Writer, scheme model.EscapingScheme) *Encoder {
+	return &Encoder{w: bufio.NewWriter(w), scheme: scheme}
+}
+
+// WriteFloatSample writes one untyped sample.
+//
+//   - name is the metric name (the value of the __name__ label).
+//   - lbls is the full label set of the series; the __name__ label and any
+//     empty-valued labels are skipped (matching upstream federation).
+//   - external are additional labels (e.g. external_labels) to attach, in the
+//     order given, but only when not already present in lbls. Pass them
+//     pre-sorted by name to match upstream byte ordering.
+//
+// A "# TYPE <name> untyped" line is emitted whenever name changes from the
+// previous call, so callers must group samples by name.
+func (e *Encoder) WriteFloatSample(name string, lbls labels.Labels, external []labels.Label, v float64, t int64) {
+	name = model.EscapeName(name, e.scheme)
+	if !e.started || name != e.lastName {
+		_, _ = e.w.WriteString("# TYPE ")
+		writeName(e.w, name)
+		_, _ = e.w.WriteString(" untyped\n")
+		e.lastName = name
+		e.started = true
+	}
+
+	// Inlined metric-line writing (rather than the metricLine helper) so the
+	// lbls.Range closure does not capture a pointer-to-struct and escape to the
+	// heap. We also capture only locals (not the receiver e) so escape analysis
+	// keeps the closure on the stack -- this keeps the encoder allocation-free
+	// per sample.
+	w := e.w
+	scheme := e.scheme
+	sep := byte('{')
+	braces := false
+	if !model.IsValidLegacyMetricName(name) {
+		braces = true
+		_ = w.WriteByte('{')
+		sep = ','
+	}
+	writeName(w, name)
+	lbls.Range(func(l labels.Label) {
+		if l.Name == labels.MetricName || l.Value == "" {
+			return
+		}
+		_ = w.WriteByte(sep)
+		braces = true
+		sep = ','
+		writeName(w, model.EscapeName(l.Name, scheme))
+		_, _ = w.WriteString(`="`)
+		writeEscaped(w, l.Value, true)
+		_ = w.WriteByte('"')
+	})
+	for _, el := range external {
+		// Upstream only suppresses an external label when the series carries
+		// that name with a non-empty value (empty-valued series labels are
+		// dropped before the "globalUsed" check), so mirror that here.
+		if lbls.Get(el.Name) != "" {
+			continue
+		}
+		_ = w.WriteByte(sep)
+		braces = true
+		sep = ','
+		writeName(w, model.EscapeName(el.Name, e.scheme))
+		_, _ = w.WriteString(`="`)
+		writeEscaped(w, el.Value, true)
+		_ = w.WriteByte('"')
+	}
+	if braces {
+		_ = w.WriteByte('}')
+	}
+
+	_ = e.w.WriteByte(' ')
+	writeFloat(e.w, v)
+	_ = e.w.WriteByte(' ')
+	writeInt(e.w, t)
+	_ = e.w.WriteByte('\n')
+}
+
+// Flush flushes any buffered output to the underlying writer.
+func (e *Encoder) Flush() error { return e.w.Flush() }

--- a/pkg/expfmt/encode_bench_test.go
+++ b/pkg/expfmt/encode_bench_test.go
@@ -1,0 +1,72 @@
+package expfmt
+
+import (
+	"io"
+	"strconv"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	commonexpfmt "github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type benchSample struct {
+	lbls labels.Labels
+	v    float64
+	t    int64
+}
+
+func benchSeries(n int) []benchSample {
+	out := make([]benchSample, n)
+	for i := 0; i < n; i++ {
+		out[i] = benchSample{
+			lbls: labels.FromStrings(
+				labels.MetricName, "promxy_bench_metric",
+				"instance", "inst-"+strconv.Itoa(i%500),
+				"job", "bench",
+				"region", "us-east-1",
+				"series", strconv.Itoa(i),
+			),
+			v: float64(i),
+			t: int64(1700000000000 + i),
+		}
+	}
+	return out
+}
+
+// BenchmarkEncoderCommon is the upstream cost per /federate request: build a
+// dto.MetricFamily tree, then encode via common/expfmt.
+func BenchmarkEncoderCommon(b *testing.B) {
+	ss := benchSeries(5000)
+	format := commonexpfmt.NewFormat(commonexpfmt.TypeTextPlain)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		mf := &dto.MetricFamily{Name: sp("promxy_bench_metric"), Type: dto.MetricType_UNTYPED.Enum()}
+		mf.Metric = make([]*dto.Metric, 0, len(ss))
+		for _, s := range ss {
+			mf.Metric = append(mf.Metric, seriesToDTOMetric(s.lbls, nil, s.v, ip(s.t)))
+		}
+		enc := commonexpfmt.NewEncoder(io.Discard, format)
+		if err := enc.Encode(mf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEncoderLean is the promxy path: stream straight from labels, no dto.
+func BenchmarkEncoderLean(b *testing.B) {
+	ss := benchSeries(5000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		enc := NewEncoder(io.Discard, model.UnderscoreEscaping)
+		for _, s := range ss {
+			enc.WriteFloatSample(s.lbls.Get(labels.MetricName), s.lbls, nil, s.v, s.t)
+		}
+		if err := enc.Flush(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/expfmt/encode_test.go
+++ b/pkg/expfmt/encode_test.go
@@ -1,0 +1,169 @@
+package expfmt
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	commonexpfmt "github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func sp(s string) *string   { return &s }
+func fp(f float64) *float64 { return &f }
+func ip(i int64) *int64     { return &i }
+
+func untypedMetric(value float64, ts *int64, lbls ...string) *dto.Metric {
+	m := &dto.Metric{Untyped: &dto.Untyped{Value: fp(value)}, TimestampMs: ts}
+	for i := 0; i+1 < len(lbls); i += 2 {
+		m.Label = append(m.Label, &dto.LabelPair{Name: sp(lbls[i]), Value: sp(lbls[i+1])})
+	}
+	return m
+}
+
+func untypedFamily(name string, metrics ...*dto.Metric) *dto.MetricFamily {
+	return &dto.MetricFamily{
+		Name:   sp(name),
+		Type:   dto.MetricType_UNTYPED.Enum(),
+		Metric: metrics,
+	}
+}
+
+// TestMetricFamilyToTextMatchesCommon asserts our MetricFamilyToText is
+// byte-for-byte identical to common/expfmt's (bare, unescaped) MetricFamilyToText
+// -- which quotes non-legacy names -- across UTF-8 names, value escaping, and
+// special floats. This validates the shared encoding primitives.
+func TestMetricFamilyToTextMatchesCommon(t *testing.T) {
+	cases := map[string]*dto.MetricFamily{
+		"legacy": untypedFamily("http_requests_total",
+			untypedMetric(1234, ip(1700000000000), "method", "get", "code", "200"),
+			untypedMetric(5, ip(1700000000000), "method", "post", "code", "500"),
+		),
+		"no_labels":      untypedFamily("up", untypedMetric(1, ip(1700000000000))),
+		"no_timestamp":   untypedFamily("up", untypedMetric(1, nil, "job", "x")),
+		"colon_name":     untypedFamily("a:b:rate", untypedMetric(2.5, nil, "x", "y")),
+		"empty_value":    untypedFamily("m", untypedMetric(1, nil, "present", "", "other", "v")),
+		"utf8_metric":    untypedFamily("my.metric.name", untypedMetric(7, ip(123), "a", "b")),
+		"utf8_label":     untypedFamily("metric", untypedMetric(7, nil, "label.with.dots", "v")),
+		"utf8_both":      untypedFamily("föö.bar", untypedMetric(7, nil, "münchen", "naïve")),
+		"utf8_no_labels": untypedFamily("my.metric", untypedMetric(7, nil)),
+		"escape_value":   untypedFamily("m", untypedMetric(1, nil, "l", "a\\b\nc\"d")),
+		"escape_in_name": untypedFamily(`weird"name`, untypedMetric(1, nil, "l", "v")),
+		"special_floats": untypedFamily("m",
+			untypedMetric(0, nil, "k", "zero"),
+			untypedMetric(1, nil, "k", "one"),
+			untypedMetric(-1, nil, "k", "negone"),
+			untypedMetric(math.NaN(), nil, "k", "nan"),
+			untypedMetric(math.Inf(1), nil, "k", "posinf"),
+			untypedMetric(math.Inf(-1), nil, "k", "neginf"),
+			untypedMetric(3.141592653589793, nil, "k", "pi"),
+			untypedMetric(-2.5e-10, nil, "k", "small"),
+			untypedMetric(1234567890123, nil, "k", "big"),
+		),
+	}
+
+	for name, mf := range cases {
+		t.Run(name, func(t *testing.T) {
+			var want bytes.Buffer
+			if _, err := commonexpfmt.MetricFamilyToText(&want, mf); err != nil {
+				t.Fatalf("common MetricFamilyToText: %v", err)
+			}
+			var got bytes.Buffer
+			if err := MetricFamilyToText(&got, mf); err != nil {
+				t.Fatalf("MetricFamilyToText: %v", err)
+			}
+			if got.String() != want.String() {
+				t.Fatalf("mismatch\n got: %q\nwant: %q", got.String(), want.String())
+			}
+		})
+	}
+}
+
+// seriesToDTOMetric builds a dto.Metric from a series the same way the federation
+// Encoder writes it: series labels (sorted, minus __name__ and empty values),
+// then external labels not already present, in order.
+func seriesToDTOMetric(lbls labels.Labels, external []labels.Label, v float64, ts *int64) *dto.Metric {
+	m := &dto.Metric{Untyped: &dto.Untyped{Value: fp(v)}, TimestampMs: ts}
+	lbls.Range(func(l labels.Label) {
+		if l.Name == labels.MetricName || l.Value == "" {
+			return
+		}
+		m.Label = append(m.Label, &dto.LabelPair{Name: sp(l.Name), Value: sp(l.Value)})
+	})
+	for _, el := range external {
+		if lbls.Get(el.Name) == "" {
+			m.Label = append(m.Label, &dto.LabelPair{Name: sp(el.Name), Value: sp(el.Value)})
+		}
+	}
+	return m
+}
+
+// TestEncoderMatchesCommonAcrossSchemes asserts the streaming Encoder is
+// byte-for-byte identical to common/expfmt's encoder path
+// (MetricFamilyToText(EscapeMetricFamily(mf, scheme))) for both the default
+// underscore-escaping scheme and the allow-utf-8 (quoting) scheme. This is the
+// correctness guarantee for the lean /federate handler, including UTF-8 names.
+func TestEncoderMatchesCommonAcrossSchemes(t *testing.T) {
+	type series struct {
+		lbls     labels.Labels
+		external []labels.Label
+		v        float64
+		t        int64
+	}
+	external := []labels.Label{{Name: "region", Value: "us-east"}, {Name: "src", Value: "promxy"}}
+
+	groups := map[string][]series{
+		"legacy": {
+			{lbls: labels.FromStrings("__name__", "http_requests_total", "code", "200", "method", "get"), external: external, v: 1234, t: 1700000000000},
+			{lbls: labels.FromStrings("__name__", "http_requests_total", "code", "500", "method", "post", "region", "eu"), external: external, v: 5, t: 1700000000000},
+		},
+		"utf8_names": {
+			{lbls: labels.FromStrings("__name__", "my.metric", "label.dots", "v", "ok", "1"), external: external, v: 7, t: 123},
+			{lbls: labels.FromStrings("__name__", "my.metric", "münchen", "naïve"), external: external, v: math.NaN(), t: 456},
+		},
+		"special_and_escape": {
+			{lbls: labels.FromStrings("__name__", "m", "l", "a\\b\nc\"d"), v: math.Inf(1), t: 1},
+			{lbls: labels.FromStrings("__name__", "m", "l", "x"), v: 0, t: 2},
+		},
+	}
+
+	schemes := map[string]model.EscapingScheme{
+		"underscore": model.UnderscoreEscaping,
+		"utf8":       model.NoEscaping,
+	}
+
+	for gname, ss := range groups {
+		for sname, scheme := range schemes {
+			t.Run(gname+"/"+sname, func(t *testing.T) {
+				// Reference: build the dto family (one metric name per group),
+				// escape per scheme, encode with common's bare MetricFamilyToText
+				// -- exactly common/expfmt's NewEncoder text path.
+				name := ss[0].lbls.Get(labels.MetricName)
+				mf := &dto.MetricFamily{Name: sp(name), Type: dto.MetricType_UNTYPED.Enum()}
+				for _, s := range ss {
+					mf.Metric = append(mf.Metric, seriesToDTOMetric(s.lbls, s.external, s.v, ip(s.t)))
+				}
+				var want bytes.Buffer
+				if _, err := commonexpfmt.MetricFamilyToText(&want, model.EscapeMetricFamily(mf, scheme)); err != nil {
+					t.Fatalf("common encode: %v", err)
+				}
+
+				// Ours: stream each series through the Encoder.
+				var got bytes.Buffer
+				enc := NewEncoder(&got, scheme)
+				for _, s := range ss {
+					enc.WriteFloatSample(s.lbls.Get(labels.MetricName), s.lbls, s.external, s.v, s.t)
+				}
+				if err := enc.Flush(); err != nil {
+					t.Fatalf("flush: %v", err)
+				}
+
+				if got.String() != want.String() {
+					t.Fatalf("mismatch\n got: %q\nwant: %q", got.String(), want.String())
+				}
+			})
+		}
+	}
+}

--- a/pkg/federate/federate.go
+++ b/pkg/federate/federate.go
@@ -1,0 +1,180 @@
+// Package federate provides a fast /federate handler for promxy.
+//
+// It is a drop-in replacement for the vendored Prometheus federation handler
+// for the common case (text/plain exposition of float samples), avoiding the
+// per-request dto.MetricFamily tree and the encode-time name re-validation that
+// dominate federation CPU/allocations (issue #784). For any other negotiated
+// format (protobuf, OpenMetrics) -- and thus for native histograms, which are
+// only servable over those formats -- it transparently delegates to a fallback
+// handler (the vendored one), so behavior is unchanged outside the fast path.
+//
+// The query path (selectors, lookback window, merge, staleness handling, sort,
+// external-label attachment) mirrors the vendored handler exactly, and the
+// output is byte-for-byte identical (verified by tests against the vendored
+// handler); only the encoding is replaced with pkg/expfmt.
+package federate
+
+import (
+	"net/http"
+	"slices"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	commonexpfmt "github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/sirupsen/logrus"
+
+	promexpfmt "github.com/jacksontj/promxy/pkg/expfmt"
+)
+
+// Handler serves /federate. Construct with New and keep external labels current
+// via SetExternalLabels on each config reload.
+type Handler struct {
+	queryable storage.Queryable
+	lookback  time.Duration
+	fallback  http.Handler
+
+	// extLabels holds the federation external labels (sorted, including the
+	// implicit empty "instance" default), swapped atomically on config reload.
+	extLabels atomic.Pointer[[]labels.Label]
+
+	now func() time.Time // overridable in tests
+}
+
+// New returns a federation handler that queries queryable over the given
+// lookback window and delegates non-text formats to fallback.
+func New(queryable storage.Queryable, lookback time.Duration, fallback http.Handler) *Handler {
+	h := &Handler{queryable: queryable, lookback: lookback, fallback: fallback, now: time.Now}
+	empty := []labels.Label{{Name: model.InstanceLabel, Value: ""}}
+	h.extLabels.Store(&empty)
+	return h
+}
+
+// SetExternalLabels updates the external labels attached to federated series.
+// It mirrors the vendored handler: the configured global external_labels plus
+// an implicit empty "instance" label when not otherwise set. Safe for
+// concurrent use with ServeHTTP.
+func (h *Handler) SetExternalLabels(ext labels.Labels) {
+	m := map[string]string{}
+	ext.Range(func(l labels.Label) { m[l.Name] = l.Value })
+	if _, ok := m[model.InstanceLabel]; !ok {
+		m[model.InstanceLabel] = ""
+	}
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]labels.Label, 0, len(names))
+	for _, n := range names {
+		out = append(out, labels.Label{Name: n, Value: m[n]})
+	}
+	h.extLabels.Store(&out)
+}
+
+type floatSample struct {
+	metric labels.Labels
+	t      int64
+	f      float64
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Only the text/plain exposition path is handled here; protobuf/OpenMetrics
+	// (and therefore native histograms) fall back to the vendored handler.
+	format := commonexpfmt.Negotiate(req.Header)
+	if format.FormatType() != commonexpfmt.TypeTextPlain {
+		h.fallback.ServeHTTP(w, req)
+		return
+	}
+
+	ctx := req.Context()
+	if err := req.ParseForm(); err != nil {
+		http.Error(w, "error parsing form values: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	matcherSets, err := parser.ParseMetricSelectors(req.Form["match[]"])
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	mint := timestamp.FromTime(h.now().Add(-h.lookback))
+	maxt := timestamp.FromTime(h.now())
+
+	q, err := h.queryable.Querier(mint, maxt)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer q.Close()
+
+	hints := &storage.SelectHints{Start: mint, End: maxt}
+	var sets []storage.SeriesSet
+	for _, mset := range matcherSets {
+		sets = append(sets, q.Select(ctx, true, hints, mset...))
+	}
+	set := storage.NewMergeSeriesSet(sets, 0, storage.ChainedSeriesMerge)
+
+	it := storage.NewBuffer(int64(h.lookback / 1e6))
+	var chkIter chunkenc.Iterator
+	var vec []floatSample
+	for set.Next() {
+		s := set.At()
+		chkIter = s.Iterator(chkIter)
+		it.Reset(chkIter)
+
+		var (
+			t int64
+			f float64
+		)
+		switch it.Seek(maxt) {
+		case chunkenc.ValFloat:
+			t, f = it.At()
+		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
+			// Native histograms are not representable in the text format; the
+			// vendored handler drops them here too.
+			continue
+		default:
+			sample, ok := it.PeekBack(1)
+			if !ok || sample.Type() != chunkenc.ValFloat {
+				continue
+			}
+			t, f = sample.T(), sample.F()
+		}
+		// Exposition formats have no stale marker; drop stale samples.
+		if value.IsStaleNaN(f) {
+			continue
+		}
+		vec = append(vec, floatSample{metric: s.Labels(), t: t, f: f})
+	}
+	if ws := set.Warnings(); len(ws) > 0 {
+		logrus.WithField("warnings", ws).Debug("federation select returned warnings")
+	}
+	if err := set.Err(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	slices.SortFunc(vec, func(a, b floatSample) int {
+		return strings.Compare(a.metric.Get(labels.MetricName), b.metric.Get(labels.MetricName))
+	})
+
+	external := *h.extLabels.Load()
+	w.Header().Set("Content-Type", string(format))
+	enc := promexpfmt.NewEncoder(w, format.ToEscapingScheme())
+	for i := range vec {
+		s := &vec[i]
+		enc.WriteFloatSample(s.metric.Get(labels.MetricName), s.metric, external, s.f, s.t)
+	}
+	if err := enc.Flush(); err != nil {
+		logrus.WithError(err).Error("federation failed")
+	}
+}

--- a/pkg/federate/federate_test.go
+++ b/pkg/federate/federate_test.go
@@ -1,0 +1,257 @@
+package federate
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	commonexpfmt "github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+func sp(s string) *string   { return &s }
+func fp(f float64) *float64 { return &f }
+func ip(i int64) *int64     { return &i }
+
+// referenceFederate is a faithful copy of the vendored Prometheus federation
+// handler (web/federate.go) for the text/float path, encoding via
+// common/expfmt. It is the equivalence oracle for our handler.
+func referenceFederate(q storage.Queryable, lookback time.Duration, now time.Time, extCfg labels.Labels, req *http.Request) ([]byte, error) {
+	if err := req.ParseForm(); err != nil {
+		return nil, err
+	}
+	matcherSets, err := parser.ParseMetricSelectors(req.Form["match[]"])
+	if err != nil {
+		return nil, err
+	}
+
+	mint := timestamp.FromTime(now.Add(-lookback))
+	maxt := timestamp.FromTime(now)
+	format := commonexpfmt.Negotiate(req.Header)
+	var buf bytes.Buffer
+	enc := commonexpfmt.NewEncoder(&buf, format)
+
+	querier, err := q.Querier(mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+	defer querier.Close()
+
+	vec := make([]promql.Sample, 0, 8000)
+	hints := &storage.SelectHints{Start: mint, End: maxt}
+	var sets []storage.SeriesSet
+	for _, mset := range matcherSets {
+		sets = append(sets, querier.Select(context.Background(), true, hints, mset...))
+	}
+	set := storage.NewMergeSeriesSet(sets, 0, storage.ChainedSeriesMerge)
+	it := storage.NewBuffer(int64(lookback / 1e6))
+	var chkIter chunkenc.Iterator
+Loop:
+	for set.Next() {
+		s := set.At()
+		chkIter = s.Iterator(chkIter)
+		it.Reset(chkIter)
+		var (
+			t  int64
+			f  float64
+			fh *histogram.FloatHistogram
+		)
+		switch it.Seek(maxt) {
+		case chunkenc.ValFloat:
+			t, f = it.At()
+		case chunkenc.ValFloatHistogram, chunkenc.ValHistogram:
+			t, fh = it.AtFloatHistogram(nil)
+		default:
+			sample, ok := it.PeekBack(1)
+			if !ok {
+				continue Loop
+			}
+			t = sample.T()
+			switch sample.Type() {
+			case chunkenc.ValFloat:
+				f = sample.F()
+			case chunkenc.ValHistogram:
+				fh = sample.H().ToFloat(nil)
+			case chunkenc.ValFloatHistogram:
+				fh = sample.FH()
+			default:
+				continue Loop
+			}
+		}
+		if value.IsStaleNaN(f) || (fh != nil && value.IsStaleNaN(fh.Sum)) {
+			continue
+		}
+		vec = append(vec, promql.Sample{Metric: s.Labels(), T: t, F: f, H: fh})
+	}
+	if set.Err() != nil {
+		return nil, set.Err()
+	}
+
+	slices.SortFunc(vec, func(a, b promql.Sample) int {
+		return strings.Compare(a.Metric.Get(labels.MetricName), b.Metric.Get(labels.MetricName))
+	})
+
+	externalLabels := extCfg.Map()
+	if _, ok := externalLabels[model.InstanceLabel]; !ok {
+		externalLabels[model.InstanceLabel] = ""
+	}
+	externalLabelNames := make([]string, 0, len(externalLabels))
+	for ln := range externalLabels {
+		externalLabelNames = append(externalLabelNames, ln)
+	}
+	sort.Strings(externalLabelNames)
+
+	var (
+		lastMetricName string
+		protMetricFam  *dto.MetricFamily
+	)
+	for _, s := range vec {
+		if s.H != nil {
+			continue // text format can't carry native histograms
+		}
+		nameSeen := false
+		globalUsed := map[string]struct{}{}
+		protMetric := &dto.Metric{Untyped: &dto.Untyped{}}
+		err := s.Metric.Validate(func(l labels.Label) error {
+			if l.Value == "" {
+				return nil
+			}
+			if l.Name == labels.MetricName {
+				nameSeen = true
+				if l.Value == lastMetricName {
+					return nil
+				}
+				if protMetricFam != nil {
+					if err := enc.Encode(protMetricFam); err != nil {
+						return err
+					}
+				}
+				protMetricFam = &dto.MetricFamily{Type: dto.MetricType_UNTYPED.Enum(), Name: sp(l.Value)}
+				lastMetricName = l.Value
+				return nil
+			}
+			protMetric.Label = append(protMetric.Label, &dto.LabelPair{Name: sp(l.Name), Value: sp(l.Value)})
+			if _, ok := externalLabels[l.Name]; ok {
+				globalUsed[l.Name] = struct{}{}
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if !nameSeen {
+			continue
+		}
+		for _, ln := range externalLabelNames {
+			if _, ok := globalUsed[ln]; !ok {
+				protMetric.Label = append(protMetric.Label, &dto.LabelPair{Name: sp(ln), Value: sp(externalLabels[ln])})
+			}
+		}
+		protMetric.TimestampMs = ip(s.T)
+		protMetric.Untyped.Value = fp(s.F)
+		protMetricFam.Metric = append(protMetricFam.Metric, protMetric)
+	}
+	if protMetricFam != nil {
+		if err := enc.Encode(protMetricFam); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// TestFederateFallsBackForNonText asserts that a request negotiating a non-text
+// format (e.g. protobuf, which can carry native histograms) is delegated to the
+// fallback (vendored) handler rather than handled by the fast text path.
+func TestFederateFallsBackForNonText(t *testing.T) {
+	st := promqltest.LoadedStorage(t, "load 1m\n  up 1 1 1\n")
+	t.Cleanup(func() { st.Close() })
+
+	fellBack := false
+	h := New(st, 5*time.Minute, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fellBack = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	h.now = func() time.Time { return timestamp.Time(120000) }
+
+	req := httptest.NewRequest(http.MethodGet, "/federate?match%5B%5D=up", nil)
+	req.Header.Set("Accept", string(commonexpfmt.NewFormat(commonexpfmt.TypeProtoDelim)))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if !fellBack {
+		t.Fatal("expected protobuf request to fall back to the vendored handler")
+	}
+}
+
+// TestFederateMatchesVendored asserts our handler's output is byte-for-byte
+// identical to the vendored federation handler across a range of selectors and
+// external-label configurations.
+func TestFederateMatchesVendored(t *testing.T) {
+	st := promqltest.LoadedStorage(t, `
+load 1m
+  http_requests_total{code="200",method="get"}   1 2 3
+  http_requests_total{code="500",method="post"}   0 0 1
+  http_requests_total{code="200",method="post",instance="i-1"}  7 8 9
+  node_cpu{cpu="0"}   0.1 0.2 0.3
+  up   1 1 1
+`)
+	t.Cleanup(func() { st.Close() })
+
+	now := timestamp.Time(120000) // last loaded sample is at t=120s
+	lookback := 5 * time.Minute
+
+	extCases := map[string]labels.Labels{
+		"none":              labels.EmptyLabels(),
+		"source_only":       labels.FromStrings("source", "promxy"),
+		"with_instance":     labels.FromStrings("source", "promxy", "instance", "fed-1"),
+		"collide_with_code": labels.FromStrings("code", "EXT", "region", "us"),
+	}
+	matchCases := []string{
+		`{__name__="http_requests_total"}`,
+		`up`,
+		`{__name__=~".+"}`,
+		`node_cpu`,
+	}
+
+	for extName, ext := range extCases {
+		for _, match := range matchCases {
+			t.Run(extName+"/"+match, func(t *testing.T) {
+				target := "/federate?match%5B%5D=" + url.QueryEscape(match)
+
+				h := New(st, lookback, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+					t.Fatal("unexpected fallback to vendored handler for text/plain request")
+				}))
+				h.now = func() time.Time { return now }
+				h.SetExternalLabels(ext)
+
+				rec := httptest.NewRecorder()
+				h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+
+				want, err := referenceFederate(st, lookback, now, ext, httptest.NewRequest(http.MethodGet, target, nil))
+				if err != nil {
+					t.Fatalf("reference: %v", err)
+				}
+
+				if got := rec.Body.Bytes(); !bytes.Equal(got, want) {
+					t.Fatalf("output mismatch\n got: %q\nwant: %q", got, want)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

A faster, lower-allocation `/federate` encoder for promxy. Related to #784, but see **Scope** below — this is a standalone perf/allocation improvement, not a confirmed fix for the `http2: stream closed` reports.

Two costs dominate federation CPU/allocations:
1. **Encode regression** — Prometheus 3.x UTF-8 name support made `common/expfmt`'s text encoder re-validate **every** metric/label name on encode (`writeName` → `model.IsValidLegacyMetricName`), ~50% slower than common v0.42 (0.85 ms → 1.28 ms / 5000 series). Not fixed upstream through the latest `common` (v0.67.2) or `main`.
2. **(pre-existing) dto tree** — the vendored federation handler builds a full `dto.MetricFamily` tree per request (~95k allocs / 5000 series) before encoding.

(Decoding the downstream response is **not** a regression — it's flat old-vs-new.)

## What this does

- **`pkg/expfmt`** — a fast text-exposition encoder that streams directly from `labels.Labels` (no `dto` tree, pooled number buffers). **Byte-for-byte compatible** with `common/expfmt`, verified across legacy and UTF-8 names under both the underscore-escaping and `allow-utf-8` (quoting) schemes, value escaping, and special floats.
- **`pkg/federate`** — a promxy `/federate` handler on top of it. Mirrors the vendored query / staleness / sort / external-label semantics exactly (byte-for-byte equivalence tested against a replica of the vendored handler), and transparently **delegates non-text formats** (protobuf, OpenMetrics — and thus native histograms) to the vendored handler.
- Wired in `cmd/promxy/main.go`, kept in sync with `global.external_labels` on reload.

## UTF-8 safety

The encoder replicates `common/expfmt`'s exact escaping logic (`model.EscapeName` per the negotiated `Accept` scheme, then quote-if-non-legacy), proven equal by `TestMetricFamilyToTextMatchesCommon` / `TestEncoderMatchesCommonAcrossSchemes`. The win comes from skipping the `dto` tree, not from cutting validation.

## Results

Encode benchmark, 5000 series (`pkg/expfmt`):

| | ns/op | allocs/op | B/op |
|---|---|---|---|
| common (dto build + encode) | 3,211,232 | 95,034 | 3.28 MB |
| pkg/expfmt (stream from labels) | 1,431,929 | **2** | 4 KB |

~2.2× faster, **95,034 → 2 allocs/op**.

## Scope — does this fix #784?

**Probably not on its own.** A multi-downstream (HA) benchmark, old vs new, found **no meaningful regression in the federation query path**:

| scenario | old | new |
|---|---|---|
| 3-member HA, instant downstreams | 0.358s | 0.395s (~10%, CPU only) |
| 3-member HA, 300ms downstream latency | 0.46s | 0.46s (identical) |

HA members are queried in parallel in both versions (no concurrency/merge regression), response bytes are identical, and the serving layer (`ServeTLS`/HTTP-2/timeouts) is unchanged. The only regression is the ~14% encode/CPU tax this PR fixes — which is negligible once real downstream latency dominates. So the `http2: stream closed` reports (client closing mid-response) are unlikely to be explained by encode latency, and this PR is best evaluated as a standalone efficiency improvement. Investigation into the reporter's symptom continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)