### PR TITLE
fix(promclient): only ever narrow the window in time filters

### DIFF
--- a/pkg/promclient/timefilter.go
+++ b/pkg/promclient/timefilter.go
@@ -10,6 +10,22 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
+// truncateWindow clamps the requested [start, end] range to the server group's
+// configured window [winStart, winEnd]. A zero winStart or winEnd means that
+// edge is unbounded and the caller's bound is left alone.
+//
+// Truncation may only ever narrow: a request that already sits inside the
+// window is passed through untouched.
+func truncateWindow(start, end, winStart, winEnd time.Time) (time.Time, time.Time) {
+	if !winStart.IsZero() && start.Before(winStart) {
+		start = winStart
+	}
+	if !winEnd.IsZero() && end.After(winEnd) {
+		end = winEnd
+	}
+	return start, end
+}
+
 // AbsoluteTimeFilter will filter queries out (return nil,nil) for all queries outside the given times
 type AbsoluteTimeFilter struct {
 	API
@@ -24,12 +40,7 @@ func (tf *AbsoluteTimeFilter) LabelNames(ctx context.Context, matchers []string,
 	}
 
 	if tf.Truncate {
-		if startTime.Before(tf.Start) {
-			startTime = tf.Start
-		}
-		if endTime.After(tf.End) {
-			endTime = tf.End
-		}
+		startTime, endTime = truncateWindow(startTime, endTime, tf.Start, tf.End)
 	}
 
 	return tf.API.LabelNames(ctx, matchers, startTime, endTime)
@@ -42,12 +53,7 @@ func (tf *AbsoluteTimeFilter) LabelValues(ctx context.Context, label string, mat
 	}
 
 	if tf.Truncate {
-		if !tf.Start.IsZero() && startTime.Before(tf.Start) {
-			startTime = tf.Start
-		}
-		if !tf.End.IsZero() && endTime.After(tf.End) {
-			endTime = tf.End
-		}
+		startTime, endTime = truncateWindow(startTime, endTime, tf.Start, tf.End)
 	}
 
 	return tf.API.LabelValues(ctx, label, matchers, startTime, endTime)
@@ -92,12 +98,7 @@ func (tf *AbsoluteTimeFilter) Series(ctx context.Context, matches []string, star
 	}
 
 	if tf.Truncate {
-		if !tf.Start.IsZero() && startTime.Before(tf.Start) {
-			startTime = tf.Start
-		}
-		if !tf.End.IsZero() && endTime.After(tf.End) {
-			endTime = tf.End
-		}
+		startTime, endTime = truncateWindow(startTime, endTime, tf.Start, tf.End)
 	}
 
 	return tf.API.Series(ctx, matches, startTime, endTime)
@@ -110,12 +111,7 @@ func (tf *AbsoluteTimeFilter) GetValue(ctx context.Context, start, end time.Time
 	}
 
 	if tf.Truncate {
-		if !tf.Start.IsZero() && start.Before(tf.Start) {
-			start = tf.Start
-		}
-		if !tf.End.IsZero() && end.After(tf.End) {
-			end = tf.End
-		}
+		start, end = truncateWindow(start, end, tf.Start, tf.End)
 	}
 
 	return tf.API.GetValue(ctx, start, end, matchers)
@@ -128,12 +124,7 @@ func (tf *AbsoluteTimeFilter) QueryExemplars(ctx context.Context, query string, 
 	}
 
 	if tf.Truncate {
-		if !tf.Start.IsZero() && startTime.Before(tf.Start) {
-			startTime = tf.Start
-		}
-		if !tf.End.IsZero() && endTime.After(tf.End) {
-			endTime = tf.End
-		}
+		startTime, endTime = truncateWindow(startTime, endTime, tf.Start, tf.End)
 	}
 
 	return tf.API.QueryExemplars(ctx, query, startTime, endTime)
@@ -168,12 +159,7 @@ func (tf *RelativeTimeFilter) LabelNames(ctx context.Context, matchers []string,
 	}
 
 	if tf.Truncate {
-		if !tfStart.IsZero() && startTime.Before(tfStart) {
-			startTime = tfStart
-		}
-		if !tfEnd.IsZero() && endTime.After(tfEnd) {
-			endTime = tfEnd
-		}
+		startTime, endTime = truncateWindow(startTime, endTime, tfStart, tfEnd)
 	}
 
 	return tf.API.LabelNames(ctx, matchers, startTime, endTime)
@@ -187,12 +173,7 @@ func (tf *RelativeTimeFilter) LabelValues(ctx context.Context, label string, mat
 	}
 
 	if tf.Truncate {
-		if !tfStart.IsZero() && startTime.Before(tfStart) {
-			startTime = tfStart
-		}
-		if !tfEnd.IsZero() && endTime.After(tfEnd) {
-			endTime = tfEnd
-		}
+		startTime, endTime = truncateWindow(startTime, endTime, tfStart, tfEnd)
 	}
 
 	return tf.API.LabelValues(ctx, label, matchers, startTime, endTime)
@@ -240,12 +221,7 @@ func (tf *RelativeTimeFilter) Series(ctx context.Context, matches []string, star
 	}
 
 	if tf.Truncate {
-		if !tfStart.IsZero() && startTime.Before(tfStart) {
-			startTime = tfStart
-		}
-		if !tfEnd.IsZero() && endTime.Before(tfEnd) {
-			endTime = tfEnd
-		}
+		startTime, endTime = truncateWindow(startTime, endTime, tfStart, tfEnd)
 	}
 
 	return tf.API.Series(ctx, matches, startTime, endTime)
@@ -259,12 +235,7 @@ func (tf *RelativeTimeFilter) GetValue(ctx context.Context, start, end time.Time
 	}
 
 	if tf.Truncate {
-		if !tfStart.IsZero() && start.Before(tfStart) {
-			start = tfStart
-		}
-		if !tfEnd.IsZero() && end.Before(tfEnd) {
-			end = tfEnd
-		}
+		start, end = truncateWindow(start, end, tfStart, tfEnd)
 	}
 
 	return tf.API.GetValue(ctx, start, end, matchers)
@@ -278,12 +249,7 @@ func (tf *RelativeTimeFilter) QueryExemplars(ctx context.Context, query string, 
 	}
 
 	if tf.Truncate {
-		if !tfStart.IsZero() && startTime.Before(tfStart) {
-			startTime = tfStart
-		}
-		if !tfEnd.IsZero() && endTime.Before(tfEnd) {
-			endTime = tfEnd
-		}
+		startTime, endTime = truncateWindow(startTime, endTime, tfStart, tfEnd)
 	}
 
 	return tf.API.QueryExemplars(ctx, query, startTime, endTime)

--- a/pkg/promclient/timefilter_truncate_test.go
+++ b/pkg/promclient/timefilter_truncate_test.go
@@ -1,0 +1,185 @@
+package promclient
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// windowRecorder captures the [start, end] range each call was forwarded with, so
+// these tests can assert on what the filter actually sent downstream rather
+// than only on whether it forwarded at all (which is what the stubAPI-based
+// tests in timefilter_test.go cover).
+type windowRecorder struct {
+	API
+	called     bool
+	start, end time.Time
+}
+
+func (r *windowRecorder) LabelNames(_ context.Context, _ []string, s, e time.Time) ([]string, v1.Warnings, error) {
+	r.called, r.start, r.end = true, s, e
+	return nil, nil, nil
+}
+
+func (r *windowRecorder) LabelValues(_ context.Context, _ string, _ []string, s, e time.Time) (model.LabelValues, v1.Warnings, error) {
+	r.called, r.start, r.end = true, s, e
+	return nil, nil, nil
+}
+
+func (r *windowRecorder) Series(_ context.Context, _ []string, s, e time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	r.called, r.start, r.end = true, s, e
+	return nil, nil, nil
+}
+
+func (r *windowRecorder) GetValue(_ context.Context, s, e time.Time, _ []*labels.Matcher) storage.SeriesSet {
+	r.called, r.start, r.end = true, s, e
+	return storage.EmptySeriesSet()
+}
+
+func (r *windowRecorder) QueryExemplars(_ context.Context, _ string, s, e time.Time) ([]v1.ExemplarQueryResult, error) {
+	r.called, r.start, r.end = true, s, e
+	return nil, nil
+}
+
+// rangeCalls are the API methods that take a [start, end] range and truncate it
+// against the filter window. QueryRange is excluded: it truncates too, but also
+// has to keep the result on the requested step grid, so it is covered by
+// Test{Absolute,Relative}TimeFilterStepAlignment instead.
+var rangeCalls = map[string]func(API, time.Time, time.Time){
+	"LabelNames":     func(a API, s, e time.Time) { a.LabelNames(context.TODO(), nil, s, e) },
+	"LabelValues":    func(a API, s, e time.Time) { a.LabelValues(context.TODO(), "__name__", nil, s, e) },
+	"Series":         func(a API, s, e time.Time) { a.Series(context.TODO(), nil, s, e) },
+	"GetValue":       func(a API, s, e time.Time) { a.GetValue(context.TODO(), s, e, nil) },
+	"QueryExemplars": func(a API, s, e time.Time) { a.QueryExemplars(context.TODO(), "foo", s, e) },
+}
+
+// forEachRangeCall runs check against every range-taking method, so a fix (or a
+// regression) in one method can't hide behind the others.
+func forEachRangeCall(t *testing.T, mk func(API) API, reqStart, reqEnd time.Time, check func(*testing.T, *windowRecorder)) {
+	t.Helper()
+	names := make([]string, 0, len(rangeCalls))
+	for name := range rangeCalls {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			rec := &windowRecorder{}
+			rangeCalls[name](mk(rec), reqStart, reqEnd)
+			if !rec.called {
+				t.Fatal("call was not forwarded downstream")
+			}
+			check(t, rec)
+		})
+	}
+}
+
+// Truncation may only ever narrow the requested range. Pushing the end
+// *forward* to the window edge sends the downstream a wider request than was
+// asked for: it over-fetches (GetValue is the raw-sample path) and it changes
+// results, since Series then reports series that exist only in the extra
+// window.
+func TestRelativeTimeFilterTruncateNeverWidens(t *testing.T) {
+	// A long-term-storage shaped group: holds data from 90d ago to 12h ago.
+	start := -90 * 24 * time.Hour
+	end := -12 * time.Hour
+
+	// A request that sits wholly inside that window; nothing to adjust.
+	reqStart := time.Now().Add(-25 * time.Hour)
+	reqEnd := time.Now().Add(-24 * time.Hour)
+
+	forEachRangeCall(t,
+		func(a API) API { return &RelativeTimeFilter{API: a, Start: &start, End: &end, Truncate: true} },
+		reqStart, reqEnd,
+		func(t *testing.T, rec *windowRecorder) {
+			if rec.start.Before(reqStart) {
+				t.Errorf("start widened: requested %v, sent %v", reqStart, rec.start)
+			}
+			if rec.end.After(reqEnd) {
+				t.Errorf("end widened: requested %v, sent %v", reqEnd, rec.end)
+			}
+		},
+	)
+}
+
+// ...and it must still clamp a request that overruns the window.
+func TestRelativeTimeFilterTruncateClamps(t *testing.T) {
+	start := -2 * time.Hour
+	end := -1 * time.Hour
+
+	reqStart := time.Now().Add(-24 * time.Hour)
+	reqEnd := time.Now()
+
+	// The window is recomputed from time.Now() inside the filter, so allow a
+	// minute of slack on either side rather than asserting an exact instant.
+	const slack = time.Minute
+
+	forEachRangeCall(t,
+		func(a API) API { return &RelativeTimeFilter{API: a, Start: &start, End: &end, Truncate: true} },
+		reqStart, reqEnd,
+		func(t *testing.T, rec *windowRecorder) {
+			if rec.start.Before(time.Now().Add(start).Add(-slack)) {
+				t.Errorf("start not clamped to the window: sent %v", rec.start)
+			}
+			if rec.end.After(time.Now().Add(end).Add(slack)) {
+				t.Errorf("end not clamped to the window: sent %v", rec.end)
+			}
+		},
+	)
+}
+
+// An unset window edge means unbounded, so it must be left alone rather than
+// used as a bound. Truncating against a zero time.Time collapses the request to
+// year 1, and the server group then silently answers nothing.
+func TestAbsoluteTimeFilterTruncateUnsetEdge(t *testing.T) {
+	reqStart := time.Now().Add(-time.Hour)
+	reqEnd := time.Now()
+
+	t.Run("end unset", func(t *testing.T) {
+		filterStart := time.Now().Add(-24 * time.Hour)
+		forEachRangeCall(t,
+			func(a API) API { return &AbsoluteTimeFilter{API: a, Start: filterStart, Truncate: true} },
+			reqStart, reqEnd,
+			func(t *testing.T, rec *windowRecorder) {
+				if !rec.end.Equal(reqEnd) {
+					t.Errorf("end rewritten against an unset filter end: requested %v, sent %v", reqEnd, rec.end)
+				}
+			},
+		)
+	})
+
+	t.Run("start unset", func(t *testing.T) {
+		filterEnd := time.Now().Add(time.Hour)
+		forEachRangeCall(t,
+			func(a API) API { return &AbsoluteTimeFilter{API: a, End: filterEnd, Truncate: true} },
+			reqStart, reqEnd,
+			func(t *testing.T, rec *windowRecorder) {
+				if !rec.start.Equal(reqStart) {
+					t.Errorf("start rewritten against an unset filter start: requested %v, sent %v", reqStart, rec.start)
+				}
+			},
+		)
+	})
+}
+
+func TestRelativeTimeFilterTruncateUnsetEdge(t *testing.T) {
+	start := -24 * time.Hour
+	reqStart := time.Now().Add(-time.Hour)
+	reqEnd := time.Now()
+
+	forEachRangeCall(t,
+		func(a API) API { return &RelativeTimeFilter{API: a, Start: &start, Truncate: true} },
+		reqStart, reqEnd,
+		func(t *testing.T, rec *windowRecorder) {
+			if !rec.end.Equal(reqEnd) {
+				t.Errorf("end rewritten against an unset filter end: requested %v, sent %v", reqEnd, rec.end)
+			}
+		},
+	)
+}


### PR DESCRIPTION
Truncation in the time filters is open-coded in each method, and two of those copies had drifted.

### `RelativeTimeFilter` widens instead of narrowing

`Series`, `GetValue` and `QueryExemplars` compare the request end against the filter end with `Before`, where the other three methods use `After`:

```go
// LabelNames, LabelValues, QueryRange — correct
if !tfEnd.IsZero() && endTime.After(tfEnd) { endTime = tfEnd }

// Series, GetValue, QueryExemplars — inverted
if !tfEnd.IsZero() && endTime.Before(tfEnd) { endTime = tfEnd }
```

The inverted test fires when the request end is already *inside* the group's window, and pushes it forward to the window edge. Against a group configured `end: -12h` with `truncate: true`, a request for the hour ending 24h ago goes downstream asking for everything up to 12h ago:

```
requested  [2026-09-01T20:53, 2026-09-01T21:53]
downstream [2026-09-01T20:53, 2026-09-02T09:53]   # +12h
LabelNames (control)      end unchanged  ✓
```

`GetValue` is the raw-sample path, so a `foo[1h]` selector fetches thirteen hours of samples instead of one, JSON-encoded, from every target in the group. `Series` is wrong rather than merely wasteful — it reports series that exist only in the extra window.

### `AbsoluteTimeFilter.LabelNames` collapses the window to year 1

It drops the `IsZero` guards every other method has. With only `start` configured — the natural way to say "this group has nothing before date X" — `tf.End` is the zero `time.Time`, every real end is after it, and the end is rewritten:

```
requested end  2026-09-03T04:53:36Z
downstream end 0001-01-01T00:00:00Z
```

The group then returns no label names for any query, surfacing as silently missing values in autocomplete and `label_values()` rather than as an error.

### The fix

Both are one-line errors, so the change is mostly about making them not recur: all ten range-taking call sites now go through a single `truncateWindow` helper. `QueryRange` keeps its own block — it additionally has to hold the result on the requested step grid.

### Testing

The new tests exercise every range-taking method rather than one, so a regression in a single method can't hide behind the others. Verified against the unfixed code: the widening test fails for exactly `Series`, `GetValue` and `QueryExemplars`, and the unset-edge test fails for exactly `LabelNames`.

`go test -race -mod=vendor -tags netgo,builtinassets ./pkg/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
