### PR TITLE
[cmd/promxy] add `--query.align-range-with-step` to fix no-data on unaligned `query_range`

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -98,8 +98,10 @@ type cliOpts struct {
 	QueryMaxSamples     int           `long:"query.max-samples" description:"Maximum number of samples a single query can load into memory. Note that queries will fail if they would load more samples than this into memory, so this also limits the number of samples a query can return." default:"50000000"`
 	QueryLookbackDelta  time.Duration `long:"query.lookback-delta" description:"The maximum lookback duration for retrieving metrics during expression evaluations." default:"5m"`
 	QueryMaxConcurrency int           `long:"query.max-concurrency" default:"-1" description:"Maximum number of queries executed concurrently."`
-	StoragePath         string        `long:"storage.path" description:"Base directory for promxy's local working state (active query tracker file, remote_write WAL)."`
-	LegacyStoragePath   string        `long:"storage.tsdb.path" description:"DEPRECATED: use --storage.path instead. (Promxy has no TSDB; this flag is misnamed.)"`
+
+	QueryAlignRangeWithStep bool   `long:"query.align-range-with-step" description:"Snap /api/v1/query_range start/end down to a multiple of step before evaluation. Off by default. Fixes 'no data' when start/end are not step-aligned and a backend (e.g. Mimir/Cortex) step-aligns query_range results."`
+	StoragePath             string `long:"storage.path" description:"Base directory for promxy's local working state (active query tracker file, remote_write WAL)."`
+	LegacyStoragePath       string `long:"storage.tsdb.path" description:"DEPRECATED: use --storage.path instead. (Promxy has no TSDB; this flag is misnamed.)"`
 
 	RemoteReadMaxConcurrency int `long:"remote-read.max-concurrency" description:"Maximum number of concurrent remote read calls." default:"10"`
 
@@ -519,7 +521,13 @@ func main() {
 		logrus.Fatalf("Invalid AccessLogDestination: %s", opts.AccessLogDestination)
 	}
 
-	srv, err := server.CreateAndStart(opts.BindAddr, opts.LogFormat, opts.WebReadTimeout, accessLogOut, middleware.NewProxyHeaders(r, opts.ProxyHeaders), opts.WebConfigFile)
+	var handler http.Handler = r
+	if opts.QueryAlignRangeWithStep {
+		handler = middleware.NewAlignQueryRangeStep(handler, path.Join(apiPrefix, "query_range"))
+	}
+	handler = middleware.NewProxyHeaders(handler, opts.ProxyHeaders)
+
+	srv, err := server.CreateAndStart(opts.BindAddr, opts.LogFormat, opts.WebReadTimeout, accessLogOut, handler, opts.WebConfigFile)
 	if err != nil {
 		logrus.Fatalf("Error creating server: %v", err)
 	}

--- a/pkg/middleware/align_range.go
+++ b/pkg/middleware/align_range.go
@@ -1,0 +1,102 @@
+package middleware
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+// NewAlignQueryRangeStep wraps h and, for requests to queryRangePath, snaps the query_range
+// start/end down to a multiple of step before they reach the wrapped handler. This keeps Promxy's
+// local evaluation grid on the epoch step grid, matching backends that step-align query_range
+// results (e.g. Mimir/Cortex); without it an unaligned start (start % step != 0) yields no data.
+func NewAlignQueryRangeStep(h http.Handler, queryRangePath string) *AlignQueryRangeStep {
+	return &AlignQueryRangeStep{h: h, path: queryRangePath}
+}
+
+type AlignQueryRangeStep struct {
+	h    http.Handler
+	path string
+}
+
+func (a *AlignQueryRangeStep) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == a.path {
+		alignRangeRequest(r)
+	}
+	a.h.ServeHTTP(w, r)
+}
+
+// alignRangeRequest rewrites the request form in place. It is a no-op if start/end/step are
+// missing or unparsable, or if the range is already aligned.
+func alignRangeRequest(r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		return
+	}
+	stepStr, startStr, endStr := r.Form.Get("step"), r.Form.Get("start"), r.Form.Get("end")
+	if stepStr == "" || startStr == "" || endStr == "" {
+		return
+	}
+	step, err := parseQueryDuration(stepStr)
+	if err != nil || step <= 0 {
+		return
+	}
+	start, err := parseQueryTime(startStr)
+	if err != nil {
+		return
+	}
+	end, err := parseQueryTime(endStr)
+	if err != nil {
+		return
+	}
+	stepMs := step.Milliseconds()
+	if stepMs <= 0 {
+		return
+	}
+	r.Form.Set("start", formatUnixMillis(floorToStep(start.UnixMilli(), stepMs)))
+	r.Form.Set("end", formatUnixMillis(floorToStep(end.UnixMilli(), stepMs)))
+}
+
+// floorToStep snaps a millisecond timestamp down to a multiple of step. This mirrors the
+// algorithm used by Mimir's query-frontend step alignment, itself from Cortex (Apache-2.0):
+// start := (start / step) * step. It is reimplemented here rather than imported to avoid pulling
+// in Mimir (AGPL-3.0, and a conflicting prometheus fork). Query timestamps are non-negative, so
+// integer truncation toward zero is equivalent to floor.
+func floorToStep(tsMs, stepMs int64) int64 {
+	return (tsMs / stepMs) * stepMs
+}
+
+func formatUnixMillis(ms int64) string {
+	return strconv.FormatFloat(float64(ms)/1000, 'f', -1, 64)
+}
+
+// parseQueryTime and parseQueryDuration mirror the parsing in prometheus/web/api/v1 so the
+// rewritten values are interpreted identically by the downstream handler.
+func parseQueryTime(s string) (time.Time, error) {
+	if v, err := strconv.ParseFloat(s, 64); err == nil {
+		sec, frac := math.Modf(v)
+		frac = math.Round(frac*1000) / 1000
+		return time.Unix(int64(sec), int64(frac*float64(time.Second))).UTC(), nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("cannot parse %q to a valid timestamp", s)
+}
+
+func parseQueryDuration(s string) (time.Duration, error) {
+	if v, err := strconv.ParseFloat(s, 64); err == nil {
+		ts := v * float64(time.Second)
+		if ts > float64(math.MaxInt64) || ts < float64(math.MinInt64) {
+			return 0, fmt.Errorf("cannot parse %q to a valid duration. It overflows int64", s)
+		}
+		return time.Duration(ts), nil
+	}
+	if d, err := model.ParseDuration(s); err == nil {
+		return time.Duration(d), nil
+	}
+	return 0, fmt.Errorf("cannot parse %q to a valid duration", s)
+}

--- a/pkg/middleware/align_range_test.go
+++ b/pkg/middleware/align_range_test.go
@@ -1,0 +1,260 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// epoch-grid (multiple of 7200s) anchors used across tests.
+const (
+	onGridStart = "1781654400" // 2026-06-17T00:00:00Z
+	onGridEnd   = "1781697600" // 2026-06-17T12:00:00Z
+	offGridStr  = "1781658000" // 2026-06-17T01:00:00Z (off grid by 1h)
+	offGridEnd  = "1781701200" // 2026-06-17T13:00:00Z
+)
+
+func TestAlignRangeRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		start, end, step   string
+		wantStart, wantEnd string
+		wantUntouched      bool
+	}{
+		{
+			name:  "off-grid unix seconds floored down",
+			start: offGridStr, end: offGridEnd, step: "7200",
+			wantStart: onGridStart, wantEnd: onGridEnd,
+		},
+		{
+			name:  "on-grid unchanged",
+			start: onGridStart, end: onGridEnd, step: "7200",
+			wantStart: onGridStart, wantEnd: onGridEnd,
+		},
+		{
+			name:  "off-grid RFC3339 floored down",
+			start: "2026-06-17T01:00:00Z", end: "2026-06-17T13:00:00Z", step: "7200",
+			wantStart: onGridStart, wantEnd: onGridEnd,
+		},
+		{
+			name:  "missing step is a no-op",
+			start: offGridStr, end: offGridEnd, step: "",
+			wantUntouched: true,
+		},
+		{
+			name:  "zero step is a no-op",
+			start: offGridStr, end: offGridEnd, step: "0",
+			wantUntouched: true,
+		},
+		{
+			name:  "unparsable start is a no-op",
+			start: "not-a-time", end: offGridEnd, step: "7200",
+			wantUntouched: true,
+		},
+		{
+			name:  "unparsable end is a no-op",
+			start: offGridStr, end: "not-a-time", step: "7200",
+			wantUntouched: true,
+		},
+		{
+			name:  "sub-millisecond step is a no-op",
+			start: offGridStr, end: offGridEnd, step: "0.0005",
+			wantUntouched: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := url.Values{}
+			if tc.start != "" {
+				v.Set("start", tc.start)
+			}
+			if tc.end != "" {
+				v.Set("end", tc.end)
+			}
+			if tc.step != "" {
+				v.Set("step", tc.step)
+			}
+			req := httptest.NewRequest("GET", "/api/v1/query_range?"+v.Encode(), nil)
+
+			alignRangeRequest(req)
+
+			gotStart, gotEnd := req.Form.Get("start"), req.Form.Get("end")
+			if tc.wantUntouched {
+				if gotStart != tc.start || gotEnd != tc.end {
+					t.Fatalf("expected no rewrite, got start=%q end=%q (was start=%q end=%q)", gotStart, gotEnd, tc.start, tc.end)
+				}
+				return
+			}
+
+			gotStartT, err := parseQueryTime(gotStart)
+			if err != nil {
+				t.Fatalf("rewritten start %q unparsable: %v", gotStart, err)
+			}
+			gotEndT, err := parseQueryTime(gotEnd)
+			if err != nil {
+				t.Fatalf("rewritten end %q unparsable: %v", gotEnd, err)
+			}
+			wantStartT, _ := parseQueryTime(tc.wantStart)
+			wantEndT, _ := parseQueryTime(tc.wantEnd)
+			if !gotStartT.Equal(wantStartT) {
+				t.Errorf("start: got %v, want %v", gotStartT.UTC(), wantStartT.UTC())
+			}
+			if !gotEndT.Equal(wantEndT) {
+				t.Errorf("end: got %v, want %v", gotEndT.UTC(), wantEndT.UTC())
+			}
+			const stepMs = int64(7200 * 1000)
+			if gotStartT.UnixMilli()%stepMs != 0 || gotEndT.UnixMilli()%stepMs != 0 {
+				t.Errorf("result not aligned to step: start=%v end=%v", gotStartT.UTC(), gotEndT.UTC())
+			}
+		})
+	}
+}
+
+// TestAlignRangeRequestPOST ensures the form-body (POST) path is rewritten too, not just the URL query (GET) path.
+func TestAlignRangeRequestPOST(t *testing.T) {
+	body := url.Values{"start": {offGridStr}, "end": {offGridEnd}, "step": {"7200"}}.Encode()
+	req := httptest.NewRequest("POST", "/api/v1/query_range", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	alignRangeRequest(req)
+
+	if got := req.Form.Get("start"); got != onGridStart {
+		t.Errorf("start: got %q, want %q", got, onGridStart)
+	}
+	if got := req.Form.Get("end"); got != onGridEnd {
+		t.Errorf("end: got %q, want %q", got, onGridEnd)
+	}
+}
+
+// TestAlignRangeRequestParseFormError covers the ParseForm error path (malformed query string):
+// the function must return without panicking and without rewriting anything.
+func TestAlignRangeRequestParseFormError(t *testing.T) {
+	req := httptest.NewRequest("GET", "/api/v1/query_range", nil)
+	req.URL.RawQuery = "%zz" // invalid percent-encoding -> ParseForm errors
+	alignRangeRequest(req)
+	if got := req.Form.Get("start"); got != "" {
+		t.Errorf("expected no rewrite on ParseForm error, got start=%q", got)
+	}
+}
+
+func TestAlignQueryRangeStepServeHTTP(t *testing.T) {
+	var called bool
+	var gotStart string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_ = r.ParseForm()
+		gotStart = r.Form.Get("start")
+	})
+	mw := NewAlignQueryRangeStep(inner, "/api/v1/query_range")
+
+	// Matching path -> start aligned before reaching inner handler.
+	mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/v1/query_range?start="+offGridStr+"&end="+offGridEnd+"&step=7200", nil))
+	if !called {
+		t.Fatal("inner handler not called")
+	}
+	if gotStart != onGridStart {
+		t.Errorf("matching path: got start=%q, want %q", gotStart, onGridStart)
+	}
+
+	// Non-matching path -> passed through untouched.
+	called, gotStart = false, ""
+	mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/api/v1/query?start="+offGridStr, nil))
+	if !called {
+		t.Fatal("inner handler not called on passthrough")
+	}
+	if gotStart != offGridStr {
+		t.Errorf("passthrough modified start: got %q, want %q", gotStart, offGridStr)
+	}
+}
+
+func TestFloorToStep(t *testing.T) {
+	for _, tc := range []struct {
+		ts, step, want int64
+	}{
+		{ts: 3600_000, step: 7200_000, want: 0},
+		{ts: 7200_000, step: 7200_000, want: 7200_000},
+		{ts: 10800_000, step: 7200_000, want: 7200_000},
+		{ts: 0, step: 7200_000, want: 0},
+	} {
+		if got := floorToStep(tc.ts, tc.step); got != tc.want {
+			t.Errorf("floorToStep(%d,%d)=%d, want %d", tc.ts, tc.step, got, tc.want)
+		}
+	}
+}
+
+func TestParseQueryTime(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		wantSec int64
+		wantErr bool
+	}{
+		{in: "1781654400", wantSec: 1781654400},
+		{in: "1781654400.000", wantSec: 1781654400},
+		{in: "2026-06-17T00:00:00Z", wantSec: 1781654400},
+		{in: "2026-06-17T00:00:00.000Z", wantSec: 1781654400},
+		{in: "not-a-time", wantErr: true},
+		{in: "", wantErr: true},
+	} {
+		got, err := parseQueryTime(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseQueryTime(%q): expected error, got %v", tc.in, got.UTC())
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseQueryTime(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		if got.Unix() != tc.wantSec {
+			t.Errorf("parseQueryTime(%q): got %d, want %d", tc.in, got.Unix(), tc.wantSec)
+		}
+	}
+}
+
+func TestParseQueryDuration(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{in: "7200", want: 2 * time.Hour},
+		{in: "120.5", want: 120500 * time.Millisecond},
+		{in: "2h", want: 2 * time.Hour},
+		{in: "5m", want: 5 * time.Minute},
+		{in: "garbage", wantErr: true},
+		{in: "1e19", wantErr: true}, // overflows int64 nanoseconds
+	} {
+		got, err := parseQueryDuration(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parseQueryDuration(%q): expected error, got %v", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseQueryDuration(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseQueryDuration(%q): got %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFormatUnixMillis(t *testing.T) {
+	for _, tc := range []struct {
+		ms   int64
+		want string
+	}{
+		{ms: 1781654400000, want: "1781654400"},
+		{ms: 1781654400500, want: "1781654400.5"},
+		{ms: 0, want: "0"},
+	} {
+		if got := formatUnixMillis(tc.ms); got != tc.want {
+			t.Errorf("formatUnixMillis(%d): got %q, want %q", tc.ms, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #787

### What's happening

A `query_range` whose `start`/`end` aren't multiples of `step` is off the epoch step grid. Promxy re-evaluates backend results through its local engine with a tight `LookbackDelta = step - 1ns`, but backends (e.g., Mimir/Cortex) return samples snapped to the epoch grid (`k*step`). When the grids don't coincide, every point falls outside the lookback window and returns no data. Requests already aligned to the step (`start % step == 0`) work.

### Fix

New opt-in flag `--query.align-range-with-step` (off by default). When enabled, incoming `/api/v1/query_range` `start`/`end` are floored to a multiple of `step` before evaluation, so Promxy's grid matches the epoch grid backends return.

Implemented as an `http.Handler` middleware in `pkg/middleware` (`NewAlignQueryRangeStep`), wired in `cmd/promxy` alongside `NewProxyHeaders`.

### Scope / compatibility

- Only touches the incoming `query_range` edge; backend communication and the pushdown/`LookbackDelta` logic are unchanged.
- Flooring to `step` is standard `query_range` behavior (identical to what aligned requests already return); works regardless of whether a backend step-aligns.
- Off by default → no behavior change unless enabled.
- Other endpoints (e.g., remote write) are untouched: the middleware only rewrites the matched `query_range` path and never calls `ParseForm` on anything else.
- Alignment math mirrors Mimir/Cortex's `(t/step)*step`, reimplemented (not imported) to avoid an AGPL dependency and a conflicting Prometheus fork.

### Tests

Added unit tests to cover this new feature and tested in a real deployment without any issue.