### PR TITLE
test: cut integration suite ~112s → ~23s (discovery interval)

### DIFF
--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -34,6 +34,16 @@ import (
 	//	sd_config "github.com/prometheus/prometheus/discovery/config"
 )
 
+// DiscoveryUpdateInterval controls how often each server group's discovery
+// manager coalesces and applies target updates. Prometheus defaults this to 5s
+// to throttle chatty service-discovery mechanisms; promxy keeps that default so
+// production behavior is unchanged. It is exposed as a var mainly so tests can
+// drive it low — the discovery manager only emits its first target set (and
+// thus lets the server group become Ready) on the first tick of this interval,
+// so a 5s value adds ~5s of startup latency to every proxy the tests spin up.
+// Must be > 0 (time.NewTicker panics on zero).
+var DiscoveryUpdateInterval = 5 * time.Second
+
 var (
 	// TODO: have a marker for "which" servergroup
 	serverGroupSummary = prometheus.NewSummaryVec(prometheus.SummaryOpts{
@@ -73,7 +83,7 @@ func NewServerGroup() (*ServerGroup, error) {
 		return nil, err
 	}
 	sdLogger := logging.NewLogger(logrus.WithField("component", "servergroup-discovery"))
-	sg.targetManager = discovery.NewManager(ctx, sdLogger, prometheus.NewRegistry(), sdMetrics)
+	sg.targetManager = discovery.NewManager(ctx, sdLogger, prometheus.NewRegistry(), sdMetrics, discovery.Updatert(DiscoveryUpdateInterval))
 	if sg.targetManager == nil {
 		return nil, fmt.Errorf("failed to create discovery manager")
 	}

--- a/test/promql_test.go
+++ b/test/promql_test.go
@@ -30,6 +30,7 @@ import (
 
 	proxyconfig "github.com/jacksontj/promxy/pkg/config"
 	"github.com/jacksontj/promxy/pkg/proxystorage"
+	"github.com/jacksontj/promxy/pkg/servergroup"
 )
 
 func init() {
@@ -37,6 +38,13 @@ func init() {
 		log.Println(http.ListenAndServe("localhost:6060", nil))
 	}()
 	parser.EnableExperimentalFunctions = true
+
+	// Each subtest spins up a fresh promxy whose server group only becomes
+	// Ready on the first tick of the discovery manager's update interval. The
+	// 5s production default would add ~5s of pure startup wait to every one of
+	// the ~20 integration subtests (dwarfing the sub-second query work); drop
+	// it so the suite is bound by actual evaluation time instead.
+	servergroup.DiscoveryUpdateInterval = 10 * time.Millisecond
 }
 
 // Config templates take the bound API address(es) as %s. We pick ports


### PR DESCRIPTION
## Why

Follow-up to the PR-cache work (#804). Most PRs touch the query path, which changes the `test/` integration binary's hash and forces the suite to actually re-run (cache can't help there). So the suite's own runtime matters — and it was ~112s.

Profiling showed the time isn't query work. Every `.test` subtest took a **uniform ~5s**, while the individual eval lines inside took 0.02–0.05s:

```
--- PASS: TestUpstreamEvaluations/0literals.test (5.04s)   ← trivial file, still 5s
--- PASS: TestEvaluations/0testdata/issue_562.test (5.20s)
...
    --- PASS: .../line_52/topk(...) (0.02s)                 ← the actual work
```

## Root cause

Each subtest spins up a fresh promxy and blocks in `proxyStorage.Ready()` until its server group is ready. A server group only becomes ready after its **first target sync**, and Prometheus's discovery manager (`pkg/servergroup`) emits that first sync on the **first tick of its update interval — default `5s`** (`discovery/manager.go`: `updatert = 5 * time.Second`, and `sender()` only sends on `ticker.C`).

So it was ~20 subtests × ~5s of pure startup wait ≈ the entire 112s.

## Fix

Expose the interval as `servergroup.DiscoveryUpdateInterval`, **defaulting to the current 5s so production is unchanged**, and set it to `10ms` in the `test` package's `init()`.

## Measured (full `test/` package, `-race`, forced run)

| | Before | After |
|---|---|---|
| `test/` package | ~112s | **~23s** |

Still passing (`ok github.com/jacksontj/promxy/test 23.0s`). The residual ~23s is genuine serial evaluation work — a future `t.Parallel()` on the subtests could cut that further, but it needs per-subtest port isolation (they currently share `:8083`/`:8085`), so I've left it as a separate change.

## Scope / safety

- Production default unchanged (5s). Only the test overrides it.
- `pkg/servergroup` unit tests still pass (they use the default path).
- Independent of #804 (cache) — they stack: cache helps PRs that don't touch the query path; this helps the ones that do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)