### PR TITLE
Bump Go to 1.25 in Dockerfile and CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: install
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.21 AS builder
 
 ARG BUILDPLATFORM
 ARG TARGETARCH


### PR DESCRIPTION
## Summary
`go.mod` requires `go >= 1.25.0`, but the Docker builder image (`golang:1.24-alpine3.21`) and the CI workflow both pinned Go 1.24. This caused the container build to fail:

```
go: ../../go.mod requires go >= 1.25.0 (running go 1.24.11; GOTOOLCHAIN=local)
```

## Changes
- `Dockerfile`: `golang:1.24-alpine3.21` → `golang:1.25-alpine3.21`
- `.github/workflows/go.yml`: `go-version: '1.24'` → `'1.25'` (would fail the same way)

Fixes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)