### PR TITLE
feat(alerts): configurable GeneratorURL templates (#736)

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -253,3 +253,35 @@ promxy:
       # meaning if this servergroup returns and error and others don't the overall
       # query can still succeed
       ignore_error: true
+
+  # alert_templates optionally customizes the GeneratorURL promxy sets on the
+  # alerts it sends to Alertmanager. By default promxy emits the same
+  # Prometheus-style URL as upstream (a link to promxy's own graph page for the
+  # alert expression). This block is entirely opt-in; omit it to keep that
+  # default. Each template is a Go text/template rendered per-alert with these
+  # fields: .ExternalURL, .Expr, .AlertName, .Labels (map), .Annotations (map).
+  # Two extra functions are available: `urlquery` and `urlpath`.
+  #
+  # alert_templates:
+  #   # default is used when no rule matches. It may be an inline template body
+  #   # or the name of one of the `named` templates below.
+  #   default: '{{.ExternalURL}}/graph?g0.expr={{.Expr | urlquery}}&g0.tab=1'
+  #
+  #   # named holds reusable templates addressable from `default` and `rules`.
+  #   named:
+  #     grafana: 'https://grafana.example.com/alerting/groups?queryString=alertname%3D%22{{.AlertName | urlquery}}%22'
+  #     pagerduty: 'https://example.pagerduty.com/incidents/new?title={{.AlertName | urlquery}}'
+  #
+  #   # rules select a template by alert labels, evaluated top-to-bottom;
+  #   # the first rule whose match_labels all match wins. `template` is a named
+  #   # template or an inline body.
+  #   rules:
+  #     - match_labels:
+  #         severity: critical
+  #       template: pagerduty
+  #     - match_labels:
+  #         team: frontend
+  #       template: grafana
+  #     - match_labels:
+  #         alertname: DatabaseDown
+  #       template: 'https://db.example.com/status?db={{.Labels.database | urlquery}}'

--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/jacksontj/promxy/pkg/alertbackfill"
+	"github.com/jacksontj/promxy/pkg/alerttemplate"
 	proxyconfig "github.com/jacksontj/promxy/pkg/config"
 	"github.com/jacksontj/promxy/pkg/federate"
 	"github.com/jacksontj/promxy/pkg/logging"
@@ -331,11 +332,19 @@ func main() {
 	} else {
 		ruleQueryable = proxyStorage
 	}
+	// alertTemplates renders configurable GeneratorURLs for alerts. It is
+	// populated from the promxy config on (re)load below; until then (and when
+	// unconfigured) sendAlerts falls back to the built-in GeneratorURL.
+	alertTemplates := alerttemplate.NewManager()
+	reloadables = append(reloadables, &proxyconfig.PromxyApplyConfigFunc{F: func(cfg *proxyconfig.Config) error {
+		return alertTemplates.Apply(cfg.AlertTemplates)
+	}})
+
 	ruleManager := rules.NewManager(&rules.ManagerOptions{
 		Context:         ctx,         // base context for all background tasks
 		ExternalURL:     externalUrl, // URL listed as URL for "who fired this alert"
 		QueryFunc:       rules.EngineQueryFunc(engine, proxyStorage),
-		NotifyFunc:      sendAlerts(notifierManager, externalUrl.String()),
+		NotifyFunc:      sendAlerts(notifierManager, externalUrl.String(), alertTemplates),
 		Appendable:      proxyStorage,
 		Queryable:       ruleQueryable,
 		Logger:          logger,
@@ -572,7 +581,7 @@ func main() {
 
 // sendAlerts implements the rules.NotifyFunc for a Notifier.
 // It filters any non-firing alerts from the input.
-func sendAlerts(n *notifier.Manager, externalURL string) rules.NotifyFunc {
+func sendAlerts(n *notifier.Manager, externalURL string, alertTemplates *alerttemplate.Manager) rules.NotifyFunc {
 	return func(ctx context.Context, expr string, alerts ...*rules.Alert) {
 		var res []*notifier.Alert
 
@@ -581,11 +590,17 @@ func sendAlerts(n *notifier.Manager, externalURL string) rules.NotifyFunc {
 			if alert.State == rules.StatePending {
 				continue
 			}
+			// Use a configured GeneratorURL template if one applies, otherwise
+			// fall back to the built-in Prometheus-style URL.
+			generatorURL, ok := alertTemplates.GeneratorURL(alert, expr, externalURL)
+			if !ok {
+				generatorURL = externalURL + strutil.TableLinkForExpression(expr)
+			}
 			a := &notifier.Alert{
 				StartsAt:     alert.FiredAt,
 				Labels:       alert.Labels,
 				Annotations:  alert.Annotations,
-				GeneratorURL: externalURL + strutil.TableLinkForExpression(expr),
+				GeneratorURL: generatorURL,
 			}
 			if !alert.ResolvedAt.IsZero() {
 				a.EndsAt = alert.ResolvedAt

--- a/pkg/alerttemplate/template.go
+++ b/pkg/alerttemplate/template.go
@@ -1,0 +1,198 @@
+// Package alerttemplate renders configurable GeneratorURL values for promxy's
+// alerts. By default promxy emits the same Prometheus-style GeneratorURL as
+// upstream (a link to promxy's own graph page for the alert expression). That
+// is not useful when promxy is the central evaluation point for many backends
+// and operators triage alerts elsewhere (Grafana alerting, an incident manager,
+// a per-tenant dashboard, ...). This package lets an operator configure Go
+// templates, selected per-alert by label, that produce the GeneratorURL
+// instead. It is entirely opt-in: with no configuration the caller falls back
+// to the built-in URL.
+package alerttemplate
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"sync"
+	"text/template"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/rules"
+	"github.com/sirupsen/logrus"
+)
+
+// Config is the promxy alert-template configuration, nested under
+// `promxy.alert_templates` in the config file.
+type Config struct {
+	// Default is used when no rule matches. It is either an inline template
+	// body or the name of one of the Named templates. When empty, promxy uses
+	// its built-in Prometheus-style GeneratorURL.
+	Default string `yaml:"default,omitempty"`
+
+	// Named holds reusable inline templates, addressable by name from Default
+	// and from a rule's Template.
+	Named map[string]string `yaml:"named,omitempty"`
+
+	// Rules select a template based on alert labels. They are evaluated
+	// top-to-bottom and the first match wins.
+	Rules []Rule `yaml:"rules,omitempty"`
+}
+
+// Rule selects a template when every entry in MatchLabels equals the
+// corresponding alert label.
+type Rule struct {
+	// MatchLabels must all be present on the alert with the given value for the
+	// rule to match. An empty MatchLabels never matches (use Default for a
+	// catch-all).
+	MatchLabels map[string]string `yaml:"match_labels"`
+
+	// Template is an inline template body or the name of a Named template.
+	Template string `yaml:"template"`
+}
+
+// Data is the value passed to a GeneratorURL template during execution.
+type Data struct {
+	// ExternalURL is promxy's configured external URL.
+	ExternalURL string
+	// Expr is the PromQL expression that triggered the alert.
+	Expr string
+	// Labels are the alert's labels.
+	Labels map[string]string
+	// Annotations are the alert's annotations.
+	Annotations map[string]string
+	// AlertName is a convenience for the value of the "alertname" label.
+	AlertName string
+}
+
+// templateFuncs are the helpers available to every template.
+var templateFuncs = template.FuncMap{
+	"urlquery": url.QueryEscape,
+	"urlpath":  url.PathEscape,
+}
+
+// compiledRule is a Rule with its template pre-parsed.
+type compiledRule struct {
+	match map[string]string
+	tmpl  *template.Template
+}
+
+// matches reports whether every label in the rule is present with the expected
+// value. An empty match set never matches.
+func (r compiledRule) matches(labels map[string]string) bool {
+	if len(r.match) == 0 {
+		return false
+	}
+	for k, v := range r.match {
+		if labels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// Manager holds the compiled templates and renders GeneratorURLs. Its zero
+// value is not usable; construct one with NewManager. It is safe for concurrent
+// use: Apply swaps the compiled template set under a write lock while
+// GeneratorURL reads it under a read lock.
+type Manager struct {
+	mu    sync.RWMutex
+	def   *template.Template // nil when no default configured
+	rules []compiledRule
+}
+
+// NewManager returns an empty Manager. Until Apply installs a configuration,
+// GeneratorURL always reports that no template applies.
+func NewManager() *Manager {
+	return &Manager{}
+}
+
+// Apply compiles cfg and atomically installs it. It returns an error (leaving
+// the previous configuration in place) if any template fails to parse, so a bad
+// template fails the config reload loudly rather than silently disabling alert
+// URLs.
+func (m *Manager) Apply(cfg Config) error {
+	// Pre-compile all named templates so typos are caught even when a name is
+	// only referenced indirectly.
+	named := make(map[string]*template.Template, len(cfg.Named))
+	for name, body := range cfg.Named {
+		t, err := template.New(name).Funcs(templateFuncs).Parse(body)
+		if err != nil {
+			return fmt.Errorf("alert_templates.named[%q]: %w", name, err)
+		}
+		named[name] = t
+	}
+
+	// resolve turns a template reference (a Named name or an inline body) into a
+	// compiled template. An empty reference yields a nil template.
+	resolve := func(ref string) (*template.Template, error) {
+		if ref == "" {
+			return nil, nil
+		}
+		if t, ok := named[ref]; ok {
+			return t, nil
+		}
+		return template.New("generatorURL").Funcs(templateFuncs).Parse(ref)
+	}
+
+	def, err := resolve(cfg.Default)
+	if err != nil {
+		return fmt.Errorf("alert_templates.default: %w", err)
+	}
+
+	compiled := make([]compiledRule, 0, len(cfg.Rules))
+	for i, r := range cfg.Rules {
+		if r.Template == "" {
+			return fmt.Errorf("alert_templates.rules[%d]: template is required", i)
+		}
+		if len(r.MatchLabels) == 0 {
+			return fmt.Errorf("alert_templates.rules[%d]: match_labels is required", i)
+		}
+		t, err := resolve(r.Template)
+		if err != nil {
+			return fmt.Errorf("alert_templates.rules[%d]: %w", i, err)
+		}
+		compiled = append(compiled, compiledRule{match: r.MatchLabels, tmpl: t})
+	}
+
+	m.mu.Lock()
+	m.def = def
+	m.rules = compiled
+	m.mu.Unlock()
+	return nil
+}
+
+// GeneratorURL renders the GeneratorURL for alert. ok is false when no template
+// is configured for the alert or when rendering fails (the failure is logged),
+// in which case the caller should fall back to the default GeneratorURL.
+func (m *Manager) GeneratorURL(alert *rules.Alert, expr, externalURL string) (url string, ok bool) {
+	m.mu.RLock()
+	tmpl := m.def
+	rules := m.rules
+	m.mu.RUnlock()
+
+	labels := alert.Labels.Map()
+	for _, r := range rules {
+		if r.matches(labels) {
+			tmpl = r.tmpl
+			break
+		}
+	}
+	if tmpl == nil {
+		return "", false
+	}
+
+	data := Data{
+		ExternalURL: externalURL,
+		Expr:        expr,
+		Labels:      labels,
+		Annotations: alert.Annotations.Map(),
+		AlertName:   alert.Labels.Get(model.AlertNameLabel),
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		logrus.Warnf("alert %q: rendering GeneratorURL template failed, falling back to default: %v", data.AlertName, err)
+		return "", false
+	}
+	return buf.String(), true
+}

--- a/pkg/alerttemplate/template_test.go
+++ b/pkg/alerttemplate/template_test.go
@@ -1,0 +1,197 @@
+package alerttemplate
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/rules"
+)
+
+// newAlert builds a minimal *rules.Alert with the given labels for testing.
+func newAlert(lbls map[string]string, annotations map[string]string) *rules.Alert {
+	return &rules.Alert{
+		Labels:      labels.FromMap(lbls),
+		Annotations: labels.FromMap(annotations),
+	}
+}
+
+func TestGeneratorURL_NoConfig(t *testing.T) {
+	m := NewManager()
+	alert := newAlert(map[string]string{model.AlertNameLabel: "HighLatency"}, nil)
+
+	if url, ok := m.GeneratorURL(alert, "up == 0", "http://promxy"); ok {
+		t.Fatalf("expected no template to apply, got %q", url)
+	}
+}
+
+func TestApply_Default(t *testing.T) {
+	m := NewManager()
+	err := m.Apply(Config{
+		Default: `http://grafana/alerting?alert={{.AlertName | urlquery}}&sev={{.Labels.severity}}`,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	alert := newAlert(map[string]string{
+		model.AlertNameLabel: "High Latency",
+		"severity":           "critical",
+	}, nil)
+
+	url, ok := m.GeneratorURL(alert, "up == 0", "http://promxy")
+	if !ok {
+		t.Fatal("expected default template to apply")
+	}
+	want := "http://grafana/alerting?alert=High+Latency&sev=critical"
+	if url != want {
+		t.Fatalf("got %q, want %q", url, want)
+	}
+}
+
+func TestApply_RuleSelectionOrder(t *testing.T) {
+	m := NewManager()
+	err := m.Apply(Config{
+		Default: "http://default",
+		Named: map[string]string{
+			"pd": "http://pagerduty/new?title={{.AlertName | urlquery}}",
+		},
+		Rules: []Rule{
+			// First matching rule wins.
+			{MatchLabels: map[string]string{"severity": "critical"}, Template: "pd"},
+			{MatchLabels: map[string]string{"team": "frontend"}, Template: "http://grafana/{{.Labels.team}}"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{
+			name:   "named template via rule",
+			labels: map[string]string{model.AlertNameLabel: "DBDown", "severity": "critical"},
+			want:   "http://pagerduty/new?title=DBDown",
+		},
+		{
+			name:   "inline template via rule",
+			labels: map[string]string{"team": "frontend"},
+			want:   "http://grafana/frontend",
+		},
+		{
+			name:   "falls through to default",
+			labels: map[string]string{"team": "backend"},
+			want:   "http://default",
+		},
+		{
+			name:   "first rule wins over later match",
+			labels: map[string]string{"severity": "critical", "team": "frontend"},
+			want:   "http://pagerduty/new?title=",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			url, ok := m.GeneratorURL(newAlert(tc.labels, nil), "up == 0", "http://promxy")
+			if !ok {
+				t.Fatal("expected a template to apply")
+			}
+			if url != tc.want {
+				t.Fatalf("got %q, want %q", url, tc.want)
+			}
+		})
+	}
+}
+
+func TestApply_MultiLabelRuleRequiresAll(t *testing.T) {
+	m := NewManager()
+	err := m.Apply(Config{
+		Rules: []Rule{
+			{MatchLabels: map[string]string{"severity": "critical", "team": "db"}, Template: "http://match"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Only one of the two labels matches -> no rule, no default -> not ok.
+	if _, ok := m.GeneratorURL(newAlert(map[string]string{"severity": "critical"}, nil), "e", "x"); ok {
+		t.Fatal("expected partial label match to not match the rule")
+	}
+	// Both labels match.
+	if _, ok := m.GeneratorURL(newAlert(map[string]string{"severity": "critical", "team": "db"}, nil), "e", "x"); !ok {
+		t.Fatal("expected full label match to match the rule")
+	}
+}
+
+func TestGeneratorURL_DataFields(t *testing.T) {
+	m := NewManager()
+	err := m.Apply(Config{
+		Default: "{{.ExternalURL}}|{{.Expr}}|{{.AlertName}}|{{.Labels.instance}}|{{.Annotations.summary}}",
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	alert := newAlert(
+		map[string]string{model.AlertNameLabel: "Foo", "instance": "host:9090"},
+		map[string]string{"summary": "it broke"},
+	)
+	url, ok := m.GeneratorURL(alert, "up == 0", "http://promxy")
+	if !ok {
+		t.Fatal("expected template to apply")
+	}
+	want := "http://promxy|up == 0|Foo|host:9090|it broke"
+	if url != want {
+		t.Fatalf("got %q, want %q", url, want)
+	}
+}
+
+func TestGeneratorURL_RenderErrorFallsBack(t *testing.T) {
+	m := NewManager()
+	// Valid syntax, but references a field that does not exist on the data ->
+	// execution error at render time.
+	if err := m.Apply(Config{Default: "{{.NoSuchField.Nested}}"}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if _, ok := m.GeneratorURL(newAlert(map[string]string{"x": "y"}, nil), "e", "x"); ok {
+		t.Fatal("expected render error to report not-ok so caller falls back")
+	}
+}
+
+func TestApply_InvalidTemplateRejected(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{"bad default", Config{Default: "{{.Unclosed"}},
+		{"bad named", Config{Named: map[string]string{"x": "{{.Unclosed"}}},
+		{"bad inline rule", Config{Rules: []Rule{{MatchLabels: map[string]string{"a": "b"}, Template: "{{.Unclosed"}}}},
+		{"rule without template", Config{Rules: []Rule{{MatchLabels: map[string]string{"a": "b"}}}}},
+		{"rule without match_labels", Config{Rules: []Rule{{Template: "http://x"}}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := (NewManager()).Apply(tc.cfg); err == nil {
+				t.Fatal("expected Apply to reject invalid config")
+			}
+		})
+	}
+}
+
+func TestApply_BadReloadKeepsPreviousConfig(t *testing.T) {
+	m := NewManager()
+	if err := m.Apply(Config{Default: "http://good"}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// A subsequent bad reload must not clobber the working configuration.
+	if err := m.Apply(Config{Default: "{{.Unclosed"}); err == nil {
+		t.Fatal("expected bad config to error")
+	}
+	url, ok := m.GeneratorURL(newAlert(map[string]string{"a": "b"}, nil), "e", "x")
+	if !ok || url != "http://good" {
+		t.Fatalf("expected previous config retained, got ok=%v url=%q", ok, url)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/prometheus/config"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/jacksontj/promxy/pkg/alerttemplate"
 	"github.com/jacksontj/promxy/pkg/servergroup"
 )
 
@@ -114,4 +115,8 @@ func (c *Config) String() string {
 type PromxyConfig struct {
 	// Config for each of the server groups promxy is configured to aggregate
 	ServerGroups []*servergroup.Config `yaml:"server_groups"`
+
+	// AlertTemplates optionally configures Go templates for alert GeneratorURLs.
+	// When unset, promxy emits its built-in Prometheus-style GeneratorURL.
+	AlertTemplates alerttemplate.Config `yaml:"alert_templates,omitempty"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,6 +3,8 @@ package proxyconfig
 import (
 	"os"
 	"testing"
+
+	"github.com/jacksontj/promxy/pkg/alerttemplate"
 )
 
 func TestConfigFromFile(t *testing.T) {
@@ -118,5 +120,42 @@ remote_write:
 				}
 			}
 		})
+	}
+}
+
+// TestAlertTemplatesConfig verifies the promxy.alert_templates block unmarshals
+// into the alerttemplate.Config wired onto PromxyConfig.
+func TestAlertTemplatesConfig(t *testing.T) {
+	raw := `
+promxy:
+  server_groups: []
+  alert_templates:
+    default: 'http://default'
+    named:
+      grafana: 'http://grafana/{{.AlertName}}'
+    rules:
+      - match_labels:
+          severity: critical
+        template: grafana
+`
+	cfg, err := ConfigFromBytes([]byte(raw))
+	if err != nil {
+		t.Fatalf("ConfigFromBytes: %v", err)
+	}
+
+	at := cfg.PromxyConfig.AlertTemplates
+	if at.Default != "http://default" {
+		t.Errorf("default = %q, want %q", at.Default, "http://default")
+	}
+	if at.Named["grafana"] != "http://grafana/{{.AlertName}}" {
+		t.Errorf("named[grafana] = %q", at.Named["grafana"])
+	}
+	if len(at.Rules) != 1 || at.Rules[0].MatchLabels["severity"] != "critical" || at.Rules[0].Template != "grafana" {
+		t.Errorf("unexpected rules: %+v", at.Rules)
+	}
+
+	// The parsed config must be accepted by the manager.
+	if err := alerttemplate.NewManager().Apply(at); err != nil {
+		t.Fatalf("manager rejected parsed config: %v", err)
 	}
 }

--- a/pkg/config/reloadable.go
+++ b/pkg/config/reloadable.go
@@ -37,3 +37,16 @@ type ApplyConfigFunc struct {
 func (a *ApplyConfigFunc) ApplyConfig(cfg *config.Config) error {
 	return a.F(cfg)
 }
+
+// PromxyApplyConfigFunc wraps a single function that applies a promxy Config
+// into something that implements the `Reloadable` interface. Unlike
+// ApplyConfigFunc it receives the full promxy Config (including the promxy-only
+// sections), not just the embedded prometheus config.
+type PromxyApplyConfigFunc struct {
+	F func(*Config) error
+}
+
+// ApplyConfig applies new configuration
+func (a *PromxyApplyConfigFunc) ApplyConfig(cfg *Config) error {
+	return a.F(cfg)
+}


### PR DESCRIPTION
Fixes #736. Reimplements the approach from #737 on top of the current (post-Prometheus-3.5) `master`.

## Problem
Promxy hardcodes the alert `GeneratorURL` to a link to its own graph page for the alert expression (matching upstream Prometheus). When promxy is the central evaluation point for many backends and operators triage alerts elsewhere — Grafana alerting, an incident manager, a per-tenant dashboard — that URL isn't useful, and it points at the wrong backend for series that originated in e.g. VictoriaMetrics.

## Change
New opt-in `pkg/alerttemplate` renders the `GeneratorURL` from Go templates configured under `promxy.alert_templates`:

- `default` — template used when no rule matches (inline body or a `named` reference)
- `named` — reusable inline templates addressable from `default`/`rules`
- `rules` — label-matched selectors, evaluated top-to-bottom, first match wins

Template data: `.ExternalURL`, `.Expr`, `.AlertName`, `.Labels`, `.Annotations`; plus `urlquery` / `urlpath` funcs.

Templates are compiled **once** on config (re)load behind a `RWMutex` and selected per-alert in `sendAlerts`. **With no configuration, promxy falls back to the exact built-in URL**, so default behavior is unchanged. An invalid template fails the config reload loudly and keeps the previous good config.

## Scope vs. #737 / #736
Kept it minimal and close to upstream:
- Dropped the template **directory / `.tmpl` loader** and the **CLI flags** — inline `named` templates cover the use cases in #736 without filesystem/flag surface. Easy to add later if wanted.
- Compiles templates once (not per-alert) and is race-free on reload.

## Tests
- `pkg/alerttemplate` — rule ordering, multi-label AND, named-vs-inline, data fields, render-error fallback, invalid-config rejection, bad-reload-keeps-previous-config.
- `pkg/config` — `alert_templates` YAML round-trips into a manager-accepted config.
- Documented example in `cmd/promxy/config.yaml`.

Credit to @ramessesii2 for the original implementation and design in #737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)