### PR TITLE
ci: speed up multi-arch build with Go + layer caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,14 @@ jobs:
       - name: Available platforms
         run: 'echo ${{ steps.buildx.outputs.platforms }}'
       - name: Run Buildx
-        run: |
-          docker buildx build \
-            --platform linux/amd64,linux/386,linux/arm/v7,linux/arm64 \
-            --push -t quay.io/jacksontj/promxy:${GITHUB_REF_NAME//master/latest} .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/386,linux/arm/v7,linux/arm64
+          push: true
+          tags: quay.io/jacksontj/promxy:${{ github.ref_name == 'master' && 'latest' || github.ref_name }}
+          # Reuse the Go build cache (and image layers) across runs. Combined with
+          # the cache mounts in the Dockerfile this avoids recompiling promxy +
+          # vendor from scratch for all four platforms on every push.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,13 @@ ARG TARGETOS
 ENV GOARCH=${TARGETARCH} GOOS=${TARGETOS}
 
 COPY . /go/src/github.com/jacksontj/promxy
-RUN cd /go/src/github.com/jacksontj/promxy/cmd/promxy && CGO_ENABLED=0 go build -mod=vendor -tags netgo,builtinassets
-RUN cd /go/src/github.com/jacksontj/promxy/cmd/remote_write_exporter && CGO_ENABLED=0 go build -mod=vendor
+# Persist the Go build cache across the per-platform cross-compiles (and, with the
+# gha buildx cache, across CI runs). Scope the build cache by target arch so the
+# parallel platform builds don't contend on a single shared cache mount.
+RUN --mount=type=cache,target=/root/.cache/go-build,id=gobuild-${TARGETARCH} \
+    cd /go/src/github.com/jacksontj/promxy/cmd/promxy && CGO_ENABLED=0 go build -mod=vendor -tags netgo,builtinassets
+RUN --mount=type=cache,target=/root/.cache/go-build,id=gobuild-${TARGETARCH} \
+    cd /go/src/github.com/jacksontj/promxy/cmd/remote_write_exporter && CGO_ENABLED=0 go build -mod=vendor
 
 FROM   alpine:3.21.3
 LABEL  org.opencontainers.image.authors="Thomas Jackson <jacksontj.89@gmail.com>"


### PR DESCRIPTION
## Why

The `build` workflow (multi-arch docker, runs on master push + tags) spends ~10m almost entirely in one step:

| Workflow | Trigger | Total | Slow step |
|---|---|---|---|
| `build` | master push + tags | 10m39s | `Run Buildx` = **10m12s** |

The Dockerfile cross-compiles (`$BUILDPLATFORM`, `CGO_ENABLED=0`), so the four arches aren't emulated under QEMU — they're four native cross-compiles. But every push did `COPY . …` → full `go build` of promxy + all of vendor, ×4 platforms, from a cold build cache, with no layer cache between runs.

## What

- **Dockerfile:** add per-arch `--mount=type=cache,target=/root/.cache/go-build` mounts so the Go build cache is reused across the four platform builds.
- **build.yml:** drive the build with `docker/build-push-action@v6` and `cache-from/to: type=gha` so that cache (and image layers) also persists across runs.

Expected: ~10m → ~2–3m on warm cache. The first run still populates the cache.

## Notes

- Node 20 deprecation warnings remain, but `checkout@v4` / `docker/setup-*@v3` / `azure/docker-login@v2` are already on their latest majors — nothing to bump yet.
- Considered splitting the `Go` test workflow's lint and test into parallel jobs, but dropped it: the jobs run on separate runners (no shared build cache mid-run) and staticcheck (non-race) vs `go test -race` compile different artifacts, so it traded a whole extra runner for a marginal wall-clock gain. `go.yml` is unchanged.
- Based on `master` (already Go 1.25), independent of the in-flight OCI branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)