### PR TITLE
ci: seed a rolling Go build cache from master to speed up PR runs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,15 +17,53 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.25'
+        # Disable setup-go's built-in cache: it keys only on go.sum, so the
+        # entry is written once and then frozen ("cache hit, not saving"),
+        # which means changed packages and go-test results never persist
+        # across runs. We manage the caches explicitly below instead.
+        cache: false
+
+    # Module download cache. Only changes when go.sum changes, so a stable
+    # key is correct and every branch may populate it.
+    - name: Module cache
+      uses: actions/cache@v4
+      with:
+        path: ~/go/pkg/mod
+        key: gomod-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          gomod-${{ runner.os }}-
+
+    # Build + go-test result cache. master runs write a fresh entry every
+    # time (github.run_id makes the key unique); PRs restore the most recent
+    # one via restore-keys but never write. GitHub cache scoping lets a PR
+    # read its base branch's (master's) caches, so every PR builds and tests
+    # off master's warm base and only recompiles / re-runs what it changed.
+    - name: Restore build cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+        restore-keys: |
+          gobuild-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+          gobuild-${{ runner.os }}-
 
     - name: install
       run: |
         go install -v golang.org/x/tools/cmd/goimports@latest
         go install -v honnef.co/go/tools/cmd/staticcheck@latest
-      
+
     - name: Test
       run: |
         make fmt && git diff --exit-code
         make imports && git diff --exit-code
         make static-check
         make test
+
+    - name: Save build cache
+      # Only master writes, so PR runs stay read-only and don't churn the
+      # cache budget with per-PR entries.
+      if: github.ref == 'refs/heads/master'
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.cache/go-build
+        key: gobuild-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}


### PR DESCRIPTION
## Why

On PRs only the `Go` workflow runs (~7m). We measured where the time goes:

- Compile: ~40–60s (partly warm).
- **Integration suite `test/`: ~112s serial** — and it dominates the run.
- Every other package: ~1s.

Two facts make this fixable:

1. The `test/` suite is **fully `go test`-cacheable** — re-running it unchanged is `(cached)` in **0.2s** vs 112s.
2. But `setup-go`'s built-in cache **keys only on `go.sum`**, so the entry is written once and then frozen. Real run log:

   ```
   Cache hit occurred on the primary key setup-go-...-<gosum>, not saving cache.
   ```

   `GOCACHE` (compile artifacts **and** go-test results live there) never rolls forward. So every PR recompiles whatever changed since that stale snapshot and re-runs all tests from scratch.

## What

Manage the caches explicitly, structured as **master writes, PRs read**:

- **Module cache** (`~/go/pkg/mod`): stable key on `go.sum`.
- **Build + test-result cache** (`~/.cache/go-build`): master runs save a fresh entry each run (`run_id` makes the key unique); PRs restore the most recent via `restore-keys` but **never save**. GitHub cache scoping lets a PR read its **base branch's** caches, so each PR builds/tests off master's warm base and only recompiles / re-runs what it changed.

This matches the wait-vs-waste balance: master runs anyway and does the writing; PR runs stay **read-only** — no extra runner, no per-PR cache churn.

## Expected impact

- PR that doesn't touch the query engine's dependency graph → `test/` served from cache → **~7m → ~1–2m**.
- PR that does touch core query code → test binary hash changes, so the 112s re-runs, but compile is still incremental off master instead of a frozen snapshot.

## Caveats

- **Seeding:** the first master run after merge writes the first entry under the new key; PRs benefit from the run *after* that. Cold until then.
- **Fork PRs** can't read the repo's caches (GitHub restricts the token) — same-repo branch PRs benefit; forks are no worse than today.
- Not touched here: `t.Parallel()` on the integration subtests (the only lever that shrinks the 112s when it *does* re-run). Cores and `-race` were measured to be near-irrelevant (2-core == 16-core because subtests are serial; `-race` cost ~5s). Happy to do that as a separate, isolation-tested follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)