### PR TITLE
Add healthcheck per server_group and be able to recover from a sync error

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -236,6 +236,32 @@ promxy:
         #            the first successful sync
         on_sync_error: abort
 
+      # health_check enables an independent, periodic HTTP probe against each
+      # target in this server_group.
+      # While a target's probe(s) are failing, it is skipped on the query path rather
+      # than sent traffic. This matters for a target that accepts the TCP
+      # connection but never answers HTTP: without health_check, every query
+      # routed to it hangs until that query's own timeout/deadline; with it,
+      # the target is detected as down (in `timeout`, not the query timeout)
+      # and skipped.
+      health_check:
+        # (optional) path probed on the target, joined onto its base URL.
+        # Defaults to "/-/healthy".
+        path: /-/healthy
+        # (optional) how often the target is probed. Defaults to 10s.
+        interval: 10s
+        # (optional) bounds each individual probe request. Deliberately
+        # independent of `http_client.timeout` (which defaults to disabled) so
+        # an unresponsive target is detected quickly and predictably
+        # regardless of how the query-path timeout is configured. Defaults to 2s.
+        timeout: 2s
+        # (optional) number of consecutive failed probes required before the
+        # target is marked unhealthy. Defaults to 1.
+        failure_threshold: 1
+        # (optional) number of consecutive successful probes required before a
+        # previously-unhealthy target is marked healthy again. Defaults to 1.
+        success_threshold: 1
+
       # inject_matchers is a list of label matchers that are injected into every selector
       # of every request sent to this server_group. This effectively scopes the server_group
       # to the subset of downstream data matching these matchers -- even for queries that

--- a/pkg/promclient/healthcheck.go
+++ b/pkg/promclient/healthcheck.go
@@ -1,0 +1,333 @@
+package promclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/sirupsen/logrus"
+)
+
+// Metrics
+var (
+	healthCheckUp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "promxy_health_check_up",
+		Help: "Whether the most recent health_check probe(s) consider this target healthy (1) or not (0)",
+	}, []string{"target"})
+	healthCheckProbeCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "promxy_health_check_probe_total",
+		Help: "How many health_check probes completed against a target, partitioned by outcome",
+	}, []string{"target", "status"})
+	healthCheckSkippedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "promxy_health_check_skipped_total",
+		Help: "How many requests have been skipped because a target was unhealthy, partitioned by query type",
+	}, []string{"target", "type"})
+)
+
+func init() {
+	prometheus.MustRegister(
+		healthCheckUp,
+		healthCheckProbeCount,
+		healthCheckSkippedCount,
+	)
+}
+
+// ErrTargetUnhealthy is returned by every wrapped method while a target's
+// health_check probe(s) are failing, so MultiAPI and ignore_error/
+// downgrade_error treat this target as down instead of a successful empty response.
+var ErrTargetUnhealthy = errors.New("promclient: target failed health_check probe(s)")
+
+const (
+	// defaultHealthCheckPath is probed when Path is unset. It is prometheus'
+	// own liveness endpoint, present on any prometheus-compatible downstream.
+	defaultHealthCheckPath = "/-/healthy"
+	// defaultHealthCheckInterval is used when Interval is unset.
+	defaultHealthCheckInterval = 10 * time.Second
+	// defaultHealthCheckTimeout is used when Timeout is unset -- independent of
+	// http_client.timeout so an unresponsive target is caught quickly regardless.
+	defaultHealthCheckTimeout = 2 * time.Second
+	// defaultHealthCheckThreshold is used when FailureThreshold/SuccessThreshold
+	// are unset.
+	defaultHealthCheckThreshold = 1
+)
+
+// HealthCheckConfig configures a periodic HTTP probe against a target. While
+// unhealthy, calls return ErrTargetUnhealthy instead of hitting the downstream
+// -- excluding the target from MultiAPI/ignore_error/downgrade_error like a
+// genuine failure, and avoiding hangs against a target that accepts TCP but
+// never answers HTTP.
+//
+// Example:
+//
+//	health_check:
+//	  path: /-/healthy
+//	  interval: 10s
+//	  timeout: 2s
+//	  failure_threshold: 1
+//	  success_threshold: 1
+type HealthCheckConfig struct {
+	// Path is the URL path probed on the target, joined onto the target's base
+	// URL (scheme+host+path_prefix). Defaults to "/-/healthy".
+	Path string `yaml:"path,omitempty"`
+	// Interval is how often the target is probed. Defaults to 10s.
+	Interval time.Duration `yaml:"interval,omitempty"`
+	// Timeout bounds each probe request, independent of http_client.timeout.
+	// Defaults to 2s.
+	Timeout time.Duration `yaml:"timeout,omitempty"`
+	// FailureThreshold is the number of consecutive failed probes required
+	// before the target is marked unhealthy. Defaults to 1.
+	FailureThreshold int `yaml:"failure_threshold,omitempty"`
+	// SuccessThreshold is the number of consecutive successful probes required
+	// before a previously-unhealthy target is marked healthy again. Defaults to 1.
+	SuccessThreshold int `yaml:"success_threshold,omitempty"`
+}
+
+// Validate fills in defaults and checks for invalid configuration.
+func (c *HealthCheckConfig) Validate() error {
+	if c.Path == "" {
+		c.Path = defaultHealthCheckPath
+	}
+	if c.Interval <= 0 {
+		c.Interval = defaultHealthCheckInterval
+	}
+	if c.Timeout <= 0 {
+		c.Timeout = defaultHealthCheckTimeout
+	}
+	if c.FailureThreshold <= 0 {
+		c.FailureThreshold = defaultHealthCheckThreshold
+	}
+	if c.SuccessThreshold <= 0 {
+		c.SuccessThreshold = defaultHealthCheckThreshold
+	}
+	if c.Timeout >= c.Interval {
+		return fmt.Errorf("health_check timeout (%s) must be less than interval (%s)", c.Timeout, c.Interval)
+	}
+	return nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *HealthCheckConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain HealthCheckConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	return c.Validate()
+}
+
+// NewHealthCheckClient returns a HealthCheckClient that periodically probes
+// targetURL+cfg.Path using httpClient and skips calls to the wrapped API
+// while the target is considered unhealthy. The probe loop runs until ctx is
+// done.
+func NewHealthCheckClient(ctx context.Context, a API, cfg *HealthCheckConfig, targetURL string, httpClient *http.Client) *HealthCheckClient {
+	c := &HealthCheckClient{
+		API:        a,
+		cfg:        cfg,
+		target:     targetURL,
+		probeURL:   targetURL + cfg.Path,
+		httpClient: httpClient,
+	}
+	// Assume healthy until the first probe completes, so a target isn't
+	// skipped during the brief startup window before any probe has run.
+	c.healthy.Store(true)
+	healthCheckUp.WithLabelValues(c.target).Set(1)
+
+	go c.probeLoop(ctx)
+
+	return c
+}
+
+// HealthCheckClient skips calls to the downstream while a periodic,
+// independently-timed HTTP probe considers the target unhealthy.
+type HealthCheckClient struct {
+	API
+
+	cfg        *HealthCheckConfig
+	target     string
+	probeURL   string
+	httpClient *http.Client
+
+	healthy atomic.Bool
+
+	// consecutive tracks the current streak of same-outcome probes (positive
+	// for successes, negative for failures), used to apply
+	// FailureThreshold/SuccessThreshold before flipping healthy.
+	consecutive atomic.Int32
+}
+
+// Healthy reports whether the most recent probe(s) consider this target healthy.
+func (c *HealthCheckClient) Healthy() bool {
+	return c.healthy.Load()
+}
+
+func (c *HealthCheckClient) probeLoop(ctx context.Context) {
+	ticker := time.NewTicker(c.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.probe(ctx)
+		}
+	}
+}
+
+func (c *HealthCheckClient) probe(ctx context.Context) {
+	probeCtx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	defer cancel()
+
+	ok := c.doProbe(probeCtx)
+
+	status := "failure"
+	if ok {
+		status = "success"
+	}
+	healthCheckProbeCount.WithLabelValues(c.target, status).Inc()
+
+	if ok {
+		if c.consecutive.Load() < 0 {
+			c.consecutive.Store(0)
+		}
+		streak := c.consecutive.Add(1)
+		if !c.healthy.Load() && streak >= int32(c.cfg.SuccessThreshold) {
+			c.healthy.Store(true)
+			healthCheckUp.WithLabelValues(c.target).Set(1)
+			logrus.Infof("health_check: target=%s recovered, marking healthy", c.target)
+			c.triggerLabelFilterSync(ctx)
+		}
+	} else {
+		if c.consecutive.Load() > 0 {
+			c.consecutive.Store(0)
+		}
+		streak := -c.consecutive.Add(-1)
+		if c.healthy.Load() && streak >= int32(c.cfg.FailureThreshold) {
+			c.healthy.Store(false)
+			healthCheckUp.WithLabelValues(c.target).Set(0)
+			logrus.Warnf("health_check: target=%s failed %d consecutive probes, marking unhealthy and skipping queries", c.target, streak)
+		}
+	}
+}
+
+// triggerLabelFilterSync kicks an immediate label_filter re-sync on recovery
+// instead of waiting for sync_interval. No-op unless this client directly
+// wraps a LabelFilterClient. Runs in the background so it can't delay the
+// next probe tick.
+func (c *HealthCheckClient) triggerLabelFilterSync(ctx context.Context) {
+	lf, ok := c.API.(*LabelFilterClient)
+	if !ok {
+		return
+	}
+	go func() {
+		if err := lf.Sync(ctx); err != nil {
+			logrus.Errorf("health_check: target=%s error re-syncing label_filter after recovery: %v", c.target, err)
+		}
+	}()
+}
+
+// doProbe issues a single probe request and reports whether it succeeded
+// (a 2xx status code within the given context's deadline).
+func (c *HealthCheckClient) doProbe(ctx context.Context) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.probeURL, nil)
+	if err != nil {
+		logrus.Errorf("health_check: error building probe request for target=%s: %v", c.target, err)
+		return false
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		logrus.Debugf("health_check: probe error for target=%s: %v", c.target, err)
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// Key returns a labelset used to determine other api clients that are the "same"
+func (c *HealthCheckClient) Key() model.LabelSet {
+	if apiLabels, ok := c.API.(APILabels); ok {
+		return apiLabels.Key()
+	}
+	return nil
+}
+
+// LabelNames returns all the unique label names present in the block in sorted order.
+// Guarded like every other method -- the probe loop uses its own httpClient
+// directly, so there's no bootstrapping concern doing so.
+func (c *HealthCheckClient) LabelNames(ctx context.Context, matchers []string, startTime, endTime time.Time) ([]string, v1.Warnings, error) {
+	if !c.Healthy() {
+		healthCheckSkippedCount.WithLabelValues(c.target, "LabelNames").Inc()
+		return nil, nil, ErrTargetUnhealthy
+	}
+	return c.API.LabelNames(ctx, matchers, startTime, endTime)
+}
+
+// LabelValues performs a query for the values of the given label.
+func (c *HealthCheckClient) LabelValues(ctx context.Context, label string, matchers []string, startTime, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	if !c.Healthy() {
+		healthCheckSkippedCount.WithLabelValues(c.target, "LabelValues").Inc()
+		return nil, nil, ErrTargetUnhealthy
+	}
+	return c.API.LabelValues(ctx, label, matchers, startTime, endTime)
+}
+
+// Query performs a query for the given time.
+func (c *HealthCheckClient) Query(ctx context.Context, query string, ts time.Time) storage.SeriesSet {
+	if !c.Healthy() {
+		healthCheckSkippedCount.WithLabelValues(c.target, "Query").Inc()
+		return storage.ErrSeriesSet(ErrTargetUnhealthy)
+	}
+	return c.API.Query(ctx, query, ts)
+}
+
+// QueryRange performs a query for the given range.
+func (c *HealthCheckClient) QueryRange(ctx context.Context, query string, r v1.Range) storage.SeriesSet {
+	if !c.Healthy() {
+		healthCheckSkippedCount.WithLabelValues(c.target, "QueryRange").Inc()
+		return storage.ErrSeriesSet(ErrTargetUnhealthy)
+	}
+	return c.API.QueryRange(ctx, query, r)
+}
+
+// Series finds series by label matchers.
+func (c *HealthCheckClient) Series(ctx context.Context, matches []string, startTime, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	if !c.Healthy() {
+		healthCheckSkippedCount.WithLabelValues(c.target, "Series").Inc()
+		return nil, nil, ErrTargetUnhealthy
+	}
+	return c.API.Series(ctx, matches, startTime, endTime)
+}
+
+// GetValue loads the raw data for a given set of matchers in the time range
+func (c *HealthCheckClient) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) storage.SeriesSet {
+	if !c.Healthy() {
+		healthCheckSkippedCount.WithLabelValues(c.target, "GetValue").Inc()
+		return storage.ErrSeriesSet(ErrTargetUnhealthy)
+	}
+	return c.API.GetValue(ctx, start, end, matchers)
+}
+
+// Metadata returns metadata about metrics currently scraped by the metric name.
+func (c *HealthCheckClient) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	if !c.Healthy() {
+		healthCheckSkippedCount.WithLabelValues(c.target, "Metadata").Inc()
+		return nil, ErrTargetUnhealthy
+	}
+	return c.API.Metadata(ctx, metric, limit)
+}
+
+// QueryExemplars performs a query for exemplars by the given query and time range.
+func (c *HealthCheckClient) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	if !c.Healthy() {
+		healthCheckSkippedCount.WithLabelValues(c.target, "QueryExemplars").Inc()
+		return nil, ErrTargetUnhealthy
+	}
+	return c.API.QueryExemplars(ctx, query, startTime, endTime)
+}

--- a/pkg/promclient/healthcheck_test.go
+++ b/pkg/promclient/healthcheck_test.go
@@ -1,0 +1,467 @@
+package promclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
+)
+
+func TestHealthCheckConfigValidate(t *testing.T) {
+	// Defaults are filled in.
+	c := &HealthCheckConfig{}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if c.Path != defaultHealthCheckPath {
+		t.Fatalf("expected default path %q, got %q", defaultHealthCheckPath, c.Path)
+	}
+	if c.Interval != defaultHealthCheckInterval {
+		t.Fatalf("expected default interval %s, got %s", defaultHealthCheckInterval, c.Interval)
+	}
+	if c.Timeout != defaultHealthCheckTimeout {
+		t.Fatalf("expected default timeout %s, got %s", defaultHealthCheckTimeout, c.Timeout)
+	}
+	if c.FailureThreshold != defaultHealthCheckThreshold {
+		t.Fatalf("expected default failure_threshold %d, got %d", defaultHealthCheckThreshold, c.FailureThreshold)
+	}
+	if c.SuccessThreshold != defaultHealthCheckThreshold {
+		t.Fatalf("expected default success_threshold %d, got %d", defaultHealthCheckThreshold, c.SuccessThreshold)
+	}
+
+	// Explicit values are preserved.
+	c = &HealthCheckConfig{Path: "/healthz", Interval: time.Minute, Timeout: time.Second, FailureThreshold: 3, SuccessThreshold: 2}
+	if err := c.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if c.Path != "/healthz" || c.Interval != time.Minute || c.Timeout != time.Second || c.FailureThreshold != 3 || c.SuccessThreshold != 2 {
+		t.Fatalf("expected explicit config to be preserved, got %+v", c)
+	}
+
+	// timeout must be less than interval.
+	c = &HealthCheckConfig{Interval: time.Second, Timeout: time.Second}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error when timeout >= interval")
+	}
+}
+
+// statusHandler is a toggleable httptest handler: it replies with the status
+// code currently stored in code, or hangs past hangFor (if non-zero) before
+// ever writing a response -- simulating "TCP connects but HTTP never answers".
+type statusHandler struct {
+	code    atomic.Int32
+	hangFor atomic.Int64 // time.Duration, 0 == don't hang
+}
+
+func newStatusHandler(initialCode int) *statusHandler {
+	h := &statusHandler{}
+	h.code.Store(int32(initialCode))
+	return h
+}
+
+func (h *statusHandler) setCode(code int) { h.code.Store(int32(code)) }
+func (h *statusHandler) setHang(d time.Duration) { h.hangFor.Store(int64(d)) }
+
+func (h *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if d := time.Duration(h.hangFor.Load()); d > 0 {
+		select {
+		case <-time.After(d):
+		case <-r.Context().Done():
+			return
+		}
+	}
+	w.WriteHeader(int(h.code.Load()))
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("condition not met within %s", timeout)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestHealthCheckClient_HealthyBeforeFirstProbe(t *testing.T) {
+	handler := newStatusHandler(http.StatusServiceUnavailable)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Interval longer than the test so the first probe never fires.
+	cfg := &HealthCheckConfig{Interval: time.Hour, Timeout: time.Second}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	underlying := newCountAPI(&stubAPI{})
+	c := NewHealthCheckClient(ctx, underlying, cfg, srv.URL, srv.Client())
+
+	if !c.Healthy() {
+		t.Fatal("expected target to be healthy before the first probe runs")
+	}
+	if err := c.Query(ctx, "up", time.Now()).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if underlying.callCount["Query"] != 1 {
+		t.Fatalf("expected query to pass through before first probe, got callCount=%d", underlying.callCount["Query"])
+	}
+}
+
+func TestHealthCheckClient_MarksUnhealthyAfterFailureThreshold(t *testing.T) {
+	handler := newStatusHandler(http.StatusOK)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := &HealthCheckConfig{Interval: 10 * time.Millisecond, Timeout: 5 * time.Millisecond, FailureThreshold: 2, SuccessThreshold: 2}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	underlying := newCountAPI(&stubAPI{})
+	c := NewHealthCheckClient(ctx, underlying, cfg, srv.URL, srv.Client())
+
+	waitFor(t, time.Second, c.Healthy)
+
+	// Start failing; after 2 consecutive failed probes it should flip unhealthy.
+	handler.setCode(http.StatusServiceUnavailable)
+	waitFor(t, 2*time.Second, func() bool { return !c.Healthy() })
+
+	before := underlying.callCount["Query"]
+	if err := c.Query(ctx, "up", time.Now()).Err(); !errors.Is(err, ErrTargetUnhealthy) {
+		t.Fatalf("expected ErrTargetUnhealthy while unhealthy, got: %v", err)
+	}
+	if got := underlying.callCount["Query"]; got != before {
+		t.Fatalf("expected query to be skipped while unhealthy, but downstream was called: before=%d after=%d", before, got)
+	}
+}
+
+func TestHealthCheckClient_RecoversAfterSuccessThreshold(t *testing.T) {
+	handler := newStatusHandler(http.StatusServiceUnavailable)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := &HealthCheckConfig{Interval: 10 * time.Millisecond, Timeout: 5 * time.Millisecond, FailureThreshold: 1, SuccessThreshold: 2}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	underlying := newCountAPI(&stubAPI{})
+	c := NewHealthCheckClient(ctx, underlying, cfg, srv.URL, srv.Client())
+
+	waitFor(t, time.Second, func() bool { return !c.Healthy() })
+
+	before := underlying.callCount["Query"]
+	if err := c.Query(ctx, "up", time.Now()).Err(); !errors.Is(err, ErrTargetUnhealthy) {
+		t.Fatalf("expected ErrTargetUnhealthy while unhealthy, got: %v", err)
+	}
+	if got := underlying.callCount["Query"]; got != before {
+		t.Fatalf("expected query to be skipped while unhealthy: before=%d after=%d", before, got)
+	}
+
+	handler.setCode(http.StatusOK)
+	waitFor(t, time.Second, c.Healthy)
+
+	before = underlying.callCount["Query"]
+	if err := c.Query(ctx, "up", time.Now()).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if got := underlying.callCount["Query"]; got != before+1 {
+		t.Fatalf("expected query to pass through after recovery: before=%d after=%d", before, got)
+	}
+}
+
+// TestHealthCheckClient_RecoversAfterRelapse proves a target that flaps
+// healthy -> unhealthy -> healthy again is tracked correctly on the second
+// transition too, not just the first.
+func TestHealthCheckClient_RecoversAfterRelapse(t *testing.T) {
+	handler := newStatusHandler(http.StatusOK)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := &HealthCheckConfig{Interval: 10 * time.Millisecond, Timeout: 5 * time.Millisecond, FailureThreshold: 1, SuccessThreshold: 1}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	underlying := newCountAPI(&stubAPI{})
+	c := NewHealthCheckClient(ctx, underlying, cfg, srv.URL, srv.Client())
+
+	waitFor(t, time.Second, c.Healthy)
+
+	before := underlying.callCount["Query"]
+	if err := c.Query(ctx, "up", time.Now()).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if got := underlying.callCount["Query"]; got != before+1 {
+		t.Fatalf("expected query to pass through while healthy: before=%d after=%d", before, got)
+	}
+
+	// Relapse: the target goes unhealthy again.
+	handler.setCode(http.StatusServiceUnavailable)
+	waitFor(t, time.Second, func() bool { return !c.Healthy() })
+
+	before = underlying.callCount["Query"]
+	if err := c.Query(ctx, "up", time.Now()).Err(); !errors.Is(err, ErrTargetUnhealthy) {
+		t.Fatalf("expected ErrTargetUnhealthy after relapse, got: %v", err)
+	}
+	if got := underlying.callCount["Query"]; got != before {
+		t.Fatalf("expected query to be skipped after relapse, but downstream was called: before=%d after=%d", before, got)
+	}
+
+	// Recovers again from the relapse.
+	handler.setCode(http.StatusOK)
+	waitFor(t, time.Second, c.Healthy)
+
+	before = underlying.callCount["Query"]
+	if err := c.Query(ctx, "up", time.Now()).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if got := underlying.callCount["Query"]; got != before+1 {
+		t.Fatalf("expected query to pass through again after recovering from relapse: before=%d after=%d", before, got)
+	}
+}
+
+// TestHealthCheckClient_HungTargetDetectedWithinTimeout proves a hung target
+// (TCP connects, HTTP never answers) is caught within the probe's own
+// timeout, not the query-path timeout.
+func TestHealthCheckClient_HungTargetDetectedWithinTimeout(t *testing.T) {
+	handler := newStatusHandler(http.StatusOK)
+	handler.setHang(time.Hour) // simulate a server that never answers
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const probeTimeout = 50 * time.Millisecond
+	cfg := &HealthCheckConfig{Interval: 100 * time.Millisecond, Timeout: probeTimeout, FailureThreshold: 1}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	underlying := newCountAPI(&stubAPI{})
+	c := NewHealthCheckClient(ctx, underlying, cfg, srv.URL, srv.Client())
+
+	// The hung target must be detected well within a couple of probe timeouts,
+	// not the hour it would take an un-bounded call to fail.
+	waitFor(t, 2*time.Second, func() bool { return !c.Healthy() })
+
+	before := underlying.callCount["Query"]
+	if err := c.Query(ctx, "up", time.Now()).Err(); !errors.Is(err, ErrTargetUnhealthy) {
+		t.Fatalf("expected ErrTargetUnhealthy against a hung target, got: %v", err)
+	}
+	if got := underlying.callCount["Query"]; got != before {
+		t.Fatalf("expected query to be skipped against a hung target: before=%d after=%d", before, got)
+	}
+}
+
+// newHealthCheckedTarget wraps a countAPI-instrumented stub, serving a single
+// sample for any query, in a HealthCheckClient probing an httptest.Server
+// controlled by the returned *statusHandler.
+func newHealthCheckedTarget(t *testing.T, ctx context.Context, initialCode int) (*HealthCheckClient, *statusHandler, *countAPI) {
+	t.Helper()
+	handler := newStatusHandler(initialCode)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	cfg := &HealthCheckConfig{Interval: 20 * time.Millisecond, Timeout: 10 * time.Millisecond, FailureThreshold: 1, SuccessThreshold: 1}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	underlying := newCountAPI(&stubAPI{
+		query: func() model.Value {
+			return model.Vector{
+				&model.Sample{Metric: model.Metric{"__name__": "up"}, Value: 1, Timestamp: 0},
+			}
+		},
+	})
+	c := NewHealthCheckClient(ctx, underlying, cfg, srv.URL, srv.Client())
+	return c, handler, underlying
+}
+
+// TestHealthCheckClient_MultiAPIExcludesUnhealthyTarget proves an unhealthy
+// target is excluded from MultiAPI's quorum/merge, not counted as a
+// successful empty result.
+func TestHealthCheckClient_MultiAPIExcludesUnhealthyTarget(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientA, handlerA, _ := newHealthCheckedTarget(t, ctx, http.StatusOK)
+	clientB, handlerB, _ := newHealthCheckedTarget(t, ctx, http.StatusOK)
+	handlerB.setCode(http.StatusServiceUnavailable)
+
+	waitFor(t, 2*time.Second, func() bool { return clientA.Healthy() && !clientB.Healthy() })
+
+	multi, err := NewMultiAPI([]API{clientA, clientB}, 0, false, nil, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := multi.Query(ctx, "up", time.Now()).Err(); err != nil {
+		t.Fatalf("expected the healthy target alone to satisfy quorum (requiredCount=1), got error: %v", err)
+	}
+
+	// Now take the previously-healthy target down too -- with every target in
+	// the quorum group unhealthy, MultiAPI must surface a failure, not
+	// silently return an empty successful result.
+	handlerA.setCode(http.StatusServiceUnavailable)
+	waitFor(t, 2*time.Second, func() bool { return !clientA.Healthy() })
+
+	if err := multi.Query(ctx, "up", time.Now()).Err(); err == nil {
+		t.Fatal("expected an error once every target in the quorum group is unhealthy, got nil")
+	}
+}
+
+// erroringLabelValuesAPI always fails LabelValues, so a LabelFilterClient
+// wrapping it can never sync -- used to drive it into a permanent blocked()
+// state.
+type erroringLabelValuesAPI struct {
+	*stubAPI
+}
+
+func (erroringLabelValuesAPI) LabelValues(ctx context.Context, label string, matchers []string, startTime, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	return nil, nil, fmt.Errorf("stub: forced LabelValues failure")
+}
+
+// newBlockedLabelFilter builds a LabelFilterClient (on_sync_error: closed)
+// whose initial sync always fails, so it stays blocked() for the test.
+func newBlockedLabelFilter(t *testing.T, ctx context.Context) (*LabelFilterClient, *countAPI) {
+	t.Helper()
+	underlying := newCountAPI(erroringLabelValuesAPI{&stubAPI{}})
+	lfCfg := &LabelFilterConfig{DynamicLabels: []string{"__name__"}, OnSyncError: LabelFilterOnSyncErrorClosed}
+	if err := lfCfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	lf, err := NewLabelFilterClient(ctx, underlying, lfCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lf.blocked() {
+		t.Fatal("expected label_filter to be blocked from a failed initial sync")
+	}
+	return lf, underlying
+}
+
+// TestHealthCheckClient_ProbesRegardlessOfLabelFilterBlocked proves the probe
+// loop still runs and flips healthy/unhealthy even when the wrapped
+// LabelFilterClient is permanently blocked().
+func TestHealthCheckClient_ProbesRegardlessOfLabelFilterBlocked(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lf, _ := newBlockedLabelFilter(t, ctx)
+
+	handler := newStatusHandler(http.StatusOK)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	cfg := &HealthCheckConfig{Interval: 10 * time.Millisecond, Timeout: 5 * time.Millisecond, FailureThreshold: 1, SuccessThreshold: 1}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	c := NewHealthCheckClient(ctx, lf, cfg, srv.URL, srv.Client())
+
+	waitFor(t, time.Second, c.Healthy)
+	if !lf.blocked() {
+		t.Fatal("expected label_filter to still be blocked")
+	}
+
+	handler.setCode(http.StatusServiceUnavailable)
+	waitFor(t, time.Second, func() bool { return !c.Healthy() })
+}
+
+// TestHealthCheckClient_UnhealthyShortCircuitsBeforeLabelFilter proves that
+// while unhealthy, calls never reach the wrapped LabelFilterClient at all --
+// filteredCount staying flat rules out falling through to its own blocked()
+// check.
+func TestHealthCheckClient_UnhealthyShortCircuitsBeforeLabelFilter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lf, underlying := newBlockedLabelFilter(t, ctx)
+
+	handler := newStatusHandler(http.StatusServiceUnavailable)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	cfg := &HealthCheckConfig{Interval: 10 * time.Millisecond, Timeout: 5 * time.Millisecond, FailureThreshold: 1}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	c := NewHealthCheckClient(ctx, lf, cfg, srv.URL, srv.Client())
+
+	waitFor(t, 2*time.Second, func() bool { return !c.Healthy() })
+
+	before := testutil.ToFloat64(filteredCount.WithLabelValues("Query"))
+	if err := c.Query(ctx, "up", time.Now()).Err(); !errors.Is(err, ErrTargetUnhealthy) {
+		t.Fatalf("expected ErrTargetUnhealthy, got: %v", err)
+	}
+	after := testutil.ToFloat64(filteredCount.WithLabelValues("Query"))
+	if after != before {
+		t.Fatalf("expected LabelFilterClient.Query to never be invoked (filteredCount unchanged): before=%v after=%v", before, after)
+	}
+	if got := underlying.callCount["Query"]; got != 0 {
+		t.Fatalf("expected downstream to never be called, got callCount=%d", got)
+	}
+}
+
+// TestHealthCheckClient_RecoveryTriggersLabelFilterSync proves recovery
+// triggers an immediate LabelFilterClient.Sync rather than waiting for its
+// (deliberately very long) sync_interval.
+func TestHealthCheckClient_RecoveryTriggersLabelFilterSync(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	underlying := newCountAPI(&stubAPI{
+		labelValues: func(label string) model.LabelValues { return model.LabelValues{"up"} },
+	})
+	lfCfg := &LabelFilterConfig{DynamicLabels: []string{"__name__"}, SyncInterval: time.Hour}
+	if err := lfCfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	lf, err := NewLabelFilterClient(ctx, underlying, lfCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseline := underlying.count("LabelValues")
+
+	handler := newStatusHandler(http.StatusServiceUnavailable)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	cfg := &HealthCheckConfig{Interval: 10 * time.Millisecond, Timeout: 5 * time.Millisecond, FailureThreshold: 1, SuccessThreshold: 1}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	c := NewHealthCheckClient(ctx, lf, cfg, srv.URL, srv.Client())
+
+	waitFor(t, time.Second, func() bool { return !c.Healthy() })
+
+	handler.setCode(http.StatusOK)
+	waitFor(t, time.Second, c.Healthy)
+
+	waitFor(t, time.Second, func() bool { return underlying.count("LabelValues") > baseline })
+}

--- a/pkg/promclient/labelfilter.go
+++ b/pkg/promclient/labelfilter.go
@@ -54,7 +54,7 @@ const (
 	// downstream (i.e. no filtering) until the first successful sync.
 	LabelFilterOnSyncErrorOpen LabelFilterOnSyncError = "open"
 	// LabelFilterOnSyncErrorClosed lets startup proceed but filters out every
-	// query (i.e. the target is skipped) until the first successful sync.
+	// query (i.e. the target is skipped) whenever the most recent sync attempt failed.
 	LabelFilterOnSyncErrorClosed LabelFilterOnSyncError = "closed"
 )
 
@@ -78,15 +78,19 @@ type LabelFilterConfig struct {
 	// StaticLabelsExclude is a set of labels to always exclude from the filter. This is done last
 	// so it will apply after the dynamic and static lists are added to the filter.
 	StaticLabelsExclude map[string][]string `yaml:"static_labels_exclude"`
-	// OnSyncError controls behavior while the filter has never successfully synced
-	// from the downstream (e.g. the target is unreachable at startup). This is
-	// distinct from the servergroup's `ignore_error`, which governs the query path.
-	//   abort  - fail the sync; this blocks servergroup startup until a sync
-	//            succeeds (default; preserves historical behavior)
-	//   open   - proceed without filtering; all queries are sent downstream until
-	//            the first successful sync
-	//   closed - proceed but filter out everything (skip this target) until the
-	//            first successful sync
+	// OnSyncError controls behavior while the filter's most recent sync attempt
+	// from the downstream did not succeed (e.g. the target is unreachable at
+	// startup, or becomes unreachable/times out later on). This is distinct from
+	// the servergroup's `ignore_error`, which governs the query path.
+	//   abort  - fail the initial sync; this blocks servergroup startup until a
+	//            sync succeeds (default; preserves historical behavior). Only
+	//            applies to startup -- later sync failures are logged, not fatal.
+	//   open   - proceed without filtering; all queries are sent downstream
+	//            whenever the most recent sync attempt failed
+	//   closed - filter out everything (skip this target) whenever the most
+	//            recent sync attempt failed -- including startup, and any later
+	//            sync that fails after a prior success. Re-opens as soon as a
+	//            subsequent sync succeeds again.
 	OnSyncError LabelFilterOnSyncError `yaml:"on_sync_error"`
 }
 
@@ -189,11 +193,11 @@ func (c *LabelFilterClient) syncLoop(ctx context.Context) {
 	}
 }
 
-// blocked reports whether the filter has never successfully synced and is
-// configured to fail closed, in which case all downstream calls are skipped
-// (the target is treated as "down" until the first successful sync).
+// blocked reports whether the most recent sync attempt failed and this client
+// is configured to fail closed, in which case all downstream calls are skipped
+// (the target is treated as "down" until the sync is successful again).
 func (c *LabelFilterClient) blocked() bool {
-	return c.cfg != nil && c.cfg.OnSyncError == LabelFilterOnSyncErrorClosed && c.LabelFilter() == nil
+	return c.cfg != nil && c.cfg.OnSyncError == LabelFilterOnSyncErrorClosed && !c.syncOK.Load()
 }
 
 // LabelFilterClient filters out calls to the downstream based on a label filter
@@ -203,6 +207,9 @@ type LabelFilterClient struct {
 
 	// filter is an atomic to hold the LabelFilter which is a map of labelName -> labelValue -> nothing (for quick lookups)
 	filter atomic.Value
+
+	// syncOK reflects whether the most recent Sync() attempt succeeded
+	syncOK atomic.Bool
 
 	// Used as the background context for this client
 	ctx context.Context
@@ -220,7 +227,11 @@ func (c *LabelFilterClient) LabelFilter() map[string]map[string]struct{} {
 	return nil
 }
 
-func (c *LabelFilterClient) Sync(ctx context.Context) error {
+func (c *LabelFilterClient) Sync(ctx context.Context) (err error) {
+	defer func() {
+		c.syncOK.Store(err == nil)
+	}()
+
 	filter := make(map[string]map[string]struct{})
 
 	for _, label := range c.cfg.DynamicLabels {

--- a/pkg/promclient/labelfilter_test.go
+++ b/pkg/promclient/labelfilter_test.go
@@ -32,54 +32,67 @@ func newCountAPI(a API) *countAPI {
 
 type countAPI struct {
 	API
+	mu        sync.Mutex
 	callCount map[string]int
+}
+
+func (s *countAPI) count(name string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.callCount[name]
+}
+
+func (s *countAPI) inc(name string) {
+	s.mu.Lock()
+	s.callCount[name]++
+	s.mu.Unlock()
 }
 
 // LabelNames returns all the unique label names present in the block in sorted order.
 func (s *countAPI) LabelNames(ctx context.Context, matchers []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error) {
-	s.callCount["LabelNames"]++
+	s.inc("LabelNames")
 	return s.API.LabelNames(ctx, matchers, startTime, endTime)
 }
 
 // LabelValues performs a query for the values of the given label.
 func (s *countAPI) LabelValues(ctx context.Context, label string, matchers []string, startTime time.Time, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
-	s.callCount["LabelValues"]++
+	s.inc("LabelValues")
 	return s.API.LabelValues(ctx, label, matchers, startTime, endTime)
 }
 
 // Query performs a query for the given time.
 func (s *countAPI) Query(ctx context.Context, query string, ts time.Time) storage.SeriesSet {
-	s.callCount["Query"]++
+	s.inc("Query")
 	return s.API.Query(ctx, query, ts)
 }
 
 // QueryRange performs a query for the given range.
 func (s *countAPI) QueryRange(ctx context.Context, query string, r v1.Range) storage.SeriesSet {
-	s.callCount["QueryRange"]++
+	s.inc("QueryRange")
 	return s.API.QueryRange(ctx, query, r)
 }
 
 // Series finds series by label matchers.
 func (s *countAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
-	s.callCount["Series"]++
+	s.inc("Series")
 	return s.API.Series(ctx, matches, startTime, endTime)
 }
 
 // GetValue loads the raw data for a given set of matchers in the time range
 func (s *countAPI) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) storage.SeriesSet {
-	s.callCount["GetValue"]++
+	s.inc("GetValue")
 	return s.API.GetValue(ctx, start, end, matchers)
 }
 
 // Metadata returns metadata about metrics currently scraped by the metric name.
 func (s *countAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
-	s.callCount["Metadata"]++
+	s.inc("Metadata")
 	return s.API.Metadata(ctx, metric, limit)
 }
 
 // QueryExemplars performs a query for exemplars by the given query and time range.
 func (s *countAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
-	s.callCount["QueryExemplars"]++
+	s.inc("QueryExemplars")
 	return s.API.QueryExemplars(ctx, query, startTime, endTime)
 }
 
@@ -405,6 +418,80 @@ func TestLabelFilterOnSyncError(t *testing.T) {
 		}
 		if got := api.getQueryCount(); got != before {
 			t.Fatalf("expected unknownmetric to be filtered after sync: before=%d after=%d", before, got)
+		}
+	})
+
+	// recover when the first sync succeeded but later on the target times out
+	t.Run("closed_then_relapses", func(t *testing.T) {
+		api := &flakyLabelValuesAPI{stubAPI: &stubAPI{}, fail: false, values: model.LabelValues{"knownmetric"}}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		cfg := &LabelFilterConfig{
+			DynamicLabels: []string{"__name__"},
+			OnSyncError:   LabelFilterOnSyncErrorClosed,
+			SyncInterval:  20 * time.Millisecond,
+		}
+		if err := cfg.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		c, err := NewLabelFilterClient(ctx, api, cfg)
+		if err != nil {
+			t.Fatalf("expected initial sync to succeed, got: %v", err)
+		}
+		if c.LabelFilter() == nil {
+			t.Fatal("expected filter to be loaded after a successful initial sync")
+		}
+
+		// Sanity check: queries pass through while healthy
+		before := api.getQueryCount()
+		if err := c.Query(ctx, "knownmetric", time.Now()).Err(); err != nil {
+			t.Fatal(err)
+		}
+		if got := api.getQueryCount(); got != before+1 {
+			t.Fatalf("expected knownmetric to pass through while synced: before=%d after=%d", before, got)
+		}
+
+		// Now the downstream starts failing (e.g. it starts timing out)
+		api.setFail(true)
+		deadline := time.Now().Add(2 * time.Second)
+		for !c.blocked() && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		if !c.blocked() {
+			t.Fatal("expected client to become blocked after a later sync failed")
+		}
+
+		// The stale (previously-successful) filter is still cached
+		if c.LabelFilter() == nil {
+			t.Fatal("expected the stale filter to remain cached, not cleared, on a later sync failure")
+		}
+
+		// Even a known-good metric must now be blocked
+		before = api.getQueryCount()
+		if err := c.Query(ctx, "knownmetric", time.Now()).Err(); err != nil {
+			t.Fatal(err)
+		}
+		if got := api.getQueryCount(); got != before {
+			t.Fatalf("expected query to be blocked after sync relapsed, but downstream was called: before=%d after=%d", before, got)
+		}
+
+		// The target recovers again: once a later sync succeeds, the client
+		// must unblock
+		api.setFail(false)
+		deadline = time.Now().Add(2 * time.Second)
+		for c.blocked() && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		if c.blocked() {
+			t.Fatal("expected client to unblock after a later sync succeeded again")
+		}
+
+		before = api.getQueryCount()
+		if err := c.Query(ctx, "knownmetric", time.Now()).Err(); err != nil {
+			t.Fatal(err)
+		}
+		if got := api.getQueryCount(); got != before+1 {
+			t.Fatalf("expected knownmetric to pass through again after recovering from relapse: before=%d after=%d", before, got)
 		}
 	})
 }

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -230,6 +230,23 @@ type Config struct {
 
 	LabelFilterConfig *promclient.LabelFilterConfig `yaml:"label_filter"`
 
+	// HealthCheckConfig enables an independent, periodic HTTP health probe
+	// against each target in this server group. While a target's probe(s)
+	// are failing, it is skipped on the query path rather than sent traffic,
+	//which would otherwise hang every query routed to it until that query's
+	// own timeout/deadline. The probe uses its own `timeout`, independent of
+	// `http_client.timeout` (which is disabled by default).
+	// Applies uniformly to every target in this server group
+	// Example:
+	//
+	//    health_check:
+	//      path: /-/healthy
+	//      interval: 10s
+	//      timeout: 2s
+	//      failure_threshold: 1
+	//      success_threshold: 1
+	HealthCheckConfig *promclient.HealthCheckConfig `yaml:"health_check"`
+
 	// InjectMatchers is a list of label matchers that are injected into every selector
 	// of every request sent to this servergroup. This effectively scopes the servergroup
 	// to the subset of downstream data matching these matchers -- even for queries that

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -385,6 +385,11 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 					}
 				}
 
+				// Add a health check if configured
+				if s.Cfg.HealthCheckConfig != nil {
+					apiClient = promclient.NewHealthCheckClient(ctx, apiClient, s.Cfg.HealthCheckConfig, u.String(), s.client)
+				}
+
 				// Add wrap for the specific target, and add to the list
 				apiClients = append(apiClients, &promclient.ErrorWrap{apiClient, "error in target=" + u.String()})
 			}


### PR DESCRIPTION
It would be nice to be able to configure a health endpoint to check if the target is healthy so we don't need to wait for a query timeout which will slow down all queries. 
I also changed the behaviour of the `on_sync_error` so that it will recover from a sync error when the first sync succeeded.