### PR TITLE
Fix "concurrent map writes" on config reload, and actually fetch in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -233,7 +233,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/prometheus/prometheus => github.com/jacksontj/prometheus v1.8.1-0.20260620043205-85414bea37c6
+replace github.com/prometheus/prometheus => github.com/jacksontj/prometheus v1.8.1-0.20260903145453-11a864f3c464
 
 replace github.com/golang/glog => github.com/kubermatic/glog-gokit v0.0.0-20181129151237-8ab7e4c2d352
 

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/hetznercloud/hcloud-go/v2 v2.21.1 h1:IH3liW8/cCRjfJ4cyqYvw3s1ek+KWP8d
 github.com/hetznercloud/hcloud-go/v2 v2.21.1/go.mod h1:XOaYycZJ3XKMVWzmqQ24/+1V7ormJHmPdck/kxrNnQA=
 github.com/ionos-cloud/sdk-go/v6 v6.3.4 h1:jTvGl4LOF8v8OYoEIBNVwbFoqSGAFqn6vGE7sp7/BqQ=
 github.com/ionos-cloud/sdk-go/v6 v6.3.4/go.mod h1:wCVwNJ/21W29FWFUv+fNawOTMlFoP1dS3L+ZuztFW48=
-github.com/jacksontj/prometheus v1.8.1-0.20260620043205-85414bea37c6 h1:/F2zNqTN+ajxu4W8dQrVfIDspMHHPpVCmkhf/EkU0KM=
-github.com/jacksontj/prometheus v1.8.1-0.20260620043205-85414bea37c6/go.mod h1:r48fNfOg8Dcc1aDd0Tuk+hv9B5HldONOTy+6LySICS4=
+github.com/jacksontj/prometheus v1.8.1-0.20260903145453-11a864f3c464 h1:e/B9CaAdXL8UEZS5GAz0rAWlsIXGBdSRznHlPlL3jxg=
+github.com/jacksontj/prometheus v1.8.1-0.20260903145453-11a864f3c464/go.mod h1:r48fNfOg8Dcc1aDd0Tuk+hv9B5HldONOTy+6LySICS4=
 github.com/jarcoal/httpmock v1.4.0 h1:BvhqnH0JAYbNudL2GMJKgOHe2CtKlzJ/5rWKyp+hc2k=
 github.com/jarcoal/httpmock v1.4.0/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=

--- a/pkg/proxystorage/parallel_fetch_test.go
+++ b/pkg/proxystorage/parallel_fetch_test.go
@@ -1,0 +1,98 @@
+package proxystorage
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/jacksontj/promxy/pkg/promclient"
+)
+
+// concurrencyStub records the peak number of downstream calls in flight at
+// once. Each call blocks for stubLatency to stand in for a round trip.
+type concurrencyStub struct {
+	stubAPI
+
+	mu       sync.Mutex
+	inFlight int
+	peak     int
+	calls    int
+}
+
+const stubLatency = 100 * time.Millisecond
+
+func (a *concurrencyStub) roundTrip() {
+	a.mu.Lock()
+	a.inFlight++
+	a.calls++
+	if a.inFlight > a.peak {
+		a.peak = a.inFlight
+	}
+	a.mu.Unlock()
+
+	time.Sleep(stubLatency)
+
+	a.mu.Lock()
+	a.inFlight--
+	a.mu.Unlock()
+}
+
+func (a *concurrencyStub) stats() (calls, peak int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.calls, a.peak
+}
+
+func (a *concurrencyStub) Query(ctx context.Context, query string, ts time.Time) storage.SeriesSet {
+	a.roundTrip()
+	return promclient.ModelValueToSeriesSet(model.Vector{}, nil, nil)
+}
+
+func (a *concurrencyStub) QueryRange(ctx context.Context, query string, r v1.Range) storage.SeriesSet {
+	a.roundTrip()
+	return promclient.ModelValueToSeriesSet(model.Matrix{}, nil, nil)
+}
+
+func (a *concurrencyStub) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) storage.SeriesSet {
+	a.roundTrip()
+	return promclient.ModelValueToSeriesSet(model.Matrix{}, nil, nil)
+}
+
+// TestParallelDownstreamFetch pins the reason parser.Walk fans out when a
+// NodeReplacer is installed: sibling subtrees of a query each cost a
+// downstream round trip, and they have to overlap. Serialising them makes a
+// fan-out query as slow as the sum of its parts (promxy#809 fixed the
+// crash by making read-only walks sequential -- this guards the other half,
+// that the fetching walk stayed parallel).
+func TestParallelDownstreamFetch(t *testing.T) {
+	for _, tc := range []struct {
+		expr      string
+		wantCalls int
+	}{
+		{`sum(a) + sum(b)`, 2},
+		{`sum(a) + sum(b) + sum(c) + sum(d)`, 4},
+		{`a + b`, 2},
+		{`rate(a[5m]) + rate(b[5m])`, 2},
+	} {
+		t.Run(tc.expr, func(t *testing.T) {
+			stub := &concurrencyStub{}
+			ps, eng := newProxyStorage(t, stub)
+
+			runRange(t, ps, eng, tc.expr, e2eGridT0, e2eGridT0+e2eStep*e2eN)
+
+			calls, peak := stub.stats()
+			if calls != tc.wantCalls {
+				t.Fatalf("downstream calls: got %d, want %d", calls, tc.wantCalls)
+			}
+			if peak != tc.wantCalls {
+				t.Fatalf("peak concurrent downstream calls: got %d, want %d -- sibling fetches were serialised", peak, tc.wantCalls)
+			}
+		})
+	}
+}

--- a/test/rule_group_test.go
+++ b/test/rule_group_test.go
@@ -1,0 +1,67 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/rules"
+)
+
+// TestRuleGroupDependencyMap covers the crash from
+// https://github.com/jacksontj/promxy/issues/809: every config reload has the
+// rule manager analyse rule dependencies, which walks each rule's AST with
+// rules.buildDependencyMap -- a visitor that writes to a plain map. Our
+// prometheus fork walks the AST in parallel when a NodeReplacer is installed,
+// which must NOT extend to read-only walks like this one, or the reload dies
+// with "fatal error: concurrent map writes".
+//
+// The crash is a race, so this is a repeated smoke test rather than a
+// deterministic assertion; the deterministic half lives in the fork
+// (promql/parser: TestWalkVisitsSequentially).
+func TestRuleGroupDependencyMap(t *testing.T) {
+	names := []string{"a", "b", "c", "d", "e", "f"}
+
+	var rs []rules.Rule
+	for i, name := range names {
+		// Each rule depends on every other one, and has a wide enough AST
+		// that a parallel walk would fan out.
+		expr := ""
+		for j, dep := range names {
+			if j > 0 {
+				expr += " + "
+			}
+			expr += fmt.Sprintf("sum(rate(%s[5m]))", dep)
+		}
+		parsed, err := parser.ParseExpr(expr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rs = append(rs, rules.NewRecordingRule(name, parsed, labels.FromStrings("i", fmt.Sprint(i))))
+	}
+
+	// NewManager installs the default RuleDependencyController; the manager
+	// runs it over every group on each config reload (rules.Manager.Update).
+	opts := &rules.ManagerOptions{Context: context.Background()}
+	rules.NewManager(opts)
+
+	for i := 0; i < 500; i++ {
+		for _, r := range rs {
+			r.SetDependentRules(nil)
+			r.SetDependencyRules(nil)
+		}
+		opts.RuleDependencyController.AnalyseRules(rs)
+	}
+
+	// Every rule references every other, so none of them is independent.
+	for _, r := range rs {
+		if r.NoDependentRules() {
+			t.Fatalf("rule %s: expected dependents", r.Name())
+		}
+		if r.NoDependencyRules() {
+			t.Fatalf("rule %s: expected dependencies", r.Name())
+		}
+	}
+}

--- a/vendor/github.com/prometheus/prometheus/promql/engine.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine.go
@@ -568,7 +568,7 @@ func (ng *Engine) validateOpts(expr parser.Expr) error {
 		return nil
 	}
 
-	_, err := parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, path []parser.Node) error {
+	_, err := parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, _ []parser.Node) error {
 		var atModifierUsed, negativeOffsetUsed bool
 		switch n := node.(type) {
 		case *parser.VectorSelector:
@@ -886,7 +886,7 @@ func (ng *Engine) findMinMaxTime(s *parser.EvalStmt) (int64, int64) {
 	// Whenever a MatrixSelector is evaluated, evalRange is set to the corresponding range.
 	// The evaluation of the VectorSelector inside then evaluates the given range and unsets
 	// the variable.
-	//var evalRange time.Duration
+	// var evalRange time.Duration
 
 	// Since this fork allows for parallel execution of the tree Walk we need a more
 	// sophisticated datastructure (to avoid conflicts)
@@ -894,7 +894,7 @@ func (ng *Engine) findMinMaxTime(s *parser.EvalStmt) (int64, int64) {
 	// We are dual-purposing the lock for both the `ranges` and the `min/max` timestamp variables
 	l := sync.RWMutex{}
 
-	parser.Inspect(context.TODO(), s, func(node parser.Node, path []parser.Node) error {
+	_, _ = parser.Inspect(context.TODO(), s, func(node parser.Node, path []parser.Node) error {
 		switch n := node.(type) {
 		case *parser.VectorSelector:
 			l.RLock()
@@ -909,15 +909,12 @@ func (ng *Engine) findMinMaxTime(s *parser.EvalStmt) (int64, int64) {
 			if end > maxTimestamp {
 				maxTimestamp = end
 			}
-			evalRange = 0
 			l.Unlock()
 
 		case *parser.MatrixSelector:
 			l.Lock()
-			prefix := make([]posrange.PositionRange, len(path))
-			for i, p := range path {
-				prefix[i] = p.PositionRange()
-			}
+			prefix := make([]parser.Node, len(path))
+			copy(prefix, path)
 			ranges = append(ranges, evalRange{Prefix: prefix, Range: n.Range})
 			l.Unlock()
 		}
@@ -995,7 +992,7 @@ func (ng *Engine) populateSeries(ctx context.Context, querier storage.Querier, s
 	// Whenever a MatrixSelector is evaluated, evalRange is set to the corresponding range.
 	// The evaluation of the VectorSelector inside then evaluates the given range and unsets
 	// the variable.
-	//var evalRange time.Duration
+	// var evalRange time.Duration
 
 	// Since this fork allows for parallel execution of the tree Walk we need a more
 	// sophisticated datastructure (to avoid conflicts)
@@ -1029,16 +1026,13 @@ func (ng *Engine) populateSeries(ctx context.Context, querier storage.Querier, s
 
 		case *parser.MatrixSelector:
 			l.Lock()
-			prefix := make([]posrange.PositionRange, len(path))
-			for i, p := range path {
-				prefix[i] = p.PositionRange()
-			}
+			prefix := make([]parser.Node, len(path))
+			copy(prefix, path)
 			ranges = append(ranges, evalRange{Prefix: prefix, Range: n.Range})
 			l.Unlock()
 		}
 		return nil
 	}, ng.NodeReplacer)
-
 	if err != nil {
 		return err
 	}
@@ -3913,7 +3907,7 @@ func setOffsetForAtModifier(evalTime int64, expr parser.Expr) {
 		return originalOffset + offsetDiff
 	}
 
-	parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, path []parser.Node) error {
+	_, _ = parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, path []parser.Node) error {
 		switch n := node.(type) {
 		case *parser.VectorSelector:
 			n.Offset = getOffset(n.Timestamp, n.OriginalOffset, path)
@@ -3935,7 +3929,7 @@ func setOffsetForAtModifier(evalTime int64, expr parser.Expr) {
 // and buckets. The function can be treated as an optimization and is not
 // required for correctness.
 func detectHistogramStatsDecoding(expr parser.Expr) {
-	parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, path []parser.Node) error {
+	_, _ = parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, path []parser.Node) error {
 		n, ok := (node).(*parser.VectorSelector)
 		if !ok {
 			return nil

--- a/vendor/github.com/prometheus/prometheus/promql/engine_extra.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine_extra.go
@@ -1,10 +1,22 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package promql
 
 import (
 	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/prometheus/prometheus/promql/parser/posrange"
 )
 
 func findPathRange(path []parser.Node, eRanges []evalRange) time.Duration {
@@ -21,7 +33,7 @@ func findPathRange(path []parser.Node, eRanges []evalRange) time.Duration {
 		// Check if we are a child
 		child := true
 		for i, p := range r.Prefix {
-			if p != path[i].PositionRange() {
+			if p != path[i] {
 				child = false
 				break
 			}
@@ -36,7 +48,12 @@ func findPathRange(path []parser.Node, eRanges []evalRange) time.Duration {
 }
 
 // evalRange summarizes a defined evalRange (from a MatrixSelector) within the ast
+//
+// Prefix identifies the ancestor chain by node pointer rather than by
+// PositionRange: parser.Walk fans siblings out when a NodeReplacer is
+// installed, and PositionRange() recurses into a node's children, so reading
+// it here would race with the SetChild calls a sibling subtree performs.
 type evalRange struct {
-	Prefix []posrange.PositionRange
+	Prefix []parser.Node
 	Range  time.Duration
 }

--- a/vendor/github.com/prometheus/prometheus/promql/info.go
+++ b/vendor/github.com/prometheus/prometheus/promql/info.go
@@ -83,7 +83,7 @@ loop:
 func (ev *evaluator) infoSelectHints(expr parser.Expr) storage.SelectHints {
 	var nodeTimestamp *int64
 	var offset int64
-	parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, _ []parser.Node) error {
+	_, _ = parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, _ []parser.Node) error {
 		switch n := node.(type) {
 		case *parser.VectorSelector:
 			if n.Timestamp != nil {

--- a/vendor/github.com/prometheus/prometheus/promql/parser/ast.go
+++ b/vendor/github.com/prometheus/prometheus/promql/parser/ast.go
@@ -230,9 +230,9 @@ type VectorSelector struct {
 	PosRange posrange.PositionRange
 }
 
-func (m *VectorSelector) GetLookbackDelta(d time.Duration) time.Duration {
-	if m.LookbackDelta > 0 {
-		return m.LookbackDelta
+func (e *VectorSelector) GetLookbackDelta(d time.Duration) time.Duration {
+	if e.LookbackDelta > 0 {
+		return e.LookbackDelta
 	}
 	return d
 }
@@ -353,7 +353,6 @@ func Walk(ctx context.Context, v Visitor, s *EvalStmt, node Node, path []Node, n
 		if err != nil {
 			return node, err
 		}
-
 	}
 
 	var err error
@@ -362,49 +361,62 @@ func Walk(ctx context.Context, v Visitor, s *EvalStmt, node Node, path []Node, n
 	}
 	path = append(path, node)
 
-	// Walk children. When a NodeReplacer is installed we may rewrite the
-	// AST, so we have to wait for each child to return before installing
-	// the (possibly new) value via SetChild — and we have to do it
-	// sequentially to avoid concurrent SetChild writes racing against
-	// PositionRange / Children reads on shared parents.
+	// Walk children. Which traversal we use is decided by the NodeReplacer:
 	//
-	// When there is no NodeReplacer the visit is read-only: we don't need
-	// SetChild at all and can fan out children to goroutines for the I/O
-	// parallelism that promxy depends on (e.g. populateSeries firing one
-	// downstream HTTP request per VectorSelector).
+	//   - NodeReplacer installed: this is the path that does I/O. promxy's
+	//     NodeReplacer issues one downstream query per pushed-down subtree
+	//     and populateSeries calls querier.Select per selector, so sibling
+	//     subtrees are walked in parallel to overlap those fetches. Each
+	//     goroutine gets its own copy of path, and SetChild only runs once
+	//     every child has returned -- nothing mutates a node while a sibling
+	//     goroutine can still read it.
+	//
+	//   - No NodeReplacer: the walk is read-only and does no I/O, so there
+	//     is nothing to overlap. Stay sequential, because visitors all over
+	//     prometheus keep unsynchronised per-walk state -- e.g. upstream's
+	//     rules.buildDependencyMap, which crashed with "concurrent map
+	//     writes" while these walks were parallel (promxy#809).
 	children := Children(node)
-	if nr != nil {
-		for i, e := range children {
-			childNode, err := Walk(ctx, v, s, e, path, nr)
-			if err != nil {
+	switch {
+	case nr == nil:
+		for _, e := range children {
+			if _, err := Walk(ctx, v, s, e, path, nr); err != nil {
 				return node, err
 			}
-			SetChild(node, i, childNode)
 		}
-	} else if len(children) == 1 {
-		// Single-child fast path: avoid spawning a goroutine for the
-		// linear chains (UnaryExpr / ParenExpr / StepInvariantExpr /
-		// MatrixSelector) that dominate AST shapes.
-		if _, err := Walk(ctx, v, s, children[0], path, nr); err != nil {
+
+	case len(children) == 1:
+		// Single-child fast path: no goroutine for the linear chains
+		// (UnaryExpr / ParenExpr / StepInvariantExpr / MatrixSelector)
+		// that dominate AST shapes.
+		childNode, err := Walk(ctx, v, s, children[0], path, nr)
+		if err != nil {
 			return node, err
 		}
-	} else {
-		wg := &sync.WaitGroup{}
+		SetChild(node, 0, childNode)
+
+	default:
+		var wg sync.WaitGroup
+		newChildren := make([]Node, len(children))
 		errs := make([]error, len(children))
 		for i, e := range children {
 			wg.Add(1)
 			go func(i int, e Node) {
 				defer wg.Done()
-				if _, childErr := Walk(ctx, v, s, e, append([]Node{}, path...), nr); childErr != nil {
-					errs[i] = childErr
-				}
+				newChildren[i], errs[i] = Walk(ctx, v, s, e, append([]Node{}, path...), nr)
 			}(i, e)
 		}
 		wg.Wait()
+
+		// If there was an error we return the first one
 		for _, err := range errs {
 			if err != nil {
 				return node, err
 			}
+		}
+
+		for i, childNode := range newChildren {
+			SetChild(node, i, childNode)
 		}
 	}
 
@@ -417,7 +429,7 @@ func ExtractSelectors(expr Expr) [][]*labels.Matcher {
 		selectors [][]*labels.Matcher
 		l         sync.Mutex
 	)
-	Inspect(context.TODO(), &EvalStmt{Expr: expr}, func(node Node, _ []Node) error {
+	_, _ = Inspect(context.TODO(), &EvalStmt{Expr: expr}, func(node Node, _ []Node) error {
 		vs, ok := node.(*VectorSelector)
 		if ok {
 			l.Lock()
@@ -443,8 +455,7 @@ func (f inspector) Visit(node Node, path []Node) (Visitor, error) {
 // f(node, path); node must not be nil. If f returns a nil error, Inspect invokes f
 // for all the non-nil children of node, recursively.
 func Inspect(ctx context.Context, s *EvalStmt, f inspector, nr NodeReplacer) (Node, error) {
-	//nolint: errcheck
-	return Walk(ctx, inspector(f), s, s.Expr, nil, nr)
+	return Walk(ctx, f, s, s.Expr, nil, nr)
 }
 
 func SetChild(node Node, i int, child Node) {
@@ -457,12 +468,13 @@ func SetChild(node Node, i int, child Node) {
 	case *AggregateExpr:
 		// While this does not look nice, it should avoid unnecessary allocations
 		// caused by slice resizing
-		if n.Expr == nil && n.Param == nil {
-		} else if n.Expr == nil {
+		switch {
+		case n.Expr == nil && n.Param == nil:
+		case n.Expr == nil:
 			n.Param = child.(Expr)
-		} else if n.Param == nil {
+		case n.Param == nil:
 			n.Expr = child.(Expr)
-		} else {
+		default:
 			switch i {
 			case 0:
 				n.Expr = child.(Expr)

--- a/vendor/github.com/prometheus/prometheus/promql/promqltest/test.go
+++ b/vendor/github.com/prometheus/prometheus/promql/promqltest/test.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -1212,16 +1211,11 @@ func atModifierTestCases(exprStr string, evalTime time.Time) ([]atModifierTestCa
 	}
 	ts := timestamp.FromTime(evalTime)
 
-	var (
-		// Fork: parser.Inspect can call the visitor concurrently from
-		// per-child goroutines. Lock the shared bookkeeping accordingly.
-		mu                       sync.Mutex
-		containsNonStepInvariant bool
-	)
+	containsNonStepInvariant := false
 	// Setting the @ timestamp for all selectors to be evalTime.
 	// If there is a subquery, then the selectors inside it don't get the @ timestamp.
 	// If any selector already has the @ timestamp set, then it is untouched.
-	parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, path []parser.Node) error {
+	_, _ = parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: expr}, func(node parser.Node, path []parser.Node) error {
 		if hasAtModifier(path) {
 			// There is a subquery with timestamp in the path,
 			// hence don't change any timestamps further.
@@ -1229,33 +1223,23 @@ func atModifierTestCases(exprStr string, evalTime time.Time) ([]atModifierTestCa
 		}
 		switch n := node.(type) {
 		case *parser.VectorSelector:
-			mu.Lock()
 			if n.Timestamp == nil {
 				n.Timestamp = makeInt64Pointer(ts)
 			}
-			mu.Unlock()
 
 		case *parser.MatrixSelector:
-			mu.Lock()
 			if vs := n.VectorSelector.(*parser.VectorSelector); vs.Timestamp == nil {
 				vs.Timestamp = makeInt64Pointer(ts)
 			}
-			mu.Unlock()
 
 		case *parser.SubqueryExpr:
-			mu.Lock()
 			if n.Timestamp == nil {
 				n.Timestamp = makeInt64Pointer(ts)
 			}
-			mu.Unlock()
 
 		case *parser.Call:
 			_, ok := promql.AtModifierUnsafeFunctions[n.Func.Name]
-			if ok {
-				mu.Lock()
-				containsNonStepInvariant = true
-				mu.Unlock()
-			}
+			containsNonStepInvariant = containsNonStepInvariant || ok
 		}
 		return nil
 	}, nil)

--- a/vendor/github.com/prometheus/prometheus/promql/promqltest/test_compat.go
+++ b/vendor/github.com/prometheus/prometheus/promql/promqltest/test_compat.go
@@ -83,9 +83,11 @@ type errStorageQuerier struct{}
 func (errStorageQuerier) Select(_ context.Context, _ bool, _ *storage.SelectHints, _ ...*labels.Matcher) storage.SeriesSet {
 	return storage.EmptySeriesSet()
 }
+
 func (errStorageQuerier) LabelValues(_ context.Context, _ string, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
 }
+
 func (errStorageQuerier) LabelNames(_ context.Context, _ *storage.LabelHints, _ ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
 }
@@ -113,7 +115,7 @@ func (errStorageChunkQuerier) Select(_ context.Context, _ bool, _ *storage.Selec
 type Test struct {
 	t        *test
 	engine   *promql.Engine
-	external *stableStorage // stable storage handed out via Storage()
+	external *stableStorage  // stable storage handed out via Storage()
 	override storage.Storage // installed via SetStorage; nil means "use external directly"
 	closed   bool
 }

--- a/vendor/github.com/prometheus/prometheus/rules/group.go
+++ b/vendor/github.com/prometheus/prometheus/rules/group.go
@@ -1116,7 +1116,7 @@ func buildDependencyMap(rules []Rule) dependencyMap {
 			break
 		}
 
-		parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: rule.Query()}, func(node parser.Node, _ []parser.Node) error {
+		_, _ = parser.Inspect(context.TODO(), &parser.EvalStmt{Expr: rule.Query()}, func(node parser.Node, _ []parser.Node) error {
 			if n, ok := node.(*parser.VectorSelector); ok {
 				// Find the name matcher for the rule.
 				var nameMatcher *labels.Matcher

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -766,7 +766,7 @@ github.com/prometheus/otlptranslator
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/prometheus/prometheus v1.8.2-0.20210707132820-dc8f50559534 => github.com/jacksontj/prometheus v1.8.1-0.20260620043205-85414bea37c6
+# github.com/prometheus/prometheus v1.8.2-0.20210707132820-dc8f50559534 => github.com/jacksontj/prometheus v1.8.1-0.20260903145453-11a864f3c464
 ## explicit; go 1.23.0
 github.com/prometheus/prometheus/config
 github.com/prometheus/prometheus/discovery
@@ -1611,6 +1611,6 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/prometheus/prometheus => github.com/jacksontj/prometheus v1.8.1-0.20260620043205-85414bea37c6
+# github.com/prometheus/prometheus => github.com/jacksontj/prometheus v1.8.1-0.20260903145453-11a864f3c464
 # github.com/golang/glog => github.com/kubermatic/glog-gokit v0.0.0-20181129151237-8ab7e4c2d352
 # k8s.io/klog => github.com/simonpasquier/klog-gokit/v3 v3.0.0


### PR DESCRIPTION
Fixes #809.

Depends on jacksontj/prometheus#5 — this branch already pins the fork commit from that PR.

### The crash

`rules.buildDependencyMap` writes to a plain `map` from its AST visitor. Since the 3.5 migration the fork's `parser.Walk` fanned that walk out to goroutines, so every config reload could hit `fatal error: concurrent map writes` — exactly the stack in #809.

### The part that surprised me

The fan-out was gated on **"no `NodeReplacer` installed"**, which is backwards for both halves:

* We **always** install a `NodeReplacer` (`cmd/promxy/main.go:288`), and every downstream fetch happens under it — `ProxyStorage.NodeReplacer` runs the query for each pushed-down subtree, `populateSeries` calls `Select` per selector. So the walk that does the I/O was fully sequential. Measured against a stub backend with 100ms latency:

  | expression | downstream calls | peak concurrency |
  |---|---|---|
  | `sum(a) + sum(b) + sum(c) + sum(d)` | 4 | **1** |

* The walks that *did* fan out are read-only ones that do no I/O — nothing to overlap, and their visitors keep unsynchronised state. That's the crash.

The fork PR swaps the gating: parallel when a `NodeReplacer` is installed, sequential when not. Same stub, same query: **peak concurrency 4**, one round trip's worth of wall clock instead of four.

### Regression tests

* `test/rule_group_test.go` — replays the reload path (the rule manager's `RuleDependencyController` over a group of interdependent rules). Against the old fork this reports the #809 race under `-race` on every run; with the fix it passes in ~0.05s.
* `pkg/proxystorage/parallel_fetch_test.go` — asserts sibling subtrees of a query are fetched concurrently, so the fan-out can't silently regress the other way again.

`make test` (race, `netgo,builtinassets`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7WBcFL81Qi8n9eg7DNDXm