### PR TITLE
servergroup: per-SG `align_query_range_with_step` (alternative to #788, fixes #787)

### DIFF
--- a/pkg/promclient/step_align.go
+++ b/pkg/promclient/step_align.go
@@ -1,0 +1,106 @@
+package promclient
+
+import (
+	"context"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+// StepAlignClient re-stamps QueryRange sample timestamps from the epoch step
+// grid (k*step, as returned by step-aligning backends such as Mimir/Cortex)
+// onto the grid implied by the request start (start + j*step). It is meant to
+// be enabled per-server-group, only for backends that actually snap
+// query_range results to the epoch grid.
+//
+// The shift is purely additive: r = start mod step, applied forward (+r), so a
+// sample the backend computed at k*step is reported at the next requested grid
+// point k*step + r. Forward-only (never backward) keeps it causal -- we never
+// surface a value as of a time later than the timestamp it is reported at.
+//
+// Why this is the right reference frame: promxy pushes each leaf selector down
+// as a QueryRange with Start = evalStart - offset, then the local engine looks
+// the returned samples back up at (evalGrid - offset) == this request's Start
+// grid. So aligning the output to r.Start's phase is exactly what the engine
+// expects, regardless of any query offset.
+type StepAlignClient struct {
+	API
+}
+
+// QueryRange performs a query for the given range, re-stamping the returned
+// samples onto the request's start+step grid. It is a no-op when the request is
+// already on the grid (start % step == 0) or the step is non-positive.
+func (c *StepAlignClient) QueryRange(ctx context.Context, query string, r v1.Range) storage.SeriesSet {
+	ss := c.API.QueryRange(ctx, query, r)
+	if r.Step <= 0 {
+		return ss
+	}
+	stepMs := r.Step.Milliseconds()
+	if stepMs <= 0 {
+		return ss
+	}
+	shift := ((r.Start.UnixMilli() % stepMs) + stepMs) % stepMs
+	if shift == 0 {
+		return ss
+	}
+	return &timeShiftSeriesSet{SeriesSet: ss, shift: shift}
+}
+
+// timeShiftSeriesSet lazily adds a fixed millisecond shift to every sample
+// timestamp of every series. It does not materialize -- the shift is applied in
+// the iterator so the result stays streamable and re-iterable like its source.
+type timeShiftSeriesSet struct {
+	storage.SeriesSet
+	shift int64
+}
+
+func (s *timeShiftSeriesSet) At() storage.Series {
+	return &timeShiftSeries{Series: s.SeriesSet.At(), shift: s.shift}
+}
+
+type timeShiftSeries struct {
+	storage.Series
+	shift int64
+}
+
+func (s *timeShiftSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
+	inner := s.Series.Iterator(nil)
+	if r, ok := it.(*timeShiftIterator); ok {
+		r.Iterator = inner
+		r.shift = s.shift
+		return r
+	}
+	return &timeShiftIterator{Iterator: inner, shift: s.shift}
+}
+
+type timeShiftIterator struct {
+	chunkenc.Iterator
+	shift int64
+}
+
+func (it *timeShiftIterator) At() (int64, float64) {
+	t, v := it.Iterator.At()
+	return t + it.shift, v
+}
+
+func (it *timeShiftIterator) AtHistogram(h *histogram.Histogram) (int64, *histogram.Histogram) {
+	t, h2 := it.Iterator.AtHistogram(h)
+	return t + it.shift, h2
+}
+
+func (it *timeShiftIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+	t, fh2 := it.Iterator.AtFloatHistogram(fh)
+	return t + it.shift, fh2
+}
+
+func (it *timeShiftIterator) AtT() int64 {
+	return it.Iterator.AtT() + it.shift
+}
+
+// Seek positions at the first sample whose *shifted* timestamp is >= t, which
+// is the first underlying sample with timestamp >= t-shift.
+func (it *timeShiftIterator) Seek(t int64) chunkenc.ValueType {
+	return it.Iterator.Seek(t - it.shift)
+}

--- a/pkg/promclient/step_align_test.go
+++ b/pkg/promclient/step_align_test.go
@@ -7,6 +7,7 @@ import (
 
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
@@ -96,6 +97,64 @@ func offGridRange() v1.Range {
 		Start: time.Unix(gridT0+offR, 0),
 		End:   time.Unix(gridT0+offR+npts*stepSec, 0),
 		Step:  time.Duration(stepSec) * time.Second,
+	}
+}
+
+// histGridSeries builds a native-(float-)histogram series on the given grid.
+// The histogram's Sum is set to its (pre-shift) timestamp so the test can
+// confirm the payload is carried through unchanged while only the timestamp
+// moves.
+func histGridSeries(lbls labels.Labels, startMs, n, stepMs int64) storage.Series {
+	samples := make([]chunks.Sample, 0, n)
+	for i := int64(0); i < n; i++ {
+		t := startMs + i*stepMs
+		samples = append(samples, promapi.HistogramSample(t, &histogram.FloatHistogram{
+			Count: float64(t),
+			Sum:   float64(t),
+		}))
+	}
+	return promapi.NewSeries(lbls, samples)
+}
+
+// dumpHist returns the (t, sum) pairs of the first series in ss.
+func dumpHist(ss storage.SeriesSet) (ts []int64, sums []float64) {
+	if !ss.Next() {
+		return nil, nil
+	}
+	it := ss.At().Iterator(nil)
+	for vt := it.Next(); vt != chunkenc.ValNone; vt = it.Next() {
+		if vt == chunkenc.ValHistogram || vt == chunkenc.ValFloatHistogram {
+			t, fh := it.AtFloatHistogram(nil)
+			ts = append(ts, t)
+			sums = append(sums, fh.Sum)
+		}
+	}
+	return ts, sums
+}
+
+// TestStepAlignClient_Restamp_Histogram: native histogram samples are shifted
+// onto the requested grid (via AtFloatHistogram), payload untouched.
+func TestStepAlignClient_Restamp_Histogram(t *testing.T) {
+	client := &StepAlignClient{API: &stubBackend{series: []storage.Series{
+		histGridSeries(labels.FromStrings("__name__", "foo"), gridT0*1000, npts, stepMs),
+	}}}
+
+	gotTs, gotSums := dumpHist(client.QueryRange(context.Background(), "foo", offGridRange()))
+	if len(gotTs) != npts {
+		t.Fatalf("expected %d histogram samples, got %d", npts, len(gotTs))
+	}
+	for i := range gotTs {
+		wantT := (gridT0 + offR + int64(i)*stepSec) * 1000
+		if gotTs[i] != wantT {
+			t.Fatalf("hist sample %d: got t=%d want t=%d", i, gotTs[i], wantT)
+		}
+		if gotTs[i]%stepMs != offR*1000 {
+			t.Fatalf("hist sample %d off requested phase: t=%d", i, gotTs[i])
+		}
+		// payload carried through unchanged: Sum is still the pre-shift timestamp.
+		if wantSum := float64(wantT - offR*1000); gotSums[i] != wantSum {
+			t.Fatalf("hist sample %d: Sum=%v want %v (payload must not change)", i, gotSums[i], wantSum)
+		}
 	}
 }
 

--- a/pkg/promclient/step_align_test.go
+++ b/pkg/promclient/step_align_test.go
@@ -1,0 +1,249 @@
+package promclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/jacksontj/promxy/pkg/promapi"
+)
+
+const (
+	stepSec = int64(3600)       // 1h step
+	stepMs  = stepSec * 1000    //
+	gridT0  = int64(1781654400) // multiple of 3600 -> epoch grid anchor (sec)
+	offR    = int64(1800)       // off-grid by 30min (deliberately > 5m lookback)
+	npts    = 6
+)
+
+// gridSeries builds one series with n float samples starting at startMs, spaced
+// stepMs apart. value(t) = t/1000 so the as-of skew is human-readable in logs.
+func gridSeries(lbls labels.Labels, startMs, n, stepMs int64) storage.Series {
+	samples := make([]chunks.Sample, 0, n)
+	for i := int64(0); i < n; i++ {
+		t := startMs + i*stepMs
+		samples = append(samples, promapi.FloatSample(t, float64(t)/1000))
+	}
+	return promapi.NewSeries(lbls, samples)
+}
+
+// epochGrid: samples at k*step -- what a step-aligning backend (Mimir/Cortex) returns.
+func epochGrid(lbls labels.Labels) storage.Series {
+	return gridSeries(lbls, gridT0*1000, npts, stepMs)
+}
+
+// reqGrid: samples at start+j*step -- what a non-aligning backend (vanilla
+// Prometheus) returns for the same off-grid request.
+func reqGrid(lbls labels.Labels) storage.Series {
+	return gridSeries(lbls, (gridT0+offR)*1000, npts, stepMs)
+}
+
+// stubBackend is an API that returns a fixed set of series for QueryRange.
+type stubBackend struct{ series []storage.Series }
+
+func (s *stubBackend) QueryRange(ctx context.Context, query string, r v1.Range) storage.SeriesSet {
+	return promapi.NewSeriesSet(s.series, nil, nil)
+}
+func (s *stubBackend) Query(context.Context, string, time.Time) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+func (s *stubBackend) LabelNames(context.Context, []string, time.Time, time.Time) ([]string, v1.Warnings, error) {
+	return nil, nil, nil
+}
+func (s *stubBackend) LabelValues(context.Context, string, []string, time.Time, time.Time) (model.LabelValues, v1.Warnings, error) {
+	return nil, nil, nil
+}
+func (s *stubBackend) Series(context.Context, []string, time.Time, time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	return nil, nil, nil
+}
+func (s *stubBackend) GetValue(context.Context, time.Time, time.Time, []*labels.Matcher) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+func (s *stubBackend) Metadata(context.Context, string, string) (map[string][]v1.Metadata, error) {
+	return nil, nil
+}
+func (s *stubBackend) QueryExemplars(context.Context, string, time.Time, time.Time) ([]v1.ExemplarQueryResult, error) {
+	return nil, nil
+}
+
+// dumpFloats returns the (t,v) pairs of the first series in ss.
+func dumpFloats(ss storage.SeriesSet) (ts []int64, vs []float64) {
+	if !ss.Next() {
+		return nil, nil
+	}
+	it := ss.At().Iterator(nil)
+	for vt := it.Next(); vt != chunkenc.ValNone; vt = it.Next() {
+		if vt == chunkenc.ValFloat {
+			t, v := it.At()
+			ts = append(ts, t)
+			vs = append(vs, v)
+		}
+	}
+	return ts, vs
+}
+
+func offGridRange() v1.Range {
+	return v1.Range{
+		Start: time.Unix(gridT0+offR, 0),
+		End:   time.Unix(gridT0+offR+npts*stepSec, 0),
+		Step:  time.Duration(stepSec) * time.Second,
+	}
+}
+
+// TestStepAlignClient_Restamp: epoch-grid samples are shifted onto the requested grid.
+func TestStepAlignClient_Restamp(t *testing.T) {
+	client := &StepAlignClient{API: &stubBackend{series: []storage.Series{
+		epochGrid(labels.FromStrings("__name__", "foo")),
+	}}}
+
+	gotTs, _ := dumpFloats(client.QueryRange(context.Background(), "foo", offGridRange()))
+	if len(gotTs) != npts {
+		t.Fatalf("expected %d samples, got %d", npts, len(gotTs))
+	}
+	for i, got := range gotTs {
+		want := (gridT0 + offR + int64(i)*stepSec) * 1000
+		if got != want {
+			t.Fatalf("sample %d: got t=%d want t=%d", i, got, want)
+		}
+		if got%stepMs != offR*1000 {
+			t.Fatalf("sample %d off requested phase: t=%d phase=%d want %d", i, got, got%stepMs, offR*1000)
+		}
+	}
+}
+
+// TestStepAlignClient_NoOp: on-grid requests and non-positive steps are passed
+// through untouched (same SeriesSet, no shift).
+func TestStepAlignClient_NoOp(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		r    v1.Range
+	}{
+		{"on-grid start", v1.Range{Start: time.Unix(gridT0, 0), End: time.Unix(gridT0+npts*stepSec, 0), Step: time.Duration(stepSec) * time.Second}},
+		{"zero step", v1.Range{Start: time.Unix(gridT0+offR, 0), End: time.Unix(gridT0+offR, 0), Step: 0}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &StepAlignClient{API: &stubBackend{series: []storage.Series{
+				epochGrid(labels.FromStrings("__name__", "foo")),
+			}}}
+			gotTs, _ := dumpFloats(client.QueryRange(context.Background(), "foo", tc.r))
+			for i, got := range gotTs {
+				want := (gridT0 + int64(i)*stepSec) * 1000
+				if got != want {
+					t.Fatalf("sample %d mutated: got t=%d want t=%d", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+// mergedQueryable mimics promxy fanning a leaf query_range out to two server
+// groups and merging the result: source a ("Mimir", epoch grid) behind a
+// StepAlignClient, source b ("vanilla Prom", request grid) untouched.
+type mergedQueryable struct {
+	a, b API
+	r    v1.Range
+}
+
+func (q *mergedQueryable) Querier(mint, maxt int64) (storage.Querier, error) {
+	return &mergedQuerier{q: q}, nil
+}
+
+type mergedQuerier struct{ q *mergedQueryable }
+
+func (qq *mergedQuerier) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
+	a := qq.q.a.QueryRange(context.Background(), "foo", qq.q.r)
+	b := qq.q.b.QueryRange(context.Background(), "foo", qq.q.r)
+	return storage.NewMergeSeriesSet([]storage.SeriesSet{a, b}, 0, storage.ChainedSeriesMerge)
+}
+func (qq *mergedQuerier) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (qq *mergedQuerier) LabelNames(context.Context, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (qq *mergedQuerier) Close() error { return nil }
+
+func runRangeEngine(t *testing.T, qa storage.Queryable) int {
+	t.Helper()
+	eng := promql.NewEngine(promql.EngineOpts{MaxSamples: 1e6, Timeout: 10 * time.Second, LookbackDelta: 5 * time.Minute})
+	q, err := eng.NewRangeQuery(context.Background(), qa, nil, "foo",
+		time.Unix(gridT0+offR, 0), time.Unix(gridT0+offR+(npts-1)*stepSec, 0), time.Duration(stepSec)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := q.Exec(context.Background())
+	if res.Err != nil {
+		t.Fatal(res.Err)
+	}
+	m, err := res.Matrix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, s := range m {
+		n += len(s.Floats)
+	}
+	return n
+}
+
+// TestStepAlignClient_MixedMerge_Disjoint: a step-aligning SG (wrapped) and a
+// non-aligning SG (untouched) hold disjoint series. After re-stamp both land on
+// the requested grid, so an off-grid range query (5m lookback) recovers every
+// point from both -- whereas without the wrapper the aligned SG's points are
+// all dropped (issue #787).
+func TestStepAlignClient_MixedMerge_Disjoint(t *testing.T) {
+	mimirSeries := func() storage.Series { return epochGrid(labels.FromStrings("__name__", "foo", "sg", "a")) }
+	vanilla := &stubBackend{series: []storage.Series{reqGrid(labels.FromStrings("__name__", "foo", "sg", "b"))}}
+	r := offGridRange()
+
+	withAlign := runRangeEngine(t, &mergedQueryable{
+		a: &StepAlignClient{API: &stubBackend{series: []storage.Series{mimirSeries()}}},
+		b: vanilla,
+		r: r,
+	})
+	if withAlign != 2*npts {
+		t.Errorf("with step_align: expected both series whole (%d points), got %d", 2*npts, withAlign)
+	}
+
+	// Control: same topology, Mimir SG NOT wrapped -> its series is lost.
+	noAlign := runRangeEngine(t, &mergedQueryable{
+		a: &stubBackend{series: []storage.Series{mimirSeries()}},
+		b: vanilla,
+		r: r,
+	})
+	if noAlign >= withAlign {
+		t.Errorf("control should lose the aligned SG's points; got noAlign=%d withAlign=%d", noAlign, withAlign)
+	}
+	t.Logf("disjoint mixed merge: with step_align=%d points, without=%d (per-series=%d, 2 series)", withAlign, noAlign, npts)
+}
+
+// TestStepAlignClient_SameSeriesSkew documents the one wrinkle: when the SAME
+// series is co-served by an aligning and a non-aligning backend, timestamps
+// coincide after re-stamp (no "T vs T-step"), but the aligned value at T is the
+// backend's value as-of T-r. Harmless for disjoint/sharded series.
+func TestStepAlignClient_SameSeriesSkew(t *testing.T) {
+	aligned := &StepAlignClient{API: &stubBackend{series: []storage.Series{epochGrid(labels.FromStrings("__name__", "foo"))}}}
+	native := &stubBackend{series: []storage.Series{reqGrid(labels.FromStrings("__name__", "foo"))}}
+
+	aTs, aVs := dumpFloats(aligned.QueryRange(context.Background(), "foo", offGridRange()))
+	bTs, bVs := dumpFloats(native.QueryRange(context.Background(), "foo", offGridRange()))
+
+	for i := range aTs {
+		if aTs[i] != bTs[i] {
+			t.Fatalf("timestamps diverge at %d: aligned=%d native=%d", i, aTs[i], bTs[i])
+		}
+		if skew := bVs[i] - aVs[i]; skew != float64(offR) {
+			t.Errorf("point %d: expected as-of skew of %ds (= r), got %.0f", i, offR, skew)
+		}
+		t.Logf("t=%d aligned=%.0f native=%.0f skew=%.0fs", aTs[i]/1000, aVs[i], bVs[i], bVs[i]-aVs[i])
+	}
+}

--- a/pkg/proxystorage/step_align_e2e_test.go
+++ b/pkg/proxystorage/step_align_e2e_test.go
@@ -1,0 +1,161 @@
+package proxystorage
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+
+	proxyconfig "github.com/jacksontj/promxy/pkg/config"
+	"github.com/jacksontj/promxy/pkg/promapi"
+	"github.com/jacksontj/promxy/pkg/promclient"
+)
+
+// stepAlignStub mimics a step-aligning backend (Mimir/Cortex): its QueryRange
+// snaps the request start down to the epoch grid and returns a dense series at
+// every k*step in the window, regardless of the off-grid start it was asked
+// for. value(t) = t/1000 (seconds) so re-stamped values are easy to assert.
+type stepAlignStub struct{ stubAPI }
+
+func (a *stepAlignStub) QueryRange(ctx context.Context, query string, r v1.Range) storage.SeriesSet {
+	stepMs := r.Step.Milliseconds()
+	if stepMs <= 0 {
+		return storage.EmptySeriesSet()
+	}
+	startMs, endMs := r.Start.UnixMilli(), r.End.UnixMilli()
+	first := (startMs / stepMs) * stepMs // floor to epoch grid
+	var samples []chunks.Sample
+	for t := first; t <= endMs; t += stepMs {
+		samples = append(samples, promapi.FloatSample(t, float64(t)/1000))
+	}
+	s := promapi.NewSeries(labels.FromStrings(model.MetricNameLabel, "foo"), samples)
+	return promapi.NewSeriesSet([]storage.Series{s}, nil, nil)
+}
+
+const (
+	e2eStep   = int64(3600)       // 1h
+	e2eGridT0 = int64(1781654400) // multiple of 3600
+	e2eOffR   = int64(1800)       // off-grid by 30min (> 5m lookback)
+	e2eN      = 6
+)
+
+func newProxyStorage(t *testing.T, client promclient.API) (*ProxyStorage, *promql.Engine) {
+	t.Helper()
+	ps := &ProxyStorage{}
+	ps.state.Store(&proxyStorageState{
+		client: client,
+		cfg:    &proxyconfig.Config{},
+	})
+	eng := promql.NewEngine(promql.EngineOpts{
+		MaxSamples:       1e6,
+		Timeout:          10 * time.Second,
+		LookbackDelta:    5 * time.Minute,
+		EnableAtModifier: true,
+	})
+	eng.NodeReplacer = ps.NodeReplacer
+	return ps, eng
+}
+
+func runRange(t *testing.T, ps *ProxyStorage, eng *promql.Engine, expr string, startSec, endSec int64) promql.Matrix {
+	t.Helper()
+	q, err := eng.NewRangeQuery(context.Background(), ps, nil, expr,
+		time.Unix(startSec, 0), time.Unix(endSec, 0), time.Duration(e2eStep)*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := q.Exec(context.Background())
+	if res.Err != nil {
+		t.Fatal(res.Err)
+	}
+	m, err := res.Matrix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func countPoints(m promql.Matrix) int {
+	n := 0
+	for _, s := range m {
+		n += len(s.Floats)
+	}
+	return n
+}
+
+// TestStepAlign_E2E_Pushdown drives the real proxystorage pushdown (NodeReplacer
+// -> QueryRange -> StepAlignClient re-stamp -> engine re-eval) for an off-grid
+// range query. With the wrapper the data is recovered on the requested grid;
+// without it every point is dropped (issue #787).
+func TestStepAlign_E2E_Pushdown(t *testing.T) {
+	startSec, endSec := e2eGridT0+e2eOffR, e2eGridT0+e2eOffR+(e2eN-1)*e2eStep
+
+	// With per-SG StepAlign wrapping.
+	ps, eng := newProxyStorage(t, &promclient.StepAlignClient{API: &stepAlignStub{}})
+	m := runRange(t, ps, eng, "foo", startSec, endSec)
+	if got := countPoints(m); got != e2eN {
+		t.Fatalf("with step_align: expected %d points, got %d", e2eN, got)
+	}
+	// Each output point sits on the requested grid; its value is the backend's
+	// as-of-(T-r) sample (the documented skew), i.e. value == (T - r) seconds.
+	for _, fp := range m[0].Floats {
+		if fp.T%(e2eStep*1000) != e2eOffR*1000 {
+			t.Errorf("point t=%d not on requested phase (want %d)", fp.T, e2eOffR*1000)
+		}
+		if want := float64(fp.T/1000 - e2eOffR); fp.F != want {
+			t.Errorf("point t=%d: value=%v want %v", fp.T, fp.F, want)
+		}
+	}
+
+	// Control: same backend, NOT wrapped -> the bug (no data).
+	psRaw, engRaw := newProxyStorage(t, &stepAlignStub{})
+	if got := countPoints(runRange(t, psRaw, engRaw, "foo", startSec, endSec)); got != 0 {
+		t.Fatalf("control (no wrapper) expected 0 points (the bug), got %d", got)
+	}
+}
+
+// TestStepAlign_E2E_Offset confirms an `offset` modifier still lines up: promxy
+// pushes the range down at Start-offset, so the re-stamp reference frame is
+// Start-offset's phase, which is exactly where the engine looks the samples back
+// up (evalGrid - offset). Data must still be recovered.
+func TestStepAlign_E2E_Offset(t *testing.T) {
+	startSec, endSec := e2eGridT0+e2eOffR, e2eGridT0+e2eOffR+(e2eN-1)*e2eStep
+
+	ps, eng := newProxyStorage(t, &promclient.StepAlignClient{API: &stepAlignStub{}})
+	m := runRange(t, ps, eng, "foo offset 1h", startSec, endSec)
+	if got := countPoints(m); got != e2eN {
+		t.Fatalf("with step_align + offset: expected %d points, got %d", e2eN, got)
+	}
+
+	psRaw, engRaw := newProxyStorage(t, &stepAlignStub{})
+	if got := countPoints(runRange(t, psRaw, engRaw, "foo offset 1h", startSec, endSec)); got != 0 {
+		t.Fatalf("control (no wrapper) + offset expected 0 points, got %d", got)
+	}
+}
+
+// TestStepAlign_E2E_AtModifier confirms the re-stamp does not break the @-pinned
+// pushdown path: the result is step-invariant and still returns data (rather
+// than the no-data the bug would produce). The pinned value is the backend's
+// grid-snapped sample, which is the step-aligning backend's own behavior.
+func TestStepAlign_E2E_AtModifier(t *testing.T) {
+	startSec, endSec := e2eGridT0+e2eOffR, e2eGridT0+e2eOffR+(e2eN-1)*e2eStep
+
+	ps, eng := newProxyStorage(t, &promclient.StepAlignClient{API: &stepAlignStub{}})
+	// @ pinned off-grid -- the path most likely to interact with the re-stamp.
+	m := runRange(t, ps, eng, "foo @ "+strconv.FormatInt(e2eGridT0+e2eOffR, 10), startSec, endSec)
+	if got := countPoints(m); got != e2eN {
+		t.Fatalf("with step_align + @: expected %d points, got %d", e2eN, got)
+	}
+	// step-invariant: every point carries the same (pinned) value.
+	for _, fp := range m[0].Floats {
+		if fp.F != m[0].Floats[0].F {
+			t.Fatalf("@-pinned result not step-invariant: %v vs %v", fp.F, m[0].Floats[0].F)
+		}
+	}
+}

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -258,6 +258,16 @@ type Config struct {
 	// in multi-tenancy mode
 	// (see https://github.com/jacksontj/promxy/issues/643)
 	HTTPClientHeaders map[string]string `yaml:"http_headers"`
+
+	// AlignQueryRangeWithStep declares that this backend snaps query_range results
+	// to the epoch step grid (k*step), as Mimir/Cortex do by default. When set,
+	// promxy re-stamps the returned samples back onto the grid implied by the
+	// request start (start + j*step) so they line up with promxy's local
+	// evaluation grid. Without it, an unaligned request (start % step != 0) whose
+	// off-grid distance exceeds the lookback-delta yields no data for this backend.
+	// Leave it OFF for backends that do not step-align (e.g. vanilla Prometheus);
+	// their samples already sit on the requested grid. See issue #787.
+	AlignQueryRangeWithStep bool `yaml:"align_query_range_with_step,omitempty"`
 }
 
 // GetScheme returns the scheme for this servergroup

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -326,6 +326,13 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 					}
 				}
 
+				// Optionally re-stamp step-aligned query_range results back onto the
+				// requested step grid. Enabled per-server-group for backends (e.g.
+				// Mimir/Cortex) that snap query_range output to the epoch grid; see #787.
+				if s.Cfg.AlignQueryRangeWithStep {
+					apiClient = &promclient.StepAlignClient{API: apiClient}
+				}
+
 				// We remove all private labels after we set the target entry
 				modelLabelSet := make(model.LabelSet, lset.Len())
 				lset.Range(func(lbl labels.Label) {


### PR DESCRIPTION
Alternative approach to #788 for #787. Opening for comparison — not to replace #788, but to weigh the tradeoffs.

## The bug

A `query_range` whose `start`/`end` are off the epoch step grid (`start % step != 0`) can return **no data** through promxy when the backend step-aligns results (Mimir/Cortex).

Mechanism: for each leaf selector promxy pushes a `query_range` down and re-evaluates the returned matrix through its **local** engine at the requested step grid. The per-step staleness check uses the **query-global** lookback (5m default) — the per-selector `LookbackDelta = step-1ns` hint only widens the `Select()` fetch range, not the staleness window (`engine.go:2332` vs `engine.go:964`). A step-aligning backend returns samples snapped to `k*step`, so every eval point sits `r = start % step` from its nearest sample. When `r >= lookback-delta` every point is dropped.

This is why it's not universally seen: it needs `start % step >= lookback-delta`. The common trigger is a timezone-aligned dashboard — e.g. a `+5:30` offset with a 1h step gives `r = 30m > 5m`. Backends that don't step-align (vanilla Prometheus return at the requested off-grid stamps) are unaffected.

Verified end-to-end against the vendored engine: on-grid query returns 6 points, the same query off-grid by 30m returns **0**, flooring/re-stamping restores all 6.

## This approach: scope the fix to the backend that causes it

#788 floors the incoming request at the HTTP edge — whole-instance, opt-in, and it changes the user-visible result timestamps for **every** backend (even ones that never had the bug), which is why it needs a flag and can't be conditional (at the edge there's no response yet to know whether alignment was needed).

This PR scopes it per-server-group instead, since the bug is *caused* by a specific backend behavior:

```yaml
server_groups:
  - static_configs: [...]        # Mimir/Cortex
    align_query_range_with_step: true
  - static_configs: [...]        # vanilla Prometheus — leave it off
```

`StepAlignClient` wraps the SG's promclient and re-stamps `QueryRange` samples from the epoch grid (`k*step`) back onto the requested grid (`start + j*step`) — a pure additive `+(start mod step)` output shift, forward-only so it stays causal. Key property: **the request sent downstream is unchanged** — the backend still floors it; we only un-floor the response. Non-aligning server groups are wrapped by nothing and left byte-for-byte untouched.

It's a lazy iterator shift (no materialization), a no-op when `start % step == 0` or `step <= 0`, and handles float + histogram samples.

## Tradeoffs vs #788

- ✅ Transparent — users keep their requested timestamps.
- ✅ Conditional — only the declared (aligning) backends are touched; others unchanged.
- ✅ Mixed server groups merge cleanly: after re-stamp every SG's samples sit on the one grid the engine evaluates, so no phase mismatch / no "T vs T-step".
- ⚠️ Caveat: a bounded as-of skew — the aligned value at `T` is the backend's value as of `T-r` — only when the **same** series is co-served by an aligning *and* a non-aligning backend. Harmless for the usual disjoint/sharded topology, and no worse than flooring.
- ➖ Cost vs the edge middleware: lives in the pushdown-adjacent client path. `offset`/`@`/subquery interaction is argued correct (re-stamp reference frame = the `Range.Start` the client receives = `evalGrid - offset`, exactly where the engine looks the samples back up) but I'd want a `promql_test.go` case nailing that down before merge.

## Tests

`pkg/promclient/step_align_test.go`:
- re-stamp correctness (epoch grid → requested grid) and no-op cases;
- **disjoint mixed merge** through the real promql engine: with `step_align` 12 points recovered (both series whole), without it only 6 (the aligned SG's series dropped — the bug);
- same-series skew, asserting timestamps coincide and the skew is exactly `r`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)