### PR TITLE
feat(label_filter): add on_sync_error to control startup failure mode

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -208,6 +208,17 @@ promxy:
         static_labels_exclude:
           __name__:
             - up
+        # (optional) on_sync_error controls behavior while the filter has never
+        # successfully synced from the downstream (e.g. the target is unreachable
+        # at startup). This is distinct from the server_group's `ignore_error`,
+        # which governs the query path.
+        #   abort  - fail the sync; this blocks promxy startup until a sync
+        #            succeeds (default; preserves historical behavior)
+        #   open   - proceed without filtering; all queries are sent downstream
+        #            until the first successful sync
+        #   closed - proceed but filter out everything (skip this target) until
+        #            the first successful sync
+        on_sync_error: abort
 
       # inject_matchers is a list of label matchers that are injected into every selector
       # of every request sent to this server_group. This effectively scopes the server_group

--- a/pkg/promclient/labelfilter.go
+++ b/pkg/promclient/labelfilter.go
@@ -40,6 +40,28 @@ func init() {
 	)
 }
 
+// LabelFilterOnSyncError defines what a LabelFilterClient does while it has
+// never successfully synced its filter from the downstream (e.g. the target is
+// unreachable when promxy starts up).
+type LabelFilterOnSyncError string
+
+const (
+	// LabelFilterOnSyncErrorAbort fails the initial sync, which propagates up to
+	// the servergroup and blocks startup until a sync succeeds. This preserves
+	// the historical behavior and is the default.
+	LabelFilterOnSyncErrorAbort LabelFilterOnSyncError = "abort"
+	// LabelFilterOnSyncErrorOpen lets startup proceed and sends all queries
+	// downstream (i.e. no filtering) until the first successful sync.
+	LabelFilterOnSyncErrorOpen LabelFilterOnSyncError = "open"
+	// LabelFilterOnSyncErrorClosed lets startup proceed but filters out every
+	// query (i.e. the target is skipped) until the first successful sync.
+	LabelFilterOnSyncErrorClosed LabelFilterOnSyncError = "closed"
+)
+
+// defaultSyncRetryInterval is how often the filter retries to obtain its first
+// successful sync when no explicit sync_interval is configured.
+const defaultSyncRetryInterval = 5 * time.Second
+
 // LabelFilterConfig is the configuration for the LabelFilterClient
 type LabelFilterConfig struct {
 	// DynamicLabels is a list of labels to dynamically maintain a filter from the downstream from
@@ -56,6 +78,16 @@ type LabelFilterConfig struct {
 	// StaticLabelsExclude is a set of labels to always exclude from the filter. This is done last
 	// so it will apply after the dynamic and static lists are added to the filter.
 	StaticLabelsExclude map[string][]string `yaml:"static_labels_exclude"`
+	// OnSyncError controls behavior while the filter has never successfully synced
+	// from the downstream (e.g. the target is unreachable at startup). This is
+	// distinct from the servergroup's `ignore_error`, which governs the query path.
+	//   abort  - fail the sync; this blocks servergroup startup until a sync
+	//            succeeds (default; preserves historical behavior)
+	//   open   - proceed without filtering; all queries are sent downstream until
+	//            the first successful sync
+	//   closed - proceed but filter out everything (skip this target) until the
+	//            first successful sync
+	OnSyncError LabelFilterOnSyncError `yaml:"on_sync_error"`
 }
 
 func (c *LabelFilterConfig) Validate() error {
@@ -67,6 +99,14 @@ func (c *LabelFilterConfig) Validate() error {
 
 	if c.SyncInterval > 0 && len(c.DynamicLabels) == 0 {
 		return fmt.Errorf("sync_interval requires `dynamic_labels_include` to be set")
+	}
+
+	switch c.OnSyncError {
+	case "":
+		c.OnSyncError = LabelFilterOnSyncErrorAbort
+	case LabelFilterOnSyncErrorAbort, LabelFilterOnSyncErrorOpen, LabelFilterOnSyncErrorClosed:
+	default:
+		return fmt.Errorf("invalid on_sync_error %q, must be one of: abort, open, closed", c.OnSyncError)
 	}
 
 	return nil
@@ -91,37 +131,69 @@ func NewLabelFilterClient(ctx context.Context, a API, cfg *LabelFilterConfig) (*
 		cfg: cfg,
 	}
 
-	// Do an initial sync
+	// Do an initial sync. If it fails, behavior depends on on_sync_error:
+	//   abort       -> return the error, which blocks servergroup startup until a
+	//                  sync succeeds (historical behavior, and the default).
+	//   open/closed -> log and continue with an unloaded filter; queries are
+	//                  passed through (open) or filtered out (closed) until a
+	//                  background sync succeeds.
 	if err := c.Sync(ctx); err != nil {
-		return nil, err
+		if cfg.OnSyncError != LabelFilterOnSyncErrorOpen && cfg.OnSyncError != LabelFilterOnSyncErrorClosed {
+			return nil, err
+		}
+		logrus.Errorf("error in initial label_filter sync from downstream (on_sync_error=%s), continuing and retrying in the background: %v", cfg.OnSyncError, err)
 	}
 
-	if cfg.SyncInterval > 0 {
-		go func() {
-			ticker := time.NewTicker(cfg.SyncInterval)
-			for {
-				select {
-				case <-ticker.C:
-					start := time.Now()
-					err := c.Sync(ctx)
-					took := time.Since(start)
-					status := "success"
-					if err != nil {
-						logrus.Errorf("error syncing in label_filter from downstream: %#v", err)
-						status = "error"
-					}
-					syncCount.WithLabelValues(status).Inc()
-					syncSummary.WithLabelValues(status).Observe(took.Seconds())
-
-				case <-ctx.Done():
-					ticker.Stop()
-					return
-				}
-			}
-		}()
+	// Run a background sync loop when either a periodic sync_interval is
+	// configured, or the initial sync failed and we need to keep retrying until
+	// the first successful sync.
+	if cfg.SyncInterval > 0 || c.LabelFilter() == nil {
+		go c.syncLoop(ctx)
 	}
 
 	return c, nil
+}
+
+// syncLoop periodically re-syncs the filter from the downstream. When a
+// sync_interval is configured it runs forever at that cadence; when it is not,
+// the loop only exists to obtain the first successful sync (e.g. after a failed
+// initial sync) and exits once a filter has been loaded.
+func (c *LabelFilterClient) syncLoop(ctx context.Context) {
+	for {
+		interval := c.cfg.SyncInterval
+		if interval <= 0 {
+			interval = defaultSyncRetryInterval
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+			start := time.Now()
+			err := c.Sync(ctx)
+			took := time.Since(start)
+			status := "success"
+			if err != nil {
+				logrus.Errorf("error syncing in label_filter from downstream: %#v", err)
+				status = "error"
+			}
+			syncCount.WithLabelValues(status).Inc()
+			syncSummary.WithLabelValues(status).Observe(took.Seconds())
+
+			// With no configured sync_interval we're only retrying to obtain the
+			// first successful sync; stop once we have a filter loaded.
+			if c.cfg.SyncInterval <= 0 && c.LabelFilter() != nil {
+				return
+			}
+		}
+	}
+}
+
+// blocked reports whether the filter has never successfully synced and is
+// configured to fail closed, in which case all downstream calls are skipped
+// (the target is treated as "down" until the first successful sync).
+func (c *LabelFilterClient) blocked() bool {
+	return c.cfg != nil && c.cfg.OnSyncError == LabelFilterOnSyncErrorClosed && c.LabelFilter() == nil
 }
 
 // LabelFilterClient filters out calls to the downstream based on a label filter
@@ -193,6 +265,11 @@ func (c *LabelFilterClient) Sync(ctx context.Context) error {
 
 // Query performs a query for the given time.
 func (c *LabelFilterClient) Query(ctx context.Context, query string, ts time.Time) storage.SeriesSet {
+	if c.blocked() {
+		filteredCount.WithLabelValues("Query").Inc()
+		return storage.EmptySeriesSet()
+	}
+
 	// Parse out the promql query into expressions etc.
 	e, err := parser.ParseExpr(query)
 	if err != nil {
@@ -213,6 +290,11 @@ func (c *LabelFilterClient) Query(ctx context.Context, query string, ts time.Tim
 
 // QueryRange performs a query for the given range.
 func (c *LabelFilterClient) QueryRange(ctx context.Context, query string, r v1.Range) storage.SeriesSet {
+	if c.blocked() {
+		filteredCount.WithLabelValues("QueryRange").Inc()
+		return storage.EmptySeriesSet()
+	}
+
 	// Parse out the promql query into expressions etc.
 	e, err := parser.ParseExpr(query)
 	if err != nil {
@@ -233,6 +315,10 @@ func (c *LabelFilterClient) QueryRange(ctx context.Context, query string, r v1.R
 
 // Series finds series by label matchers.
 func (c *LabelFilterClient) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	if c.blocked() {
+		filteredCount.WithLabelValues("Series").Inc()
+		return nil, nil, nil
+	}
 	for _, m := range matches {
 		matchers, err := parser.ParseMetricSelector(m)
 		if err != nil {
@@ -251,6 +337,10 @@ func (c *LabelFilterClient) Series(ctx context.Context, matches []string, startT
 
 // GetValue loads the raw data for a given set of matchers in the time range
 func (c *LabelFilterClient) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) storage.SeriesSet {
+	if c.blocked() {
+		filteredCount.WithLabelValues("GetValue").Inc()
+		return storage.EmptySeriesSet()
+	}
 	// check if the matcher is excluded by our filter
 	for _, matcher := range matchers {
 		if !FilterLabelMatchers(c.LabelFilter(), matcher) {
@@ -263,6 +353,10 @@ func (c *LabelFilterClient) GetValue(ctx context.Context, start, end time.Time, 
 
 // Metadata returns metadata about metrics currently scraped by the metric name.
 func (c *LabelFilterClient) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	if c.blocked() {
+		filteredCount.WithLabelValues("Metadata").Inc()
+		return nil, nil
+	}
 	matcher, err := labels.NewMatcher(labels.MatchEqual, labels.MetricName, metric)
 	if err != nil {
 		return nil, err
@@ -282,6 +376,10 @@ func (c *LabelFilterClient) Metadata(ctx context.Context, metric, limit string) 
 // still forwarded (we can't easily rewrite a PromQL string) — the
 // non-satisfiable side just returns no exemplars.
 func (c *LabelFilterClient) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	if c.blocked() {
+		filteredCount.WithLabelValues("QueryExemplars").Inc()
+		return nil, nil
+	}
 	expr, err := parser.ParseExpr(query)
 	if err != nil {
 		// Parse error: let the downstream return the canonical error rather

--- a/pkg/promclient/labelfilter_test.go
+++ b/pkg/promclient/labelfilter_test.go
@@ -2,7 +2,9 @@ package promclient
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -244,4 +246,165 @@ func TestLabelFilter(t *testing.T) {
 		}
 	})
 
+}
+
+// flakyLabelValuesAPI lets a test toggle whether the downstream LabelValues call
+// (the one the label_filter sync uses) succeeds, and counts Query passthroughs.
+// All state is mutex-guarded so it is safe to poke from a test while the
+// LabelFilterClient background sync goroutine is running.
+type flakyLabelValuesAPI struct {
+	*stubAPI
+
+	mu         sync.Mutex
+	fail       bool
+	values     model.LabelValues
+	queryCount int
+}
+
+func (s *flakyLabelValuesAPI) LabelValues(ctx context.Context, label string, matchers []string, startTime, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.fail {
+		return nil, nil, fmt.Errorf("downstream unavailable")
+	}
+	return s.values, nil, nil
+}
+
+func (s *flakyLabelValuesAPI) Query(ctx context.Context, query string, ts time.Time) storage.SeriesSet {
+	s.mu.Lock()
+	s.queryCount++
+	s.mu.Unlock()
+	return s.stubAPI.Query(ctx, query, ts)
+}
+
+func (s *flakyLabelValuesAPI) setFail(b bool) {
+	s.mu.Lock()
+	s.fail = b
+	s.mu.Unlock()
+}
+
+func (s *flakyLabelValuesAPI) getQueryCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.queryCount
+}
+
+func TestLabelFilterConfigOnSyncErrorValidate(t *testing.T) {
+	// Empty defaults to abort.
+	c := &LabelFilterConfig{}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if c.OnSyncError != LabelFilterOnSyncErrorAbort {
+		t.Fatalf("expected default on_sync_error=abort, got %q", c.OnSyncError)
+	}
+
+	// Explicit valid values are accepted.
+	for _, v := range []LabelFilterOnSyncError{LabelFilterOnSyncErrorAbort, LabelFilterOnSyncErrorOpen, LabelFilterOnSyncErrorClosed} {
+		c := &LabelFilterConfig{OnSyncError: v}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error for on_sync_error=%q: %v", v, err)
+		}
+	}
+
+	// Unknown values are rejected.
+	c = &LabelFilterConfig{OnSyncError: "bogus"}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error for invalid on_sync_error")
+	}
+}
+
+func TestLabelFilterOnSyncError(t *testing.T) {
+	// abort (the default) surfaces the initial sync error, which blocks startup.
+	t.Run("abort", func(t *testing.T) {
+		api := &flakyLabelValuesAPI{stubAPI: &stubAPI{}, fail: true}
+		cfg := &LabelFilterConfig{DynamicLabels: []string{"__name__"}}
+		if err := cfg.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewLabelFilterClient(context.Background(), api, cfg); err == nil {
+			t.Fatal("expected NewLabelFilterClient to fail when the initial sync errors under on_sync_error=abort")
+		}
+	})
+
+	// open lets startup proceed and sends queries downstream (unfiltered) until synced.
+	t.Run("open", func(t *testing.T) {
+		api := &flakyLabelValuesAPI{stubAPI: &stubAPI{}, fail: true}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		cfg := &LabelFilterConfig{DynamicLabels: []string{"__name__"}, OnSyncError: LabelFilterOnSyncErrorOpen}
+		if err := cfg.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		c, err := NewLabelFilterClient(ctx, api, cfg)
+		if err != nil {
+			t.Fatalf("expected startup to proceed under on_sync_error=open, got: %v", err)
+		}
+		if c.LabelFilter() != nil {
+			t.Fatal("expected filter to be unloaded after a failed initial sync")
+		}
+		// Unloaded + open => query is passed straight through to the downstream.
+		before := api.getQueryCount()
+		if err := c.Query(ctx, "anymetric", time.Now()).Err(); err != nil {
+			t.Fatal(err)
+		}
+		if got := api.getQueryCount(); got != before+1 {
+			t.Fatalf("expected query to pass through while unloaded (open), downstream calls before=%d after=%d", before, got)
+		}
+	})
+
+	// closed lets startup proceed but filters out everything until the first
+	// successful sync, then recovers and filters normally.
+	t.Run("closed_then_recovers", func(t *testing.T) {
+		api := &flakyLabelValuesAPI{stubAPI: &stubAPI{}, fail: true, values: model.LabelValues{"knownmetric"}}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		cfg := &LabelFilterConfig{
+			DynamicLabels: []string{"__name__"},
+			OnSyncError:   LabelFilterOnSyncErrorClosed,
+			SyncInterval:  20 * time.Millisecond,
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		c, err := NewLabelFilterClient(ctx, api, cfg)
+		if err != nil {
+			t.Fatalf("expected startup to proceed under on_sync_error=closed, got: %v", err)
+		}
+
+		// While unloaded, everything is filtered out (target treated as down).
+		before := api.getQueryCount()
+		if err := c.Query(ctx, "knownmetric", time.Now()).Err(); err != nil {
+			t.Fatal(err)
+		}
+		if got := api.getQueryCount(); got != before {
+			t.Fatalf("expected query to be blocked while unloaded (closed), but downstream was called: before=%d after=%d", before, got)
+		}
+
+		// Recover the downstream and wait for a background sync to load the filter.
+		api.setFail(false)
+		deadline := time.Now().Add(2 * time.Second)
+		for c.LabelFilter() == nil && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		if c.LabelFilter() == nil {
+			t.Fatal("filter never synced after the downstream recovered")
+		}
+
+		// Now filtering behaves normally: known metric passes, unknown is filtered.
+		before = api.getQueryCount()
+		if err := c.Query(ctx, "knownmetric", time.Now()).Err(); err != nil {
+			t.Fatal(err)
+		}
+		if got := api.getQueryCount(); got != before+1 {
+			t.Fatalf("expected knownmetric to pass through after sync: before=%d after=%d", before, got)
+		}
+		before = api.getQueryCount()
+		if err := c.Query(ctx, "unknownmetric", time.Now()).Err(); err != nil {
+			t.Fatal(err)
+		}
+		if got := api.getQueryCount(); got != before {
+			t.Fatalf("expected unknownmetric to be filtered after sync: before=%d after=%d", before, got)
+		}
+	})
 }


### PR DESCRIPTION
## Problem

Fixes #732.

A `label_filter` is the only per-target wrapper that makes a network call at **construction time** — the initial `LabelValues` sync in `NewLabelFilterClient`. When a target is unreachable at startup, that error escapes `loadTargetGroupMap`, whose retry loop then spins forever, so the servergroup never becomes `Ready` and **promxy never starts**.

Critically, `ignore_error` can't help: it wraps the *query* path (`IgnoreErrorAPI`) and is applied only *after* the whole load succeeds, so it never gets a chance to run.

## Approach

Rather than overload `ignore_error` (a query-path concern), add a dedicated `on_sync_error` option to `LabelFilterConfig`, co-located with the feature it governs. It answers one question: *what do we do while the filter has never successfully synced?*

| value | startup | behavior until first successful sync |
|---|---|---|
| `abort` (default) | blocks until sync succeeds | n/a — historical behavior, unchanged |
| `open` | proceeds | send **all** queries downstream (unfiltered) |
| `closed` | proceeds | filter out **everything** (skip this target) |

- `abort` is the zero-value/default, so existing configs are unchanged.
- For `open`/`closed`, a failed initial sync no longer fails construction; the client retries in the background (every `sync_interval`, or every 5s when unset) until the first success, then behaves normally.
- `closed` **fails safe** — an unloaded filter returns nothing rather than silently disabling the filter and fanning every query out to a downstream it can't vouch for. This is what the reporter wanted for the authz/routing use case; a naive "just don't fail" would fail *open*.

Once a filter has loaded, a later re-sync failure keeps the last-good filter (unchanged behavior).

## Tests

- `TestLabelFilterConfigOnSyncErrorValidate` — default → `abort`, valid values accepted, unknown rejected.
- `TestLabelFilterOnSyncError` — `abort` fails construction on a down target; `open` passes queries through while unloaded; `closed` blocks while unloaded, then recovers and filters normally once the downstream comes back (run under `-race`).

## Docs

Documented `on_sync_error` in `cmd/promxy/config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)