### PR TITLE
fix(web): wire up notifications API to avoid nil-callback panic (#795)

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/prometheus/prometheus/storage"
 	promlogging "github.com/prometheus/prometheus/util/logging"
+	"github.com/prometheus/prometheus/util/notifications"
 	"github.com/prometheus/prometheus/util/strutil"
 	"github.com/prometheus/prometheus/web"
 	"github.com/sirupsen/logrus"
@@ -52,6 +53,10 @@ import (
 	"github.com/jacksontj/promxy/pkg/proxystorage"
 	"github.com/jacksontj/promxy/pkg/server"
 )
+
+// maxNotificationSubscribers bounds the number of concurrent live subscribers
+// to the notifications SSE endpoint, matching Prometheus' upstream default.
+const maxNotificationSubscribers = 16
 
 var (
 	configSuccess = promauto.NewGauge(prometheus.GaugeOpts{
@@ -124,13 +129,17 @@ func (c *cliOpts) ToFlags() map[string]string {
 
 var opts cliOpts
 
-func reloadConfig(noStepSuqueryInterval *safePromQLNoStepSubqueryInterval, rls ...proxyconfig.Reloadable) (err error) {
+func reloadConfig(noStepSuqueryInterval *safePromQLNoStepSubqueryInterval, notificationsManager *notifications.Notifications, rls ...proxyconfig.Reloadable) (err error) {
 	defer func() {
 		if err == nil {
 			configSuccess.Set(1)
 			configSuccessTime.SetToCurrentTime()
+			// Clear any prior "reload failed" banner exposed via the
+			// notifications API (no-op if none is active).
+			notificationsManager.DeleteNotification(notifications.ConfigurationUnsuccessful)
 		} else {
 			configSuccess.Set(0)
+			notificationsManager.AddNotification(notifications.ConfigurationUnsuccessful)
 		}
 	}()
 
@@ -405,6 +414,11 @@ func main() {
 		logrus.Fatalf("Error creating scrape manager: %v", err)
 	}
 
+	// The notifications API (/api/v1/notifications and its SSE variant) calls
+	// these getters unconditionally; leaving them nil panics on any request to
+	// those endpoints. Wire up a notifications manager so the handlers work.
+	notificationsManager := notifications.NewNotifications(maxNotificationSubscribers, prometheus.DefaultRegisterer)
+
 	webOptions := &web.Options{
 		Registerer:      prometheus.DefaultRegisterer,
 		Gatherer:        prometheus.DefaultGatherer,
@@ -417,6 +431,9 @@ func main() {
 		RuleManager:     ruleManager,
 		Notifier:        notifierManager,
 		LookbackDelta:   opts.QueryLookbackDelta,
+
+		NotificationsGetter: notificationsManager.Get,
+		NotificationsSub:    notificationsManager.Sub,
 
 		RemoteReadConcurrencyLimit: opts.RemoteReadMaxConcurrency,
 
@@ -498,7 +515,7 @@ func main() {
 		}
 	})
 
-	if err := reloadConfig(noStepSubqueryInterval, reloadables...); err != nil {
+	if err := reloadConfig(noStepSubqueryInterval, notificationsManager, reloadables...); err != nil {
 		logrus.Fatalf("Error loading config: %s", err)
 	}
 
@@ -529,7 +546,7 @@ func main() {
 		select {
 		case rc := <-webHandler.Reload():
 			logrus.Infof("Reloading config")
-			if err := reloadConfig(noStepSubqueryInterval, reloadables...); err != nil {
+			if err := reloadConfig(noStepSubqueryInterval, notificationsManager, reloadables...); err != nil {
 				logrus.Errorf("Error reloading config: %s", err)
 				rc <- err
 			} else {
@@ -539,11 +556,15 @@ func main() {
 			switch sig {
 			case syscall.SIGHUP:
 				logrus.Infof("Reloading config")
-				if err := reloadConfig(noStepSubqueryInterval, reloadables...); err != nil {
+				if err := reloadConfig(noStepSubqueryInterval, notificationsManager, reloadables...); err != nil {
 					logrus.Errorf("Error reloading config: %s", err)
 				}
 			case syscall.SIGTERM, syscall.SIGINT:
 				logrus.Info("promxy received exit signal, starting graceful shutdown")
+
+				// Surface the shutdown via the notifications API so connected
+				// UIs can show it during the grace period.
+				notificationsManager.AddNotification(notifications.ShuttingDown)
 
 				// Stop all services we are running
 				stopping = true        // start failing healthchecks

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -106,6 +106,15 @@ func (r *ApacheLogRecord) WriteHeader(status int) {
 	r.ResponseWriter.WriteHeader(status)
 }
 
+// Flush forwards to the wrapped ResponseWriter when it supports flushing.
+// Without this, streaming handlers (e.g. the notifications SSE endpoint) see
+// the wrapper as a non-Flusher and bail out with "Streaming unsupported".
+func (r *ApacheLogRecord) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 type LogRecordHandler func(*ApacheLogRecord)
 
 func LogToWriter(out io.Writer) LogRecordHandler {


### PR DESCRIPTION
## Problem

Promxy crashes the request handler with `runtime error: invalid memory address or nil pointer dereference` whenever the notifications endpoints are hit (`/api/v1/notifications` and its SSE variant `/api/v1/notifications/live`), as reported in #795:

```
github.com/prometheus/prometheus/web/api/v1.(*API).notificationsSSE(...)
	vendor/github.com/prometheus/prometheus/web/api/v1/api.go:1815
```

## Cause

`cmd/promxy/main.go` builds `web.Options` without setting `NotificationsGetter`/`NotificationsSub`. Those are passed straight into `v1.NewAPI`, and the handlers call them unconditionally, so any request panicked on a nil func. Two further gaps stood between that and a working endpoint:

1. **Nil callbacks** (the panic itself).
2. **Wrapper swallows Flush.** promxy's `ApacheLoggingHandler` wraps the `ResponseWriter` but only implemented `Write`/`WriteHeader`, not `http.Flusher` — so once the panic was fixed the SSE handler failed its `w.(http.Flusher)` assertion and returned `500 "Streaming unsupported"`.
3. **Empty stream.** Even with both fixed, nothing in promxy ever produced a notification, so the stream connected but stayed silent forever.

## Fix

1. Construct a `notifications.Notifications` manager (same type upstream uses) and wire its `Get`/`Sub` into `web.Options` (`maxSubscribers=16`, matching upstream default).
2. Forward `Flush()` from `ApacheLogRecord` to the underlying `ResponseWriter`.
3. Emit the notification events that are meaningful for a proxy:
   - `ConfigurationUnsuccessful` — added on config-reload failure, cleared (`Active:false`) on the next successful reload; threaded through `reloadConfig` so it covers both SIGHUP and the HTTP reload path.
   - `ShuttingDown` — added at the start of graceful shutdown.
   - (`StartingUp`/WAL-replay is intentionally omitted — promxy has no local TSDB WAL to replay.)

## Testing

Built master (pre-fix) and fixed binaries, ran promxy with a minimal config, and exercised the endpoints against a live SSE subscriber:

| Scenario | master (pre-fix) | fixed |
|---|---|---|
| `GET /api/v1/notifications` | panic → HTTP 500 (nil-ptr stack in body) | **200** `{"status":"success","data":[]}` |
| `GET /api/v1/notifications/live` | panic → HTTP 500 | **200** `Content-Type: text/event-stream`, streams |
| reload with bad config | — | SSE event `{"...reload has failed.","active":true}` |
| reload recovers | — | SSE event `{"...reload has failed.","active":false}` |
| SIGTERM (graceful shutdown) | — | SSE event `{"...shutting down...","active":true}` |

Confirmed the pre-fix panic body matches the issue's stack trace (`api.go:1805`/`1815`), and that a subscriber connecting mid-incident receives the current active notification on connect (initial replay).

Fixes #795