### PR TITLE
docs: document alertmanager http_headers in example config

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -19,6 +19,13 @@ alerting:
     static_configs:
     - targets:
       - "127.0.0.1:12345"
+    # Custom HTTP headers to inject on every request to this Alertmanager.
+    # Useful when the Alertmanager sits behind a gateway that authenticates
+    # requests via a header. Any header from the standard prometheus
+    # http_client_config is supported here (basic_auth, authorization, etc.).
+    # http_headers:
+    #   X-Gateway-Signature:
+    #     values: ["my-secret-token"]     # or `secret:`, or `files: [...]`
 
 # remote_write configuration is used by promxy as its local Appender, meaning all
 # metrics promxy would "write" (not export) would be sent to this. Examples


### PR DESCRIPTION
## Summary

Documents that `http_headers` is already supported on each `alerting.alertmanagers` entry, addressing #693.

Since that issue was filed, promxy's vendored Prometheus / `prometheus/common` were bumped, and `http_headers` now comes in for free via the inlined Prometheus `http_client_config` on each Alertmanager entry. This lets promxy inject custom headers on every request to an Alertmanager — e.g. when the Alertmanager sits behind a gateway that authenticates via a signature header, the original ask in #693.

No code change is needed; this just adds a commented example to `cmd/promxy/config.yaml` so the capability is discoverable.

```yaml
alerting:
  alertmanagers:
    - static_configs:
        - targets: ["alertmanager-gateway:9093"]
      http_headers:
        X-Gateway-Signature:
          values: ["my-secret-token"]   # or `secret:`, or `files: [...]`
```

Headers Prometheus manages itself (`Authorization`, `Host`, `Content-Type`, …) are reserved and rejected — use the dedicated `authorization`/`basic_auth` fields for those.

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)