### PR TITLE
servergroup: configurable dial_network / fallback_delay for IPv4/IPv6 dialing (#713)

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -105,6 +105,15 @@ promxy:
         # dial_timeout controls how long promxy will wait for a connection to the downstream
         # the default is 200ms.
         dial_timeout: 1s
+        # dial_network controls the address family used when dialing downstream hosts.
+        # "tcp" (default) does dual-stack dialing; "tcp4"/"tcp6" force IPv4/IPv6 respectively.
+        # Use "tcp4" to work around downstreams whose DNS resolves to an unreachable IPv6 address.
+        # dial_network: tcp
+        # fallback_delay tunes the dual-stack (RFC 6555 "Happy Eyeballs") dialer: how long to
+        # wait before trying the other address family. A zero value uses Go's default (300ms);
+        # a negative value disables the fallback attempt. To be effective it must be shorter
+        # than dial_timeout, otherwise the dial times out before the fallback is attempted.
+        # fallback_delay: 50ms
         tls_config:
           insecure_skip_verify: true
 

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -312,6 +312,10 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
+	if err := c.HTTPConfig.validate(); err != nil {
+		return err
+	}
+
 	// Validate inject_matchers parses at config-load time rather than failing later
 	// during a discovery sync.
 	if _, err := c.GetInjectMatchers(); err != nil {
@@ -359,9 +363,39 @@ func (c *Config) MarshalYAML() (interface{}, error) {
 
 // HTTPClientConfig extends prometheus' HTTPClientConfig
 type HTTPClientConfig struct {
-	DialTimeout time.Duration                `yaml:"dial_timeout"`
-	HTTPConfig  config_util.HTTPClientConfig `yaml:",inline"`
-	SigV4Config *sigv4.SigV4Config           `yaml:"sigv4,omitempty"`
+	DialTimeout time.Duration `yaml:"dial_timeout"`
+	// DialNetwork controls the address family used when dialing downstream hosts.
+	// It maps to the network passed to net.Dialer: "tcp" (default) does dual-stack
+	// dialing, while "tcp4"/"tcp6" force IPv4/IPv6 respectively. An empty value is
+	// treated as "tcp".
+	DialNetwork string `yaml:"dial_network,omitempty"`
+	// FallbackDelay maps to net.Dialer.FallbackDelay and controls how long the
+	// dual-stack (RFC 6555 "Happy Eyeballs") dialer waits before spawning a
+	// fallback connection to the other address family. A zero value uses Go's
+	// default (300ms); a negative value disables the fallback attempt entirely.
+	// Note: to be effective it must be shorter than DialTimeout, otherwise the
+	// dial times out before the fallback is ever attempted.
+	FallbackDelay time.Duration                `yaml:"fallback_delay,omitempty"`
+	HTTPConfig    config_util.HTTPClientConfig `yaml:",inline"`
+	SigV4Config   *sigv4.SigV4Config           `yaml:"sigv4,omitempty"`
+}
+
+// validate ensures the HTTPClientConfig has sane values.
+func (c *HTTPClientConfig) validate() error {
+	switch c.DialNetwork {
+	case "", "tcp", "tcp4", "tcp6":
+	default:
+		return fmt.Errorf("invalid dial_network %q: must be one of tcp, tcp4, tcp6", c.DialNetwork)
+	}
+	return nil
+}
+
+// DialNetworkOrDefault returns the configured dial network, defaulting to "tcp".
+func (c *HTTPClientConfig) DialNetworkOrDefault() string {
+	if c.DialNetwork == "" {
+		return "tcp"
+	}
+	return c.DialNetwork
 }
 
 // RelativeTimeRangeConfig configures durations relative from "now" to define

--- a/pkg/servergroup/config_test.go
+++ b/pkg/servergroup/config_test.go
@@ -2,6 +2,7 @@ package servergroup
 
 import (
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
@@ -536,6 +537,96 @@ static_configs:
 			}
 
 			t.Logf("Backward compatibility verified for test: %s", tt.name)
+		})
+	}
+}
+
+func TestDialNetworkConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          string
+		wantErr         bool
+		errMsg          string
+		wantDialNetwork string // expected result of DialNetworkOrDefault()
+		wantFallback    time.Duration
+	}{
+		{
+			name:            "unset defaults to tcp",
+			config:          "http_client: {}",
+			wantDialNetwork: "tcp",
+			wantFallback:    0,
+		},
+		{
+			name: "explicit tcp",
+			config: `
+http_client:
+  dial_network: tcp
+`,
+			wantDialNetwork: "tcp",
+		},
+		{
+			name: "force ipv4",
+			config: `
+http_client:
+  dial_network: tcp4
+  fallback_delay: 50ms
+`,
+			wantDialNetwork: "tcp4",
+			wantFallback:    50 * time.Millisecond,
+		},
+		{
+			name: "force ipv6",
+			config: `
+http_client:
+  dial_network: tcp6
+`,
+			wantDialNetwork: "tcp6",
+		},
+		{
+			name: "negative fallback delay disables happy eyeballs",
+			config: `
+http_client:
+  fallback_delay: -1ms
+`,
+			wantDialNetwork: "tcp",
+			wantFallback:    -1 * time.Millisecond,
+		},
+		{
+			name: "invalid dial_network rejected",
+			config: `
+http_client:
+  dial_network: udp
+`,
+			wantErr: true,
+			errMsg:  "invalid dial_network",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Config
+			err := yaml.Unmarshal([]byte(tt.config), &cfg)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				if tt.errMsg != "" && !contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got := cfg.HTTPConfig.DialNetworkOrDefault(); got != tt.wantDialNetwork {
+				t.Errorf("DialNetworkOrDefault() = %q, want %q", got, tt.wantDialNetwork)
+			}
+			if cfg.HTTPConfig.FallbackDelay != tt.wantFallback {
+				t.Errorf("FallbackDelay = %v, want %v", cfg.HTTPConfig.FallbackDelay, tt.wantFallback)
+			}
 		})
 	}
 }

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -433,6 +433,19 @@ func (s *ServerGroup) ApplyConfig(cfg *Config) error {
 	if err != nil {
 		return errors.Wrap(err, "error loading TLS client config")
 	}
+	// The dialer's address family and dual-stack (RFC 6555 "Happy Eyeballs")
+	// fallback timing are configurable so downstream hosts that resolve to both
+	// IPv4 and IPv6 can be reached even when one family is unreachable.
+	dialer := &net.Dialer{
+		Timeout:       cfg.HTTPConfig.DialTimeout,
+		FallbackDelay: cfg.HTTPConfig.FallbackDelay,
+	}
+	// http.Transport always calls DialContext with network "tcp"; override it so
+	// dial_network (tcp/tcp4/tcp6) can force a specific address family.
+	dialNetwork := cfg.HTTPConfig.DialNetworkOrDefault()
+	dialContext := func(ctx context.Context, _, addr string) (net.Conn, error) {
+		return dialer.DialContext(ctx, dialNetwork, addr)
+	}
 	// The only timeout we care about is the configured scrape timeout.
 	// It is applied on request. So we leave out any timings here.
 	var rt http.RoundTripper = &http.Transport{
@@ -444,7 +457,7 @@ func (s *ServerGroup) ApplyConfig(cfg *Config) error {
 		// 5 minutes is typically above the maximum sane scrape interval. So we can
 		// use keepalive for all configurations.
 		IdleConnTimeout:       cfg.IdleConnTimeout,
-		DialContext:           (&net.Dialer{Timeout: cfg.HTTPConfig.DialTimeout}).DialContext,
+		DialContext:           dialContext,
 		ResponseHeaderTimeout: cfg.Timeout,
 	}
 


### PR DESCRIPTION
## Problem

Fixes #713. When a server-group target FQDN resolves to both IPv4 and IPv6, promxy could fail to reach it if one address family (typically IPv6 in Kubernetes) is silently dropped. `curl` to the same name works because it doesn't impose a short dial timeout.

**Root cause:** Go's `net.Dialer` implements RFC 6555 "Happy Eyeballs" dual-stack fallback, but the IPv4 fallback only begins after `FallbackDelay` (Go default **300ms**). Promxy's default `dial_timeout` is **200ms**, which bounds the *entire* dial — so the dial times out before the IPv4 fallback is ever attempted, and only IPv6 is tried.

## Change

Two new (optional) `http_client` knobs, wired onto the `net.Dialer` behind the transport:

- **`dial_network`** — `tcp` (default) / `tcp4` / `tcp6`. `http.Transport` always dials with `"tcp"`; we wrap `DialContext` to substitute the configured network so `tcp4` hard-pins IPv4 (the reporter's ask).
- **`fallback_delay`** — maps to `net.Dialer.FallbackDelay`. Set it below `dial_timeout` so Happy Eyeballs fires within the budget; a negative value disables the dual-stack fallback entirely.

`dial_network` is validated at config load (`tcp`/`tcp4`/`tcp6` only).

## Backwards compatibility

Defaults are unchanged: an unset `dial_network` behaves as `"tcp"` and a zero `fallback_delay` uses Go's default, so existing configs dial byte-for-byte as before. The 200ms default `dial_timeout` is untouched.

## Tests

- `TestDialNetworkConfig` covers default/tcp/tcp4/tcp6, negative fallback delay, and rejection of an invalid `dial_network`.
- Example `cmd/promxy/config.yaml` documents both options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)