### PR TITLE
proxystorage: implement ChunkQuerier so stock Prometheus remote_read works (#356)

### DIFF
--- a/pkg/proxyquerier/chunk_querier.go
+++ b/pkg/proxyquerier/chunk_querier.go
@@ -1,0 +1,45 @@
+package proxyquerier
+
+import (
+	"context"
+	"sort"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// ProxyChunkQuerier implements prometheus' storage.ChunkQuerier on top of
+// ProxyQuerier. Promxy has no native chunk source -- it fetches raw samples
+// from the downstream server groups -- so Select runs the normal sample-based
+// ProxyQuerier.Select and re-encodes the resulting series into chunks via
+// storage.NewSeriesSetToChunkSet.
+//
+// This is what backs promxy's own remote_read endpoint (/api/v1/read) for the
+// STREAMED_XOR_CHUNKS response type, which is what a stock Prometheus
+// remote_read client negotiates by default. Without it that path returned a
+// 500 ("not implemented"). The label-querier methods (LabelValues, LabelNames,
+// Close) are promoted from the embedded *ProxyQuerier.
+type ProxyChunkQuerier struct {
+	*ProxyQuerier
+}
+
+// Select fetches the matching series as samples and re-encodes them as chunks.
+// The remote-read streaming API requires series to be sorted by label set, so
+// the result is always sorted here (ProxyQuerier.Select does not guarantee an
+// order); the sortSeries hint is therefore honored unconditionally.
+func (h *ProxyChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
+	ss := h.ProxyQuerier.Select(ctx, sortSeries, hints, matchers...)
+
+	// ProxyQuerier already materializes the full result, so collecting and
+	// sorting here adds no extra round-trips.
+	var series []storage.Series
+	for ss.Next() {
+		series = append(series, ss.At())
+	}
+	sort.Slice(series, func(i, j int) bool {
+		return labels.Compare(series[i].Labels(), series[j].Labels()) < 0
+	})
+
+	// ss.Err()/ss.Warnings() are only final once iteration is drained above.
+	return storage.NewSeriesSetToChunkSet(NewSeriesSet(series, ss.Warnings(), ss.Err()))
+}

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -354,9 +354,21 @@ func (p *ProxyStorage) Appender(ctx context.Context) storage.Appender {
 // Close releases the resources of the Querier.
 func (p *ProxyStorage) Close() error { return nil }
 
-// ChunkQuerier returns a new ChunkQuerier on the storage.
+// ChunkQuerier returns a new ChunkQuerier on the storage. Promxy has no native
+// chunk source, so this reuses the sample-based querier and re-encodes the
+// result into chunks (see proxyquerier.ProxyChunkQuerier). It backs promxy's
+// own remote_read endpoint for the STREAMED_XOR_CHUNKS response type that a
+// stock Prometheus remote_read client negotiates by default.
 func (p *ProxyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
-	return nil, errors.New("not implemented")
+	state := p.GetState()
+	return &proxyquerier.ProxyChunkQuerier{
+		ProxyQuerier: &proxyquerier.ProxyQuerier{
+			Start:  timestamp.Time(mint).UTC(),
+			End:    timestamp.Time(maxt).UTC(),
+			Client: state.client,
+			Cfg:    &state.cfg.PromxyConfig,
+		},
+	}, nil
 }
 
 // Implement web.LocalStorage

--- a/test/remote_read_test.go
+++ b/test/remote_read_test.go
@@ -9,17 +9,22 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
 // TestRemoteReadFromPromxy is an end-to-end test for issue #356: a remote_read
@@ -38,54 +43,11 @@ import (
 // Constant values make the assertion robust to how the raw range selector lands
 // on sample boundaries.
 //
-// Note: promxy's ProxyStorage does not implement ChunkQuerier, so it only serves
-// the SAMPLES response type (not STREAMED_XOR_CHUNKS). The request below asks for
-// SAMPLES explicitly, which is the path that works today; a chunked-streaming
-// client is unsupported.
+// This exercises the SAMPLES response type explicitly. See
+// TestRemoteReadFromPromxyStreamedChunks for the STREAMED_XOR_CHUNKS path that a
+// stock Prometheus remote_read client negotiates by default.
 func TestRemoteReadFromPromxy(t *testing.T) {
-	// Two downstream Prometheus instances, one per server_group, each loaded
-	// with the same series name but a distinct constant value.
-	loadA := `load 30s
-  test_metric{foo="bar"} 7 7 7 7 7`
-	loadB := `load 30s
-  test_metric{foo="bar"} 42 42 42 42 42`
-
-	storeA := promqltest.LoadedStorage(t, loadA)
-	defer storeA.Close()
-	storeB := promqltest.LoadedStorage(t, loadB)
-	defer storeB.Close()
-
-	srvA, addrA, stopA := startAPIForTest(storeA)
-	defer func() {
-		srvA.Shutdown(context.Background())
-		<-stopA
-	}()
-	srvB, addrB, stopB := startAPIForTest(storeB)
-	defer func() {
-		srvB.Shutdown(context.Background())
-		<-stopB
-	}()
-
-	// promxy in front of both downstreams; rawDoublePSConfig tags the groups
-	// with az=a / az=b.
-	ps := getProxyStorage(fmt.Sprintf(rawDoublePSConfig, addrA, addrB))
-	defer ps.GetState().Cancel(nil)
-
-	// Serve promxy's remote-read endpoint the same way cmd/promxy does: the
-	// vendored Prometheus read handler backed by the proxy storage.
-	readHandler := remote.NewReadHandler(
-		slog.New(slog.NewTextHandler(io.Discard, nil)),
-		nil, // registerer
-		ps,  // SampleAndChunkQueryable
-		func() config.Config { return config.DefaultConfig },
-		50000000, // remoteReadSampleLimit
-		1000,     // remoteReadConcurrencyLimit
-		1048576,  // remoteReadMaxBytesInFrame
-	)
-	mux := http.NewServeMux()
-	mux.Handle("/api/v1/read", readHandler)
-	promxySrv := httptest.NewServer(mux)
-	defer promxySrv.Close()
+	readURL := startRemoteReadPromxy(t)
 
 	// The five loaded samples sit at t=0,30s,...,120s. Reading [0,120s] with a
 	// raw range selector captures all of them.
@@ -107,7 +69,7 @@ func TestRemoteReadFromPromxy(t *testing.T) {
 		AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_SAMPLES},
 	}
 
-	result := doRemoteRead(t, promxySrv.URL+"/api/v1/read", readReq)
+	result := doRemoteRead(t, readURL, readReq)
 
 	// Expect exactly two series (one per server_group), distinguished by az.
 	type seriesData struct {
@@ -157,6 +119,148 @@ func TestRemoteReadFromPromxy(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestRemoteReadFromPromxyStreamedChunks is the regression test for the fix that
+// closed the remaining half of issue #356: a stock Prometheus remote_read client
+// negotiates STREAMED_XOR_CHUNKS first (remote.AcceptedResponseTypes), which used
+// to hit ProxyStorage.ChunkQuerier and return a 500 ("not implemented"). With
+// ProxyChunkQuerier in place, the same fan-out that the SAMPLES test asserts must
+// now come back over the chunked-streaming path.
+//
+// It drives the high-level remote.Client (the exact code path Prometheus uses),
+// so the chunked negotiation and decoding are real, not hand-rolled.
+func TestRemoteReadFromPromxyStreamedChunks(t *testing.T) {
+	readURL := startRemoteReadPromxy(t)
+
+	u, err := url.Parse(readURL)
+	if err != nil {
+		t.Fatalf("parse read url: %v", err)
+	}
+	client, err := remote.NewReadClient("test", &remote.ClientConfig{
+		URL:              &commoncfg.URL{URL: u},
+		Timeout:          model.Duration(30 * time.Second),
+		ChunkedReadLimit: 1e9,
+	})
+	if err != nil {
+		t.Fatalf("NewReadClient: %v", err)
+	}
+
+	mint := int64(0)
+	maxt := int64(120000)
+	matcher, err := labels.NewMatcher(labels.MatchEqual, labels.MetricName, "test_metric")
+	if err != nil {
+		t.Fatalf("build matcher: %v", err)
+	}
+	query, err := remote.ToQuery(mint, maxt, []*labels.Matcher{matcher}, &storage.SelectHints{Start: mint, End: maxt})
+	if err != nil {
+		t.Fatalf("ToQuery: %v", err)
+	}
+
+	// client.Read uses remote.AcceptedResponseTypes (STREAMED_XOR_CHUNKS first),
+	// so this is the chunked path a real Prometheus takes.
+	ss, err := client.Read(context.Background(), query, true)
+	if err != nil {
+		t.Fatalf("remote read (chunked) failed: %v", err)
+	}
+
+	type seriesData struct {
+		lbls labels.Labels
+		vals []float64
+	}
+	var got []seriesData
+	for ss.Next() {
+		s := ss.At()
+		var vals []float64
+		it := s.Iterator(nil)
+		for {
+			vt := it.Next()
+			if vt == chunkenc.ValNone {
+				break
+			}
+			if vt == chunkenc.ValFloat {
+				_, v := it.At()
+				if !math.IsNaN(v) {
+					vals = append(vals, v)
+				}
+			}
+		}
+		if err := it.Err(); err != nil {
+			t.Fatalf("series iterator: %v", err)
+		}
+		got = append(got, seriesData{lbls: s.Labels(), vals: vals})
+	}
+	if err := ss.Err(); err != nil {
+		t.Fatalf("series set: %v", err)
+	}
+	sort.Slice(got, func(i, j int) bool { return labels.Compare(got[i].lbls, got[j].lbls) < 0 })
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 series (one per server_group), got %d: %+v", len(got), got)
+	}
+	want := []struct {
+		lbls labels.Labels
+		val  float64
+	}{
+		{labels.FromStrings(labels.MetricName, "test_metric", "az", "a", "foo", "bar"), 7},
+		{labels.FromStrings(labels.MetricName, "test_metric", "az", "b", "foo", "bar"), 42},
+	}
+	for i, w := range want {
+		if !labels.Equal(got[i].lbls, w.lbls) {
+			t.Errorf("series %d: labels = %s, want %s", i, got[i].lbls, w.lbls)
+		}
+		if len(got[i].vals) == 0 {
+			t.Errorf("series %d (%s): no samples returned", i, got[i].lbls)
+			continue
+		}
+		for _, v := range got[i].vals {
+			if v != w.val {
+				t.Errorf("series %d (%s): sample value = %v, want %v", i, got[i].lbls, v, w.val)
+			}
+		}
+	}
+}
+
+// startRemoteReadPromxy stands up two downstream Prometheus v1 APIs (one per
+// server_group, tagged az=a / az=b via rawDoublePSConfig) and a promxy instance
+// in front of them serving the vendored Prometheus remote-read handler
+// (remote.NewReadHandler backed by ProxyStorage — exactly what cmd/promxy wires
+// up). It returns the promxy /api/v1/read URL; all resources are torn down via
+// t.Cleanup.
+//
+// Each downstream holds test_metric{foo="bar"} with a distinct constant value (7
+// for az=a, 42 for az=b) at t=0,30s,...,120s.
+func startRemoteReadPromxy(t *testing.T) string {
+	t.Helper()
+
+	storeA := promqltest.LoadedStorage(t, "load 30s\n  test_metric{foo=\"bar\"} 7 7 7 7 7")
+	t.Cleanup(func() { storeA.Close() })
+	storeB := promqltest.LoadedStorage(t, "load 30s\n  test_metric{foo=\"bar\"} 42 42 42 42 42")
+	t.Cleanup(func() { storeB.Close() })
+
+	srvA, addrA, stopA := startAPIForTest(storeA)
+	t.Cleanup(func() { srvA.Shutdown(context.Background()); <-stopA })
+	srvB, addrB, stopB := startAPIForTest(storeB)
+	t.Cleanup(func() { srvB.Shutdown(context.Background()); <-stopB })
+
+	ps := getProxyStorage(fmt.Sprintf(rawDoublePSConfig, addrA, addrB))
+	t.Cleanup(func() { ps.GetState().Cancel(nil) })
+
+	readHandler := remote.NewReadHandler(
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil, // registerer
+		ps,  // SampleAndChunkQueryable
+		func() config.Config { return config.DefaultConfig },
+		50000000, // remoteReadSampleLimit
+		1000,     // remoteReadConcurrencyLimit
+		1048576,  // remoteReadMaxBytesInFrame
+	)
+	mux := http.NewServeMux()
+	mux.Handle("/api/v1/read", readHandler)
+	promxySrv := httptest.NewServer(mux)
+	t.Cleanup(promxySrv.Close)
+
+	return promxySrv.URL + "/api/v1/read"
 }
 
 // doRemoteRead issues a remote-read request against url and returns the first


### PR DESCRIPTION
Follow-up to #800 (the remote_read-from-promxy test), which surfaced this bug.

### The bug
A stock Prometheus `remote_read` client negotiates response types in the order `[STREAMED_XOR_CHUNKS, SAMPLES]` (`remote.AcceptedResponseTypes`). promxy's `/api/v1/read` handler picks the first supported type — `STREAMED_XOR_CHUNKS` — and calls `queryable.ChunkQuerier(...)`. That was a stub:

```go
func (p *ProxyStorage) ChunkQuerier(mint, maxt int64) (storage.ChunkQuerier, error) {
    return nil, errors.New("not implemented")
}
```

So **every default remote_read against promxy returned HTTP 500 "not implemented"**. Only clients that explicitly request `SAMPLES` worked.

### The fix
promxy has no native chunk source (it fetches raw samples from downstream server groups), so `ProxyChunkQuerier` reuses the existing sample-based `ProxyQuerier.Select` and re-encodes the result into chunks via `storage.NewSeriesSetToChunkSet`. The streaming API requires series **sorted by label set**, so the wrapper sorts (`ProxyQuerier.Select` does not guarantee order). Label-querier methods are promoted from the embedded `*ProxyQuerier`.

### Test
Adds `TestRemoteReadFromPromxyStreamedChunks`, which drives the high-level `remote.Client` — the exact code path a real Prometheus uses, so the chunked negotiation and decoding are real, not hand-rolled — and asserts the same two-series fan-out (`az=a`→7, `az=b`→42) the SAMPLES test checks. Shared topology setup is factored into `startRemoteReadPromxy` and reused by both tests.

Verified the new test fails (HTTP 500) without the `ChunkQuerier` change and passes with it; `TestRemoteReadFromPromxy` and the `proxystorage` package tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)