### PR TITLE
docs: add a docs/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ With that configuration modified and ready, all that is left is to run promxy:
 ./promxy --config=config.yaml
 ```
 
+## Documentation
+Full documentation lives in [docs/](docs/):
+
+- [Getting started](docs/getting-started.md)
+- [Configuration](docs/configuration/README.md) — [server groups](docs/configuration/server-groups.md), [CLI flags](docs/configuration/cli-flags.md), [alert templates](docs/configuration/alert-templates.md)
+- [Concepts](docs/concepts/architecture.md) — [architecture](docs/concepts/architecture.md), [HA and merging](docs/concepts/ha-and-merging.md)
+- Guides — [multi-tenancy](docs/guides/multi-tenancy.md), [rules and alerting](docs/guides/rules-and-alerting.md), [native histograms](docs/guides/native-histograms.md), [label filtering](docs/guides/label-filtering.md), [security](docs/guides/security.md)
+- Operations — [running promxy](docs/operations/running.md), [metrics](docs/operations/metrics.md), [troubleshooting](docs/operations/troubleshooting.md)
+- [Development](docs/development.md)
+
 ## FAQ
 
 ### What is a "ServerGroup"?

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,11 @@
 # Promxy documentation
 
-Promxy is an aggregating proxy that makes many shards of Prometheus appear as a
-single Prometheus API endpoint. It requires no sidecars, no custom builds, and
-no changes to your existing Prometheus infrastructure.
+Promxy makes many shards of Prometheus appear as a single Prometheus API
+endpoint, with no sidecars, custom builds, or changes to your existing
+infrastructure.
 
-New here? Start with the [project README](../README.md) for the high-level
-pitch and [MOTIVATION.md](../MOTIVATION.md) for the "why", then work through
-[Getting started](getting-started.md).
+For the pitch see the [project README](../README.md) and
+[MOTIVATION.md](../MOTIVATION.md).
 
 ## Getting started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,55 @@
+# Promxy documentation
+
+Promxy is an aggregating proxy that makes many shards of Prometheus appear as a
+single Prometheus API endpoint. It requires no sidecars, no custom builds, and
+no changes to your existing Prometheus infrastructure.
+
+New here? Start with the [project README](../README.md) for the high-level
+pitch and [MOTIVATION.md](../MOTIVATION.md) for the "why", then work through
+[Getting started](getting-started.md).
+
+## Getting started
+
+- [Getting started](getting-started.md) — install, a minimal config, first query
+
+## Configuration
+
+- [Configuration overview](configuration/README.md) — the anatomy of the config file
+- [Server groups](configuration/server-groups.md) — reference for every `server_groups` option
+- [Command-line flags](configuration/cli-flags.md) — reference for every flag
+- [Alert templates](configuration/alert-templates.md) — customizing alert `GeneratorURL`s
+
+The annotated example config lives at
+[`cmd/promxy/config.yaml`](../cmd/promxy/config.yaml); a worked multi-tenant
+example is at [`cmd/promxy/multi_tenant.conf`](../cmd/promxy/multi_tenant.conf).
+
+## Concepts
+
+- [Architecture](concepts/architecture.md) — how a query flows through promxy
+- [HA and merging](concepts/ha-and-merging.md) — `anti_affinity`, dedup, gap filling
+
+## Guides
+
+- [Multi-tenancy](guides/multi-tenancy.md) — Mimir/Cortex tenants, `inject_matchers`
+- [Rules and alerting](guides/rules-and-alerting.md) — alerting rules, recording rules, `remote_write`
+- [Native histograms](guides/native-histograms.md) — routing histogram queries losslessly
+- [Label filtering](guides/label-filtering.md) — skipping downstreams that can't match
+- [Security](guides/security.md) — TLS, auth to promxy and to downstreams
+
+## Operations
+
+- [Running promxy](operations/running.md) — endpoints, reloads, graceful shutdown
+- [Metrics](operations/metrics.md) — what promxy exposes about itself
+- [Troubleshooting](operations/troubleshooting.md) — common symptoms and their causes
+
+## Contributing
+
+- [Development](development.md) — building, testing, the Prometheus fork, vendoring
+
+## Deployment
+
+Deployment manifests live under [`deploy/`](../deploy):
+
+- [`deploy/docker`](../deploy/docker) — docker-compose stack (promxy + VictoriaMetrics + Alertmanager)
+- [`deploy/k8s`](../deploy/k8s) — plain Kubernetes manifests
+- [`deploy/k8s/helm-charts/promxy`](../deploy/k8s/helm-charts/promxy) — Helm chart

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,0 +1,160 @@
+# Architecture
+
+Promxy is a stateless aggregating proxy. It has no TSDB, no scrape manager, and
+no storage of its own — it speaks the Prometheus HTTP API to its clients and the
+Prometheus HTTP API (and optionally remote_read) to its downstreams.
+
+```
+      Grafana / curl / Alertmanager
+                  |
+                  v
+     +---------------------------+
+     |  HTTP server (:8082)      |
+     |  prometheus web UI + API  |
+     +------------+--------------+
+                  |
+                  v
+     +---------------------------+
+     |  PromQL engine            |
+     |  + NodeReplacer (pushdown)|
+     +------------+--------------+
+                  |
+                  v
+     +---------------------------+
+     |  ProxyStorage             |   union across groups (all required)
+     +------+-------------+------+
+            |             |
+            v             v
+    +---------------+ +---------------+
+    | server group A| | server group B|   HA merge within group
+    +---+-------+---+ +---+-------+---+   (anti-affinity dedup)
+        |       |         |       |
+       prom1  prom2     prom3   prom4
+```
+
+## The two layers of merging
+
+This distinction explains most of promxy's behaviour, so it is worth stating
+precisely.
+
+**Within a server group** — the members hold the *same* data (HA replicas).
+Promxy fans a request out to every target, requires **one** success, and merges
+the successful responses with anti-affinity dedup: overlapping samples collapse,
+and a hole in one replica is filled from another. See
+[HA and merging](ha-and-merging.md).
+
+**Across server groups** — the groups hold *different* data (shards). Promxy
+fans out to every group and unions the results, with an anti-affinity buffer of
+zero (only exactly-coincident duplicates collapse) and **all** groups required
+to succeed. That "all required" default is why a single dead group fails the
+whole query — and why `ignore_error` / `downgrade_error` exist to opt individual
+groups out of it.
+
+Everything else follows from this: label-less aggregations like `count(up)` are
+only correct if each group's data is genuinely distinct, which is why static
+`labels` per group matter, and why multi-tenant backends need one group per
+tenant.
+
+## Query pushdown (`NodeReplacer`)
+
+The naive implementation would fetch all raw series from every downstream and
+evaluate locally. Promxy instead pushes as much of the query as it safely can
+down to the Prometheus servers, which are far better placed to run it — they
+have the data locally.
+
+Promxy's PromQL engine is configured with a `NodeReplacer`
+([`pkg/proxystorage/proxy.go`](../../pkg/proxystorage/proxy.go)). Before
+evaluation, the engine walks the AST and asks promxy whether each node can be
+replaced. Promxy answers by *executing that subtree remotely* and substituting a
+synthetic `VectorSelector` holding the result.
+
+The ground rules, in priority order:
+
+1. **Correctness beats speed.** If a rewrite could change the answer, promxy
+   declines and lets the engine evaluate locally over raw data.
+2. **No nested aggregations.** A child that is itself an `AggregateExpr` has its
+   own combining logic, so the subtree isn't safe to push down as-is.
+3. **Offsets in the subtree must agree.** Mismatched offsets would fetch
+   mismatched data; promxy waits until it is far enough down the tree that they
+   converge.
+4. **No loss of granularity.** Pushdown must not reduce accuracy.
+
+### What gets pushed down
+
+**Aggregations** are pushed down when the operation is *reentrant* — applying it
+to partial results and then again to those results gives the same answer:
+
+| Operation | Handling |
+| --------- | -------- |
+| `sum`, `min`, `max`, `topk`, `bottomk`, `group` | Pushed down directly; re-applied locally over the per-downstream results. |
+| `count` | Pushed down as `count`, then combined locally with `sum`. |
+| `count_values` | Pushed down, then combined as `sum(count_values(...)) by (key)`. |
+| `avg` | Rewritten as `sum(...) / count(...)`, both of which push down. |
+| `quantile` | Not pushed down — a true quantile needs the full data set. |
+| `stddev`, `stdvar` | Not pushed down — need the full data set. |
+| `limitk`, `limit_ratio` | Not pushed down — the engine selects series by hash over the *complete* input vector, so per-downstream selection would pick an inconsistent subset. |
+
+**Function calls** (`rate`, `increase`, `*_over_time`, …) are pushed down
+wholesale — the downstream computes them over its local raw data. Exceptions:
+
+- `absent`, `absent_over_time` — semantics are hard to reconstruct at this
+  layer, so promxy pushes down elsewhere in the tree instead.
+- `label_join`, `label_replace`, `info` — the engine evaluates these through
+  dedicated dispatchers with precise error messages; pushing them to a single
+  downstream would mangle that wording as the error round-trips through promxy's
+  error wrappers.
+
+**Selectors and subqueries** are pushed down where the offset/`@` rules allow.
+Queries using the `@` modifier are handled specially: the downstream resolves
+`@ T offset O` internally, so promxy must not strip offsets or shift the request
+window. For step-invariant `@` subtrees promxy issues a single instant query and
+replicates the result across the step grid.
+
+Anything not pushed down falls through to `ProxyStorage.Querier` →
+`proxyquerier` → the same server-group fan-out, fetching raw data instead.
+
+## The per-target client stack
+
+Most per-server-group options are implemented as decorators around a base API
+client, one stack per discovered target. Innermost first:
+
+| Layer | Configured by |
+| ----- | ------------- |
+| HTTP API client | `scheme`, `path_prefix`, `query_params`, `http_headers`, `http_client`, `timeout` |
+| Debug logging | `--log-level=debug` |
+| remote_read | `remote_read`, `remote_read_path` |
+| Absolute / relative time filter | `absolute_time_range`, `relative_time_range` |
+| Step re-alignment | `align_query_range_with_step` |
+| Matcher injection | `inject_matchers` |
+| Label addition | `labels` + labels from `relabel_configs` |
+| Metric relabeling | `metrics_relabel_configs` |
+| Label filtering | `label_filter` |
+| Error wrapping | *(always — annotates errors with `target=…`)* |
+
+The stack order is deliberate: `inject_matchers` sits *beneath* the
+label-manipulation layers so its matchers reach the downstream verbatim, without
+interacting with `label_filter`'s query filtering or `metrics_relabel`'s
+matcher reversal.
+
+Those per-target stacks are then combined into the group-level client
+(anti-affinity merge, one success required), wrapped with `servergroup ord=N`
+error annotation, and finally with `ignore_error` / `downgrade_error` if
+configured. The group clients are combined into the cross-group client, and the
+whole thing is wrapped in a time-truncation layer.
+
+## Config reload
+
+Reload rebuilds the entire client stack: new server groups are constructed,
+discovery is started, and the new state waits until every group is ready before
+being atomically swapped in. Only then is the old state cancelled. If any group
+fails to apply, the new state is discarded and the old one keeps serving — a bad
+reload never takes promxy down.
+
+## Writes
+
+Promxy's Appender is `remote_write`. Recording rules and alert-state series are
+appended to a WAL-only agent-mode DB, whose WAL the remote_write queue managers
+tail and ship to the configured endpoints. With `--storage.path` that WAL is
+durable across restarts; without it, it lives in a temp directory removed on
+shutdown. With no `remote_write` configured the appender is a stub that discards
+everything.

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,8 +1,8 @@
 # Architecture
 
-Promxy is a stateless aggregating proxy. It has no TSDB, no scrape manager, and
-no storage of its own — it speaks the Prometheus HTTP API to its clients and the
-Prometheus HTTP API (and optionally remote_read) to its downstreams.
+Promxy is stateless: no TSDB, no scrape manager. It speaks the Prometheus HTTP
+API to its clients, and the Prometheus HTTP API (optionally remote_read) to its
+downstreams.
 
 ```
       Grafana / curl / Alertmanager
@@ -34,89 +34,80 @@ Prometheus HTTP API (and optionally remote_read) to its downstreams.
 
 ## The two layers of merging
 
-This distinction explains most of promxy's behaviour, so it is worth stating
-precisely.
+**Within a server group** — members hold the *same* data (HA replicas). Promxy
+fans out to every target, requires **one** success, and merges with
+anti-affinity dedup: overlapping samples collapse, holes in one replica are
+filled from another. See [HA and merging](ha-and-merging.md).
 
-**Within a server group** — the members hold the *same* data (HA replicas).
-Promxy fans a request out to every target, requires **one** success, and merges
-the successful responses with anti-affinity dedup: overlapping samples collapse,
-and a hole in one replica is filled from another. See
-[HA and merging](ha-and-merging.md).
+**Across server groups** — groups hold *different* data (shards). Promxy fans
+out to every group and unions the results, with an anti-affinity buffer of zero
+(only exactly-coincident duplicates collapse) and **all** groups required to
+succeed.
 
-**Across server groups** — the groups hold *different* data (shards). Promxy
-fans out to every group and unions the results, with an anti-affinity buffer of
-zero (only exactly-coincident duplicates collapse) and **all** groups required
-to succeed. That "all required" default is why a single dead group fails the
-whole query — and why `ignore_error` / `downgrade_error` exist to opt individual
-groups out of it.
+Two consequences:
 
-Everything else follows from this: label-less aggregations like `count(up)` are
-only correct if each group's data is genuinely distinct, which is why static
-`labels` per group matter, and why multi-tenant backends need one group per
-tenant.
+- A single dead group fails the whole query. `ignore_error` /
+  `downgrade_error` opt individual groups out.
+- `count(up)` is only correct if each group's data is distinct —
+  hence static `labels` per group, and one group per tenant on multi-tenant
+  backends.
 
 ## Query pushdown (`NodeReplacer`)
 
-The naive implementation would fetch all raw series from every downstream and
-evaluate locally. Promxy instead pushes as much of the query as it safely can
-down to the Prometheus servers, which are far better placed to run it — they
-have the data locally.
+Promxy pushes as much of each query as it safely can down to the Prometheus
+servers rather than pulling raw series back and evaluating locally.
 
-Promxy's PromQL engine is configured with a `NodeReplacer`
+The engine is configured with a `NodeReplacer`
 ([`pkg/proxystorage/proxy.go`](../../pkg/proxystorage/proxy.go)). Before
-evaluation, the engine walks the AST and asks promxy whether each node can be
-replaced. Promxy answers by *executing that subtree remotely* and substituting a
-synthetic `VectorSelector` holding the result.
+evaluation it walks the AST and asks promxy whether each node can be replaced;
+promxy answers by executing that subtree remotely and substituting a synthetic
+`VectorSelector` holding the result.
 
-The ground rules, in priority order:
+Rules, in priority order:
 
 1. **Correctness beats speed.** If a rewrite could change the answer, promxy
-   declines and lets the engine evaluate locally over raw data.
-2. **No nested aggregations.** A child that is itself an `AggregateExpr` has its
-   own combining logic, so the subtree isn't safe to push down as-is.
-3. **Offsets in the subtree must agree.** Mismatched offsets would fetch
-   mismatched data; promxy waits until it is far enough down the tree that they
-   converge.
-4. **No loss of granularity.** Pushdown must not reduce accuracy.
+   declines and the engine evaluates locally.
+2. **No nested aggregations.** An `AggregateExpr` child has its own combining
+   logic, so the subtree isn't safe as-is.
+3. **Offsets in the subtree must agree.** Promxy waits until it is far enough
+   down the tree that they converge.
+4. **No loss of granularity.**
 
 ### What gets pushed down
 
-**Aggregations** are pushed down when the operation is *reentrant* — applying it
-to partial results and then again to those results gives the same answer:
+**Aggregations**, when the operation is *reentrant* (applying it to partial
+results and again to those results gives the same answer):
 
 | Operation | Handling |
 | --------- | -------- |
 | `sum`, `min`, `max`, `topk`, `bottomk`, `group` | Pushed down directly; re-applied locally over the per-downstream results. |
-| `count` | Pushed down as `count`, then combined locally with `sum`. |
-| `count_values` | Pushed down, then combined as `sum(count_values(...)) by (key)`. |
+| `count` | Pushed down as `count`, combined locally with `sum`. |
+| `count_values` | Pushed down, combined as `sum(count_values(...)) by (key)`. |
 | `avg` | Rewritten as `sum(...) / count(...)`, both of which push down. |
-| `quantile` | Not pushed down — a true quantile needs the full data set. |
-| `stddev`, `stdvar` | Not pushed down — need the full data set. |
-| `limitk`, `limit_ratio` | Not pushed down — the engine selects series by hash over the *complete* input vector, so per-downstream selection would pick an inconsistent subset. |
+| `quantile`, `stddev`, `stdvar` | Not pushed down; need the full data set. |
+| `limitk`, `limit_ratio` | Not pushed down. The engine selects series by hash over the *complete* input vector, so per-downstream selection would pick an inconsistent subset. |
 
 **Function calls** (`rate`, `increase`, `*_over_time`, …) are pushed down
-wholesale — the downstream computes them over its local raw data. Exceptions:
+wholesale. Exceptions:
 
-- `absent`, `absent_over_time` — semantics are hard to reconstruct at this
-  layer, so promxy pushes down elsewhere in the tree instead.
+- `absent`, `absent_over_time` — hard to reconstruct at this layer; promxy
+  pushes down elsewhere in the tree instead.
 - `label_join`, `label_replace`, `info` — the engine evaluates these through
-  dedicated dispatchers with precise error messages; pushing them to a single
-  downstream would mangle that wording as the error round-trips through promxy's
-  error wrappers.
+  dedicated dispatchers with precise error messages, which promxy's error
+  wrappers would mangle.
 
 **Selectors and subqueries** are pushed down where the offset/`@` rules allow.
-Queries using the `@` modifier are handled specially: the downstream resolves
-`@ T offset O` internally, so promxy must not strip offsets or shift the request
-window. For step-invariant `@` subtrees promxy issues a single instant query and
-replicates the result across the step grid.
+With `@` in play the downstream resolves `@ T offset O` itself, so promxy must
+not strip offsets or shift the request window. For step-invariant `@` subtrees
+promxy issues one instant query and replicates the result across the step grid.
 
 Anything not pushed down falls through to `ProxyStorage.Querier` →
-`proxyquerier` → the same server-group fan-out, fetching raw data instead.
+`proxyquerier` → the same fan-out, fetching raw data instead.
 
 ## The per-target client stack
 
-Most per-server-group options are implemented as decorators around a base API
-client, one stack per discovered target. Innermost first:
+Most per-group options are decorators around a base API client, one stack per
+discovered target. Innermost first:
 
 | Layer | Configured by |
 | ----- | ------------- |
@@ -131,30 +122,26 @@ client, one stack per discovered target. Innermost first:
 | Label filtering | `label_filter` |
 | Error wrapping | *(always — annotates errors with `target=…`)* |
 
-The stack order is deliberate: `inject_matchers` sits *beneath* the
-label-manipulation layers so its matchers reach the downstream verbatim, without
-interacting with `label_filter`'s query filtering or `metrics_relabel`'s
-matcher reversal.
+`inject_matchers` sits *beneath* the label-manipulation layers deliberately, so
+its matchers reach the downstream verbatim without interacting with
+`label_filter`'s query filtering or `metrics_relabel`'s matcher reversal.
 
-Those per-target stacks are then combined into the group-level client
-(anti-affinity merge, one success required), wrapped with `servergroup ord=N`
-error annotation, and finally with `ignore_error` / `downgrade_error` if
-configured. The group clients are combined into the cross-group client, and the
-whole thing is wrapped in a time-truncation layer.
+Those stacks combine into the group client (anti-affinity merge, one success
+required), wrapped with `servergroup ord=N` error annotation, then with
+`ignore_error` / `downgrade_error`. Group clients combine into the cross-group
+client, wrapped in a time-truncation layer.
 
 ## Config reload
 
-Reload rebuilds the entire client stack: new server groups are constructed,
-discovery is started, and the new state waits until every group is ready before
-being atomically swapped in. Only then is the old state cancelled. If any group
-fails to apply, the new state is discarded and the old one keeps serving — a bad
-reload never takes promxy down.
+Reload rebuilds the whole client stack: new groups are constructed, discovery
+starts, and the new state waits for every group to be ready before being swapped
+in atomically. Only then is the old state cancelled. If any group fails to
+apply, the new state is discarded and the old one keeps serving.
 
 ## Writes
 
 Promxy's Appender is `remote_write`. Recording rules and alert-state series are
-appended to a WAL-only agent-mode DB, whose WAL the remote_write queue managers
-tail and ship to the configured endpoints. With `--storage.path` that WAL is
-durable across restarts; without it, it lives in a temp directory removed on
-shutdown. With no `remote_write` configured the appender is a stub that discards
-everything.
+appended to a WAL-only agent-mode DB; the remote_write queue managers tail that
+WAL and ship it. `--storage.path` makes the WAL durable across restarts;
+without it it lives in a temp directory removed on shutdown. With no
+`remote_write` configured the appender discards everything.

--- a/docs/concepts/ha-and-merging.md
+++ b/docs/concepts/ha-and-merging.md
@@ -1,23 +1,17 @@
 # HA and merging
 
-Prometheus has no clustering or HA story of its own, so the accepted practice is
-to run N servers with an identical config, each scraping everything
-independently. That gives you redundancy but leaves you with N datasources that
-nobody can aggregate across.
-
-Promxy's job is to turn those N servers back into one. The hard part is that
-their data is *nearly* — but not exactly — identical.
+Promxy merges the N Prometheus servers in a server group back into one series
+set. Their data is nearly, but not exactly, identical.
 
 ## Why the data doesn't line up
 
-Prometheus stores the timestamp at which a scrape **starts**. Two servers
-scraping the same target will start their scrapes at different moments, and the
-same server's scrape duration varies with exporter latency, serialisation, and
-network jitter. Add clock drift between hosts and you get two series that
-represent the same measurements at slightly different timestamps.
+Prometheus stores the timestamp at which a scrape **starts**. Two servers start
+their scrapes at different moments, and scrape duration varies with exporter
+latency and network jitter. Add clock drift and you have two series recording
+the same measurements at slightly different timestamps.
 
-Naively unioning them doubles your sample count. Naively taking one and ignoring
-the other loses the gap-filling that made HA worth running.
+Union them and your sample count doubles. Take one and ignore the other and you
+lose the gap-filling that HA was for.
 
 ## `anti_affinity`
 
@@ -32,86 +26,72 @@ promxy:
       anti_affinity: 10s   # default
 ```
 
-The merge works like this
-([`pkg/promhttputil/merge.go`](../../pkg/promhttputil/merge.go)):
+The algorithm ([`pkg/promhttputil/merge.go`](../../pkg/promhttputil/merge.go)):
 
-1. Of the two series being merged, the one with **more** samples becomes the
-   base. When one downstream has a hole and the other doesn't, this picks the
-   complete side rather than merging up from the worse one.
-2. Samples from the other side that fall **before** the base's first sample
-   (minus the buffer) are prepended.
-3. Walking the base, whenever the gap between two consecutive samples exceeds
+1. The series with **more** samples becomes the base, so a side with a hole
+   never wins over a complete one.
+2. Samples from the other side falling before the base's first sample (minus
+   the buffer) are prepended.
+3. Walking the base, wherever the gap between consecutive samples exceeds
    `2 × anti_affinity`, promxy looks for a sample from the other side that fits
-   in the middle of that gap without landing within `anti_affinity` of either
-   neighbour.
+   in that gap without landing within `anti_affinity` of either neighbour.
 
-So a buffer of `10s` tolerates about 5s of skew on either side. Duplicate
-samples collapse; genuine holes get filled.
+A `10s` buffer tolerates ~5s of skew on either side.
 
-**Set `anti_affinity` to your scrape interval.** That is the value at which a
-missing sample is a real gap and anything closer is skew.
+**Set `anti_affinity` to your scrape interval.**
 
-### Getting it wrong
-
-- **Too small** — skewed duplicates from the second replica survive the merge.
-  A `count_over_time` roughly doubles; rates and deltas get noisy.
-- **Too large** — legitimately-spaced samples are treated as duplicates and
-  dropped, thinning your series.
+| Setting | Symptom |
+| ------- | ------- |
+| Too small | Skewed duplicates survive. `count_over_time` roughly doubles; rates get noisy. |
+| Too large | Legitimately-spaced samples are dropped as duplicates, thinning the series. |
 
 ## `anti_affinity_dynamic`
 
-A single static buffer only works when every series in the group shares a scrape
-interval. If one group serves jobs scraped at 15s alongside jobs scraped at 1m,
-no single value is right: `15s` is too wide for the fast job and far too tight
-for the slow one, whose normal 60s spacing looks like a gap and gets filled.
+A static buffer only works when every series in the group shares a scrape
+interval. With 15s and 1m jobs in one group, no single value fits: `15s` is too
+tight for the 1m job (its normal spacing looks like a gap and gets filled) and
+too wide for the 15s one.
 
 ```yaml
 anti_affinity_dynamic: true
 ```
 
-With this set, promxy infers the buffer **per series** from the data itself —
-half the median inter-sample gap of the longer side, which models "scrape
-interval / 2" without you having to declare it. `anti_affinity` remains the
-fallback for series with too few samples (fewer than three gaps) to estimate
-from.
-
-See [issue #734](https://github.com/jacksontj/promxy/issues/734).
+Promxy then infers the buffer **per series** — half the median inter-sample gap
+of the longer side. `anti_affinity` remains the fallback for series with fewer
+than three gaps to estimate from. See
+[issue #734](https://github.com/jacksontj/promxy/issues/734).
 
 ## `prefer_max`
 
-When both sides have a sample at the same timestamp, promxy has to pick one. By
-default it takes the base series' value; `prefer_max: true` takes the larger.
-This is occasionally useful for monotonic counters where one replica missed
-increments, but it is not a substitute for correct `anti_affinity`.
+When both sides have a sample at the same timestamp, promxy takes the base
+series' value. `prefer_max: true` takes the larger instead. Not a substitute
+for correct `anti_affinity`.
 
 ## Native histograms
 
-Float samples and native-histogram samples coexist on a series and are merged
-independently, so a series carrying both still deduplicates correctly. Note that
-histogram fidelity through the *JSON* API is lossy — see
-[Native histograms](../guides/native-histograms.md) for why `remote_read`
-matters here.
+Float and histogram samples on a series are merged independently, so a series
+carrying both deduplicates correctly, and histograms round-trip losslessly.
+Histogram fidelity through the *JSON* API is lossy, though — see
+[Native histograms](../guides/native-histograms.md).
 
 ## Availability vs. correctness
 
-Within a group, promxy requires **one** target to succeed. Across groups it
-requires **all** of them, because a missing shard means silently missing data
-and promxy would rather error than hand alerting rules a wrong answer.
+Within a group promxy requires **one** target to succeed. Across groups it
+requires **all** of them: a missing shard means silently missing data, and an
+error beats a wrong answer that alerting depends on.
 
 To trade that for availability, per group:
 
-- `downgrade_error: true` — errors become warnings on the response. Preferred:
-  you keep serving, and clients that surface warnings still see the problem.
-- `ignore_error: true` — errors are dropped entirely. The query succeeds with
-  no indication that a shard was missing.
-
-Neither should be the default for groups whose data alerts depend on.
+| Option | Effect |
+| ------ | ------ |
+| `downgrade_error: true` | Errors become warnings on the response. Preferred — clients that surface warnings still see the problem. |
+| `ignore_error: true` | Errors dropped entirely. No indication a shard was missing. |
 
 ## Deduplicating replica labels
 
 If your Prometheus servers add a distinguishing external label (`replica`,
-`prometheus_replica`, …), their series won't have identical label sets and
-promxy can't merge them. Drop the label in the query path:
+`prometheus_replica`), their series have different label sets and can't be
+merged. Drop it in the query path:
 
 ```yaml
 metrics_relabel_configs:
@@ -119,7 +99,6 @@ metrics_relabel_configs:
     source_label: replica
 ```
 
-This is the same idea as Thanos' replica-label deduplication. Because promxy
-rewrites incoming query matchers to match, the label must be dropped with a
-*reversible* action — see
+Same idea as Thanos' replica-label dedup. The action must be *reversible*
+because promxy rewrites incoming query matchers to match — see
 [`metrics_relabel_configs`](../configuration/server-groups.md#metrics_relabel_configs).

--- a/docs/concepts/ha-and-merging.md
+++ b/docs/concepts/ha-and-merging.md
@@ -1,0 +1,125 @@
+# HA and merging
+
+Prometheus has no clustering or HA story of its own, so the accepted practice is
+to run N servers with an identical config, each scraping everything
+independently. That gives you redundancy but leaves you with N datasources that
+nobody can aggregate across.
+
+Promxy's job is to turn those N servers back into one. The hard part is that
+their data is *nearly* — but not exactly — identical.
+
+## Why the data doesn't line up
+
+Prometheus stores the timestamp at which a scrape **starts**. Two servers
+scraping the same target will start their scrapes at different moments, and the
+same server's scrape duration varies with exporter latency, serialisation, and
+network jitter. Add clock drift between hosts and you get two series that
+represent the same measurements at slightly different timestamps.
+
+Naively unioning them doubles your sample count. Naively taking one and ignoring
+the other loses the gap-filling that made HA worth running.
+
+## `anti_affinity`
+
+Promxy merges with an **anti-affinity buffer**: it refuses to place a sample
+within `anti_affinity` of an existing one.
+
+```yaml
+promxy:
+  server_groups:
+    - static_configs:
+        - targets: [prom-01:9090, prom-02:9090]
+      anti_affinity: 10s   # default
+```
+
+The merge works like this
+([`pkg/promhttputil/merge.go`](../../pkg/promhttputil/merge.go)):
+
+1. Of the two series being merged, the one with **more** samples becomes the
+   base. When one downstream has a hole and the other doesn't, this picks the
+   complete side rather than merging up from the worse one.
+2. Samples from the other side that fall **before** the base's first sample
+   (minus the buffer) are prepended.
+3. Walking the base, whenever the gap between two consecutive samples exceeds
+   `2 × anti_affinity`, promxy looks for a sample from the other side that fits
+   in the middle of that gap without landing within `anti_affinity` of either
+   neighbour.
+
+So a buffer of `10s` tolerates about 5s of skew on either side. Duplicate
+samples collapse; genuine holes get filled.
+
+**Set `anti_affinity` to your scrape interval.** That is the value at which a
+missing sample is a real gap and anything closer is skew.
+
+### Getting it wrong
+
+- **Too small** — skewed duplicates from the second replica survive the merge.
+  A `count_over_time` roughly doubles; rates and deltas get noisy.
+- **Too large** — legitimately-spaced samples are treated as duplicates and
+  dropped, thinning your series.
+
+## `anti_affinity_dynamic`
+
+A single static buffer only works when every series in the group shares a scrape
+interval. If one group serves jobs scraped at 15s alongside jobs scraped at 1m,
+no single value is right: `15s` is too wide for the fast job and far too tight
+for the slow one, whose normal 60s spacing looks like a gap and gets filled.
+
+```yaml
+anti_affinity_dynamic: true
+```
+
+With this set, promxy infers the buffer **per series** from the data itself —
+half the median inter-sample gap of the longer side, which models "scrape
+interval / 2" without you having to declare it. `anti_affinity` remains the
+fallback for series with too few samples (fewer than three gaps) to estimate
+from.
+
+See [issue #734](https://github.com/jacksontj/promxy/issues/734).
+
+## `prefer_max`
+
+When both sides have a sample at the same timestamp, promxy has to pick one. By
+default it takes the base series' value; `prefer_max: true` takes the larger.
+This is occasionally useful for monotonic counters where one replica missed
+increments, but it is not a substitute for correct `anti_affinity`.
+
+## Native histograms
+
+Float samples and native-histogram samples coexist on a series and are merged
+independently, so a series carrying both still deduplicates correctly. Note that
+histogram fidelity through the *JSON* API is lossy — see
+[Native histograms](../guides/native-histograms.md) for why `remote_read`
+matters here.
+
+## Availability vs. correctness
+
+Within a group, promxy requires **one** target to succeed. Across groups it
+requires **all** of them, because a missing shard means silently missing data
+and promxy would rather error than hand alerting rules a wrong answer.
+
+To trade that for availability, per group:
+
+- `downgrade_error: true` — errors become warnings on the response. Preferred:
+  you keep serving, and clients that surface warnings still see the problem.
+- `ignore_error: true` — errors are dropped entirely. The query succeeds with
+  no indication that a shard was missing.
+
+Neither should be the default for groups whose data alerts depend on.
+
+## Deduplicating replica labels
+
+If your Prometheus servers add a distinguishing external label (`replica`,
+`prometheus_replica`, …), their series won't have identical label sets and
+promxy can't merge them. Drop the label in the query path:
+
+```yaml
+metrics_relabel_configs:
+  - action: labeldrop
+    source_label: replica
+```
+
+This is the same idea as Thanos' replica-label deduplication. Because promxy
+rewrites incoming query matchers to match, the label must be dropped with a
+*reversible* action — see
+[`metrics_relabel_configs`](../configuration/server-groups.md#metrics_relabel_configs).

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -1,0 +1,105 @@
+# Configuration overview
+
+Promxy takes a single config file (`--config`, default `config.yaml`). That
+file is a **Prometheus configuration file** with one additional top-level key:
+`promxy`.
+
+```yaml
+# ---- standard prometheus configuration ----
+global: {}
+rule_files: []
+alerting: {}
+remote_write: []
+
+# ---- promxy-specific configuration ----
+promxy:
+  server_groups: []
+  alert_templates: {}
+```
+
+Validate a config without starting up:
+
+```
+promxy --config=config.yaml --check-config
+```
+
+The fully annotated example config is
+[`cmd/promxy/config.yaml`](../../cmd/promxy/config.yaml).
+
+## The Prometheus half
+
+These sections are parsed by Prometheus' own config package and behave as
+documented [upstream](https://prometheus.io/docs/prometheus/latest/configuration/configuration/),
+with the caveats below.
+
+### `global`
+
+`evaluation_interval`, `external_labels`, `query_log_file`, and
+`query_log_file`-adjacent settings all apply. `external_labels` are added to
+everything promxy returns, and are honoured by promxy's `/federate` handler.
+
+Scrape-related settings (`scrape_interval`, `scrape_configs`) are meaningless —
+promxy never scrapes anything.
+
+### `rule_files` / `alerting`
+
+Alerting rules work and evaluate across your **entire** infrastructure, which is
+their main appeal: a global error-rate alert is trivial in promxy and impossible
+on an individual Prometheus server.
+
+Two things differ from Prometheus:
+
+- **Recording rules are rejected.** Promxy has no local TSDB. Configuring a
+  recording rule without `remote_write` is a fatal config error.
+- **Alerting rules without `remote_write` log a warning.** The alerts still
+  fire, but the `ALERTS`/`ALERTS_FOR_STATE` series have nowhere to go.
+
+See [Rules and alerting](../guides/rules-and-alerting.md).
+
+### `remote_write`
+
+Promxy has no local storage, so `remote_write` *is* promxy's Appender. Anything
+promxy would "write" — recording rule output, `ALERTS` and `ALERTS_FOR_STATE`
+series from alerting rules — is sent here.
+
+```yaml
+remote_write:
+  - url: http://localhost:8083/receive
+```
+
+One promxy-specific default: `queue_config.max_samples_per_send` defaults to
+**100**, not upstream Prometheus' 2000. Large batches of high-cardinality
+recording-rule output can decompress past the 32 MiB snappy limit that
+Prometheus 3.5.3+ enforces on the receiving side, and the receiver then rejects
+the whole batch. Setting `max_samples_per_send` explicitly overrides this.
+
+If you set `--storage.path`, the remote_write WAL is durable across restarts;
+otherwise a temporary directory is used and removed on shutdown.
+
+### `tls_server_config`
+
+A top-level `tls_server_config` key is accepted by the parser but **has no
+effect** — promxy's web server is configured entirely from `--web.config.file`.
+Use that instead; see [Security](../guides/security.md).
+
+## The promxy half
+
+### `promxy.server_groups`
+
+The bulk of promxy's configuration. Each entry is a set of Prometheus-API
+endpoints holding the **same** data, which promxy merges and deduplicates.
+Different data belongs in different groups.
+
+Full reference: [Server groups](server-groups.md).
+
+### `promxy.alert_templates`
+
+Optional. Customizes the `GeneratorURL` promxy puts on alerts sent to
+Alertmanager. Reference: [Alert templates](alert-templates.md).
+
+## Reloading
+
+Promxy reloads its config on `SIGHUP`, and on `POST /-/reload` when started with
+`--web.enable-lifecycle`. Everything in the file is reloadable — server groups,
+rules, alertmanagers, remote_write, alert templates. See
+[Running promxy](../operations/running.md).

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -1,8 +1,7 @@
 # Configuration overview
 
-Promxy takes a single config file (`--config`, default `config.yaml`). That
-file is a **Prometheus configuration file** with one additional top-level key:
-`promxy`.
+Promxy takes one config file (`--config`, default `config.yaml`): a
+**Prometheus configuration file** plus one extra top-level key, `promxy`.
 
 ```yaml
 # ---- standard prometheus configuration ----
@@ -17,37 +16,35 @@ promxy:
   alert_templates: {}
 ```
 
-Validate a config without starting up:
+Validate without starting up:
 
 ```
 promxy --config=config.yaml --check-config
 ```
 
-The fully annotated example config is
-[`cmd/promxy/config.yaml`](../../cmd/promxy/config.yaml).
+Annotated example: [`cmd/promxy/config.yaml`](../../cmd/promxy/config.yaml).
 
 ## The Prometheus half
 
-These sections are parsed by Prometheus' own config package and behave as
-documented [upstream](https://prometheus.io/docs/prometheus/latest/configuration/configuration/),
-with the caveats below.
+Parsed by Prometheus' own config package, behaving as documented
+[upstream](https://prometheus.io/docs/prometheus/latest/configuration/configuration/),
+with these caveats.
 
 ### `global`
 
-`evaluation_interval`, `external_labels`, `query_log_file`, and
-`query_log_file`-adjacent settings all apply. `external_labels` are added to
-everything promxy returns, and are honoured by promxy's `/federate` handler.
+`evaluation_interval`, `external_labels`, and `query_log_file` all apply.
+`external_labels` are added to everything promxy returns and are honoured by its
+`/federate` handler.
 
-Scrape-related settings (`scrape_interval`, `scrape_configs`) are meaningless —
-promxy never scrapes anything.
+Scrape settings (`scrape_interval`, `scrape_configs`) are meaningless; promxy
+never scrapes.
 
 ### `rule_files` / `alerting`
 
-Alerting rules work and evaluate across your **entire** infrastructure, which is
-their main appeal: a global error-rate alert is trivial in promxy and impossible
-on an individual Prometheus server.
+Alerting rules evaluate across your **entire** infrastructure — a global
+error-rate alert is trivial here and impossible on one Prometheus server.
 
-Two things differ from Prometheus:
+Two differences from Prometheus:
 
 - **Recording rules are rejected.** Promxy has no local TSDB. Configuring a
   recording rule without `remote_write` is a fatal config error.
@@ -58,48 +55,45 @@ See [Rules and alerting](../guides/rules-and-alerting.md).
 
 ### `remote_write`
 
-Promxy has no local storage, so `remote_write` *is* promxy's Appender. Anything
-promxy would "write" — recording rule output, `ALERTS` and `ALERTS_FOR_STATE`
-series from alerting rules — is sent here.
+With no local storage, `remote_write` *is* promxy's Appender: recording-rule
+output and the `ALERTS` / `ALERTS_FOR_STATE` series all go here.
 
 ```yaml
 remote_write:
   - url: http://localhost:8083/receive
 ```
 
-One promxy-specific default: `queue_config.max_samples_per_send` defaults to
-**100**, not upstream Prometheus' 2000. Large batches of high-cardinality
-recording-rule output can decompress past the 32 MiB snappy limit that
-Prometheus 3.5.3+ enforces on the receiving side, and the receiver then rejects
-the whole batch. Setting `max_samples_per_send` explicitly overrides this.
+One promxy-specific default: `queue_config.max_samples_per_send` is **100**,
+not upstream's 2000. Large batches of high-cardinality recording-rule output can
+decompress past the 32 MiB snappy limit Prometheus 3.5.3+ enforces on the
+receiver, which then rejects the batch. Set it explicitly to override.
 
-If you set `--storage.path`, the remote_write WAL is durable across restarts;
-otherwise a temporary directory is used and removed on shutdown.
+`--storage.path` makes the remote_write WAL durable across restarts; otherwise a
+temp directory is used and removed on shutdown.
 
 ### `tls_server_config`
 
-A top-level `tls_server_config` key is accepted by the parser but **has no
-effect** — promxy's web server is configured entirely from `--web.config.file`.
-Use that instead; see [Security](../guides/security.md).
+Parsed but **has no effect**; promxy's web server is configured entirely from
+`--web.config.file`. See [Security](../guides/security.md).
 
 ## The promxy half
 
 ### `promxy.server_groups`
 
 The bulk of promxy's configuration. Each entry is a set of Prometheus-API
-endpoints holding the **same** data, which promxy merges and deduplicates.
-Different data belongs in different groups.
+endpoints holding the **same** data, merged and deduplicated by promxy;
+different data belongs in different groups.
 
 Full reference: [Server groups](server-groups.md).
 
 ### `promxy.alert_templates`
 
-Optional. Customizes the `GeneratorURL` promxy puts on alerts sent to
-Alertmanager. Reference: [Alert templates](alert-templates.md).
+Optional. Customizes the `GeneratorURL` on alerts sent to Alertmanager.
+Reference: [Alert templates](alert-templates.md).
 
 ## Reloading
 
-Promxy reloads its config on `SIGHUP`, and on `POST /-/reload` when started with
-`--web.enable-lifecycle`. Everything in the file is reloadable — server groups,
+Promxy reloads on `SIGHUP`, and on `POST /-/reload` with
+`--web.enable-lifecycle`. Everything in the file is reloadable: server groups,
 rules, alertmanagers, remote_write, alert templates. See
 [Running promxy](../operations/running.md).

--- a/docs/configuration/alert-templates.md
+++ b/docs/configuration/alert-templates.md
@@ -1,12 +1,11 @@
 # Alert templates
 
-By default promxy sets the same Prometheus-style `GeneratorURL` on the alerts it
-sends to Alertmanager: a link to promxy's own graph page for the alert
-expression, built from `--web.external-url`.
+By default alerts carry a Prometheus-style `GeneratorURL`: a link to promxy's
+graph page for the alert expression, built from `--web.external-url`.
 
-`promxy.alert_templates` lets you replace that with your own URLs — a Grafana
-alert view, a PagerDuty incident form, an internal runbook — chosen per alert.
-The block is entirely opt-in; omit it to keep the default.
+`promxy.alert_templates` replaces that with your own URLs — a Grafana alert
+view, a PagerDuty incident form, a runbook — chosen per alert. Opt-in; omit the
+block to keep the default.
 
 ## Schema
 
@@ -65,7 +64,7 @@ Two extra functions are available beyond the `text/template` builtins:
 - `urlquery` — escape a value for use in a URL query string
 - `urlpath` — escape a value for use in a URL path segment
 
-Always pipe interpolated values through one of these; alert labels routinely
+Always pipe interpolated values through one of these — alert labels routinely
 contain characters that would otherwise produce a malformed URL.
 
 ```

--- a/docs/configuration/alert-templates.md
+++ b/docs/configuration/alert-templates.md
@@ -1,0 +1,73 @@
+# Alert templates
+
+By default promxy sets the same Prometheus-style `GeneratorURL` on the alerts it
+sends to Alertmanager: a link to promxy's own graph page for the alert
+expression, built from `--web.external-url`.
+
+`promxy.alert_templates` lets you replace that with your own URLs — a Grafana
+alert view, a PagerDuty incident form, an internal runbook — chosen per alert.
+The block is entirely opt-in; omit it to keep the default.
+
+## Schema
+
+```yaml
+promxy:
+  alert_templates:
+    # Used when no rule matches. Either an inline template body or the name of
+    # one of the `named` templates below.
+    default: '{{.ExternalURL}}/graph?g0.expr={{.Expr | urlquery}}&g0.tab=1'
+
+    # Reusable templates, addressable from `default` and from a rule's
+    # `template`.
+    named:
+      grafana: 'https://grafana.example.com/alerting/groups?queryString=alertname%3D%22{{.AlertName | urlquery}}%22'
+      pagerduty: 'https://example.pagerduty.com/incidents/new?title={{.AlertName | urlquery}}'
+
+    # Evaluated top-to-bottom; the first rule whose match_labels all match wins.
+    rules:
+      - match_labels:
+          severity: critical
+        template: pagerduty
+      - match_labels:
+          team: frontend
+        template: grafana
+      - match_labels:
+          alertname: DatabaseDown
+        template: 'https://db.example.com/status?db={{.Labels.database | urlquery}}'
+```
+
+## Selection order
+
+1. Each rule in `rules`, in order. A rule matches when **every** entry in its
+   `match_labels` is present on the alert with that exact value. An empty
+   `match_labels` never matches — use `default` for a catch-all.
+2. `default`, if set.
+3. Promxy's built-in Prometheus-style URL.
+
+A rule's `template` (and `default`) is either the name of a `named` template or
+an inline template body.
+
+## Template context
+
+Each template is a Go [`text/template`](https://pkg.go.dev/text/template)
+rendered once per alert with these fields:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `.ExternalURL` | string | Promxy's external URL (`--web.external-url`). |
+| `.Expr` | string | The alerting rule's expression. |
+| `.AlertName` | string | The alert name. |
+| `.Labels` | map | The alert's label set. |
+| `.Annotations` | map | The alert's annotations. |
+
+Two extra functions are available beyond the `text/template` builtins:
+
+- `urlquery` — escape a value for use in a URL query string
+- `urlpath` — escape a value for use in a URL path segment
+
+Always pipe interpolated values through one of these; alert labels routinely
+contain characters that would otherwise produce a malformed URL.
+
+```
+'https://runbooks.example.com/{{.AlertName | urlpath}}?instance={{.Labels.instance | urlquery}}'
+```

--- a/docs/configuration/cli-flags.md
+++ b/docs/configuration/cli-flags.md
@@ -1,0 +1,105 @@
+# Command-line flags
+
+Everything below is from [`cmd/promxy/main.go`](../../cmd/promxy/main.go).
+`promxy --help` prints the same list.
+
+## General
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--version`, `-v` | | Print version and exit. |
+| `--check-config` | | Load and validate the config file, then exit. |
+| `--config` | `config.yaml` | Path to the config file. |
+
+## Logging
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--log-level` | `info` | `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`. |
+| `--log-format` | `text` | `text` or `json`. |
+| `--log-max-form-prefix` | `256` | Max length of form values recorded in log entries. |
+| `--access-log-destination` | `stdout` | `stdout`, `stderr`, or `none`. |
+
+Promxy routes the embedded Prometheus libraries' logging (notifier, discovery,
+web, rules) through the same logger, so these settings govern all output.
+Kubernetes client logging is clamped below the verbosity at which it would print
+bearer tokens in clear text.
+
+## Web server
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--bind-addr` | `:8082` | Address to listen on. |
+| `--web.config.file` | | *[Experimental]* Prometheus-format web config file: TLS, HTTP headers, basic auth users. See [Security](../guides/security.md). |
+| `--web.cors.origin` | `.*` | Fully-anchored regex for allowed CORS origins. |
+| `--web.read-timeout` | `5m` | Max duration for reading a request; also closes idle connections. |
+| `--web.external-url` | | URL under which promxy is externally reachable. Used for links back to promxy (including alert `GeneratorURL`s). A path component prefixes all HTTP endpoints. |
+| `--web.route-prefix` | path of `--web.external-url` | Prefix for internal routes. |
+| `--web.enable-lifecycle` | `false` | Enable `POST /-/reload`. (`/-/quit` is also routed by the embedded Prometheus web handler, but promxy does not act on it — use `SIGTERM` to stop promxy.) |
+| `--metrics-path` | `/metrics` | URL path for promxy's own metrics. |
+| `--proxy-headers` | | Headers to forward from incoming requests to downstream server groups. Repeatable; also settable via `PROXY_HEADERS`. |
+
+## Query engine
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--query.timeout` | `2m` | Max time a query may take before being aborted. |
+| `--query.max-samples` | `50000000` | Max samples a single query may load into memory. |
+| `--query.lookback-delta` | `5m` | Max lookback when retrieving metrics during evaluation. |
+| `--query.max-concurrency` | `-1` (unlimited) | Max concurrently-executing queries. **Requires `--storage.path`** — the active query tracker needs a file on disk. |
+| `--remote-read.max-concurrency` | `10` | Max concurrent remote read calls served by promxy's *own* remote_read endpoint. |
+
+## Storage
+
+Promxy has no TSDB. `--storage.path` is only a working directory, used for the
+active query tracker file and the `remote_write` WAL.
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--storage.path` | | Base directory for promxy's local working state. |
+| `--storage.tsdb.path` | | **Deprecated** alias for `--storage.path`. Setting both is a fatal error. |
+
+Without `--storage.path` the remote_write WAL goes to a temporary directory that
+is removed on shutdown, so buffered samples do not survive a restart.
+
+## Rules and alerting
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--rules.alert.for-outage-tolerance` | `1h` | Max outage tolerated when restoring the `for` state of an alert. |
+| `--rules.alert.for-grace-period` | `10m` | Minimum duration between an alert firing and its restored `for` state. Applies only to alerts whose `for` exceeds this. |
+| `--rules.alert.resend-delay` | `1m` | Minimum time before resending an alert to Alertmanager. |
+| `--rules.alertbackfill` | `false` | Recalculate alert state at startup by querying downstreams, for when the datastore has no `ALERTS_FOR_STATE` series. |
+| `--alertmanager.notification-queue-capacity` | `10000` | Capacity of the pending-notification queue. |
+
+See [Rules and alerting](../guides/rules-and-alerting.md).
+
+## Shutdown
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--http.shutdown-delay` | `10s` | Time to keep serving after `SIGTERM` while failing health checks, so load balancers can drain. |
+| `--http.shutdown-timeout` | `60s` | Max time to wait for in-flight requests during graceful shutdown. |
+
+See [Running promxy](../operations/running.md#graceful-shutdown).
+
+---
+
+## `remote_write_exporter`
+
+A small companion binary (shipped in the same container image) that receives
+`remote_write` and re-exposes the most recent value of each series on a
+`/metrics` endpoint. It is a convenient `remote_write` target when all you want
+is for recording-rule and alert-state metrics to be scrapeable again — see
+[Rules and alerting](../guides/rules-and-alerting.md).
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--bind-addr` | `:8083` | Address to listen on. |
+| `--write-path` | `/receive` | Path accepting protobuf remote_write. |
+| `--write-text-path` | `/receive_text` | Path accepting the Prometheus text exposition format. |
+| `--metrics-path` | `/metrics` | Path exposing the received series. |
+| `--metric-ttl` | *(required)* | How long a series is retained after its last sample. |
+| `--drop-stale` | `false` | Drop series written with a `StaleNaN`. |
+
+It keeps everything in memory with a TTL sweep; it is not a storage system.

--- a/docs/configuration/cli-flags.md
+++ b/docs/configuration/cli-flags.md
@@ -20,10 +20,10 @@ Everything below is from [`cmd/promxy/main.go`](../../cmd/promxy/main.go).
 | `--log-max-form-prefix` | `256` | Max length of form values recorded in log entries. |
 | `--access-log-destination` | `stdout` | `stdout`, `stderr`, or `none`. |
 
-Promxy routes the embedded Prometheus libraries' logging (notifier, discovery,
-web, rules) through the same logger, so these settings govern all output.
-Kubernetes client logging is clamped below the verbosity at which it would print
-bearer tokens in clear text.
+The embedded Prometheus libraries (notifier, discovery, web, rules) log through
+the same logger, so these settings govern all output. Kubernetes client logging
+is clamped below the verbosity at which it would print bearer tokens in clear
+text.
 
 ## Web server
 
@@ -51,16 +51,16 @@ bearer tokens in clear text.
 
 ## Storage
 
-Promxy has no TSDB. `--storage.path` is only a working directory, used for the
-active query tracker file and the `remote_write` WAL.
+Promxy has no TSDB. `--storage.path` is a working directory for the active
+query tracker file and the `remote_write` WAL.
 
 | Flag | Default | Description |
 | ---- | ------- | ----------- |
 | `--storage.path` | | Base directory for promxy's local working state. |
 | `--storage.tsdb.path` | | **Deprecated** alias for `--storage.path`. Setting both is a fatal error. |
 
-Without `--storage.path` the remote_write WAL goes to a temporary directory that
-is removed on shutdown, so buffered samples do not survive a restart.
+Without it the WAL goes to a temp directory removed on shutdown, so buffered
+samples don't survive a restart.
 
 ## Rules and alerting
 
@@ -87,11 +87,10 @@ See [Running promxy](../operations/running.md#graceful-shutdown).
 
 ## `remote_write_exporter`
 
-A small companion binary (shipped in the same container image) that receives
-`remote_write` and re-exposes the most recent value of each series on a
-`/metrics` endpoint. It is a convenient `remote_write` target when all you want
-is for recording-rule and alert-state metrics to be scrapeable again — see
-[Rules and alerting](../guides/rules-and-alerting.md).
+A companion binary (same container image) that receives `remote_write` and
+re-exposes the most recent value of each series on `/metrics` — a convenient
+target when you just want recording-rule and alert-state metrics scrapeable
+again. See [Rules and alerting](../guides/rules-and-alerting.md).
 
 | Flag | Default | Description |
 | ---- | ------- | ----------- |
@@ -102,4 +101,4 @@ is for recording-rule and alert-state metrics to be scrapeable again — see
 | `--metric-ttl` | *(required)* | How long a series is retained after its last sample. |
 | `--drop-stale` | `false` | Drop series written with a `StaleNaN`. |
 
-It keeps everything in memory with a TTL sweep; it is not a storage system.
+Everything is in memory behind a TTL sweep; it is not a storage system.

--- a/docs/configuration/server-groups.md
+++ b/docs/configuration/server-groups.md
@@ -1,19 +1,13 @@
 # Server groups
 
-A **server group** is a set of Prometheus-API endpoints that hold the *same*
-data — the standard Prometheus HA pattern of N servers running an identical
-config. Promxy merges and deduplicates *within* a group, and scatter-gathers
-*across* groups.
-
-The single most important modelling rule:
+A **server group** is a set of Prometheus-API endpoints holding the *same*
+data — the standard HA pattern of N servers running an identical config. Promxy
+merges and deduplicates *within* a group, and scatter-gathers *across* groups.
 
 > Same data → same group. Different data → different groups.
 
-Putting servers with different data in one group causes silent
-under-counting, because promxy will dedup samples it believes are duplicates.
-Conversely, putting HA replicas in separate groups double-counts them.
-
-Configuration lives under `promxy.server_groups`:
+Different data in one group silently under-counts (promxy dedups samples it
+thinks are duplicates); HA replicas in separate groups double-count.
 
 ```yaml
 promxy:
@@ -45,8 +39,8 @@ Discovery is re-synced every 5s.
 
 ### `relabel_configs`
 
-Identical in syntax to Prometheus' scrape `relabel_configs`, but applied to the
-*downstream Prometheus targets* of this group. Two effects:
+Same syntax as Prometheus' scrape `relabel_configs`, applied to this group's
+*downstream Prometheus targets*:
 
 1. `keep`/`drop` decide which discovered hosts are in the group.
 2. Labels you set are added to every series returned by that target.
@@ -67,9 +61,8 @@ derive `path_prefix` from discovery metadata.
 
 ### `path_prefix`
 
-Prefix prepended to all request paths for hosts in this group. Useful for
-Prometheus servers behind a path-routing reverse proxy, or Mimir/Cortex
-(`/prometheus`).
+Prefix prepended to all request paths for this group. For servers behind a
+path-routing reverse proxy, or Mimir/Cortex (`/prometheus`).
 
 ```yaml
 path_prefix: /example/prefix
@@ -81,9 +74,8 @@ path_prefix: /example/prefix
 
 ### `name`
 
-Optional human-readable identifier. Shown in logs and exposed as the `name`
-label on the `server_group_targets` metric. The group's ordinal is always
-included regardless.
+Optional human-readable identifier, shown in logs and as the `name` label on
+`server_group_targets`. The ordinal is always included regardless.
 
 ```yaml
 name: primary-cluster
@@ -95,9 +87,9 @@ name: primary-cluster
 
 *Default: `10s`.*
 
-How large a gap in a timeseries must be before promxy will fill it with samples
-from another host in the same group. Best practice is to set this to your scrape
-interval. Full explanation: [HA and merging](../concepts/ha-and-merging.md).
+How large a gap must be before promxy fills it from another host in the group.
+Set it to your scrape interval. See
+[HA and merging](../concepts/ha-and-merging.md).
 
 ```yaml
 anti_affinity: 10s
@@ -107,26 +99,22 @@ anti_affinity: 10s
 
 *Default: `false`.*
 
-Infer the anti-affinity buffer per-series from the data's own inter-sample
-spacing (half the median gap), using `anti_affinity` only as a fallback when
-there are too few samples to estimate. Set this when a single group hosts
-metrics scraped at *different* intervals — a single static value is too tight
-for the slow series (gaps look like missed scrapes and get filled, doubling
-`count_over_time`) and too wide for the fast ones (fresh samples get deduped).
-See [issue #734](https://github.com/jacksontj/promxy/issues/734).
+Infer the buffer per-series from the data's inter-sample spacing (half the
+median gap), falling back to `anti_affinity` when there are too few samples.
+Set this when one group hosts metrics scraped at *different* intervals, where no
+single static value fits. See
+[issue #734](https://github.com/jacksontj/promxy/issues/734).
 
 ### `prefer_max`
 
 *Default: `false`.*
 
-When two hosts have a sample at the same timestamp, prefer the larger value
-instead of the default choice.
+When two hosts have a sample at the same timestamp, take the larger value.
 
 ### `labels`
 
-A label set added to every series returned from this group. Strongly recommended
-whenever you have more than one group, so that label-less aggregations
-(`count(up)`) remain attributable.
+Labels added to every series returned from this group. Recommended whenever you
+have more than one group, so `count(up)` and friends stay attributable.
 
 ```yaml
 labels:
@@ -135,10 +123,9 @@ labels:
 
 ### `metrics_relabel_configs`
 
-Rewrites the labels of *returned series*. Unlike Prometheus' relabeling, these
-run in the query path, so every action must be **reversible** — promxy has to
-rewrite the incoming query's matchers to match. That restricts the supported
-actions to:
+Rewrites the labels of *returned series*. These run in the query path, so every
+action must be **reversible** — promxy rewrites the incoming query's matchers to
+match. Supported actions:
 
 | Action      | Effect |
 | ----------- | ------ |
@@ -173,13 +160,12 @@ metrics_relabel_configs:
 Fetch raw data (matrix selectors like `foo[1h]`) through Prometheus' remote_read
 API instead of the JSON HTTP API.
 
-**Pros:** `StaleNaN` markers survive, roughly 2x faster, and it is the only path
-that preserves native histograms losslessly.
+**Pros:** `StaleNaN` markers survive, ~2x faster, and it is the only path that
+preserves native histograms losslessly.
 
-**Cons:** it is an "experimental" upstream API, protobuf marshalling on the
-Prometheus side doesn't stream (so the wire payload costs ~2x its in-memory size
-on the remote host), and some Prometheus-compatible backends don't implement it
-at all (notably VictoriaMetrics).
+**Cons:** "experimental" upstream API; protobuf marshalling on the Prometheus
+side doesn't stream, so the wire payload costs ~2x its in-memory size on the
+remote host; and some backends don't implement it (notably VictoriaMetrics).
 
 ```yaml
 remote_read: true
@@ -188,9 +174,9 @@ remote_read_path: api/v1/read   # default
 
 ### `native_histogram`
 
-Controls how promxy serves native-histogram queries against this group. The
-zero value (block omitted entirely) is "AST-only detection, fail loud when
-remote_read can't preserve fidelity".
+How promxy serves native-histogram queries against this group. Omitting the
+block means AST-only detection, failing loud when remote_read can't preserve
+fidelity.
 
 ```yaml
 native_histogram:
@@ -221,9 +207,9 @@ inject_matchers:
   - 'region=~"us-.*"'
 ```
 
-This effectively scopes the group to a subset of a shared downstream — the usual
-case is presenting a per-tenant view of a single merged backend (Mimir, Thanos,
-a big Prometheus). See [Multi-tenancy](../guides/multi-tenancy.md) and
+Scopes the group to a subset of a shared downstream; the usual case is a
+per-tenant view of one merged backend. See
+[Multi-tenancy](../guides/multi-tenancy.md) and
 [issue #698](https://github.com/jacksontj/promxy/issues/698).
 
 > **Not a security boundary.** It only mutates request matchers and relies on
@@ -231,11 +217,9 @@ a big Prometheus). See [Multi-tenancy](../guides/multi-tenancy.md) and
 
 ### `label_filter`
 
-Restricts which queries are sent to this downstream at all, by maintaining an
-in-memory filter of the labels the downstream actually has and skipping queries
-whose matchers can't possibly match. See
-[Label filtering](../guides/label-filtering.md) for the full reference and
-caveats.
+Skips queries whose matchers can't match this downstream, using an in-memory
+filter of the labels it actually has. Full reference:
+[Label filtering](../guides/label-filtering.md).
 
 ```yaml
 label_filter:
@@ -250,9 +234,8 @@ label_filter:
 
 ### `relative_time_range` / `absolute_time_range`
 
-Declare what time range this group actually holds data for, so promxy can skip
-it for queries outside that window. Both are optional, and `start`/`end` are
-individually optional.
+What time range this group holds data for, so promxy can skip it for queries
+outside that window. Both blocks are optional, as are `start`/`end` individually.
 
 ```yaml
 # a group holding only the last 3h, excluding the last 1h
@@ -273,8 +256,8 @@ group when the ranges only partially overlap.
 
 ### `query_params`
 
-Query parameters added to all HTTP calls to this downstream. The original
-use-case was `nocache=1` for VictoriaMetrics
+Query parameters added to all HTTP calls to this downstream, e.g. `nocache=1`
+for VictoriaMetrics
 ([issue #202](https://github.com/jacksontj/promxy/issues/202)).
 
 ```yaml
@@ -292,10 +275,9 @@ http_headers:
   X-Scope-OrgID: tenant-A
 ```
 
-> A server group represents endpoints holding the **same** data. When fanning
-> out across several Mimir/Cortex tenants, model each `(backend, tenant)` pair
-> as its own group rather than listing multiple tenants in one header —
-> otherwise label-less aggregations get under-counted. See
+> When fanning out across several Mimir/Cortex tenants, model each
+> `(backend, tenant)` pair as its own group rather than listing multiple tenants
+> in one header, or label-less aggregations get under-counted. See
 > [Multi-tenancy](../guides/multi-tenancy.md).
 
 ### `align_query_range_with_step`
@@ -303,11 +285,10 @@ http_headers:
 *Default: `false`.*
 
 Declares that this backend snaps `query_range` results to the epoch step grid
-(`k*step`), as Mimir and Cortex do by default. Promxy then re-stamps returned
-samples onto the grid implied by the request start (`start + j*step`) so they
-line up with promxy's local evaluation grid.
+(`k*step`), as Mimir and Cortex do. Promxy then re-stamps returned samples onto
+the grid implied by the request start (`start + j*step`).
 
-Leave it **off** for backends that don't step-align (vanilla Prometheus) — their
+Leave it **off** for backends that don't step-align (vanilla Prometheus); their
 samples already sit on the requested grid. Without it, an unaligned request
 (`start % step != 0`) whose off-grid distance exceeds the lookback delta yields
 no data from a step-aligning backend. See
@@ -315,23 +296,18 @@ no data from a step-aligning backend. See
 
 ## Error handling
 
-Promxy's default is to **return an error** when a group fails. If every node in
-a group is down, the result would be silently missing data — and since alerting
-may depend on it, an error is safer than a wrong answer.
-
-Two options trade consistency for availability:
+By default a failing group **fails the query**: missing data is worse than an
+error when alerting depends on it. Two options trade that for availability.
 
 ### `ignore_error`
 
-*Default: `false`.* Makes this group's response optional: if it errors and
-others don't, the overall query still succeeds. Errors are hidden entirely.
+*Default: `false`.* Makes this group's response optional — if it errors and
+others don't, the query still succeeds. Errors are hidden entirely.
 
 ### `downgrade_error`
 
-*Default: `false`.* Same availability effect, but errors are converted to
-**warnings** attached to the response rather than being dropped. Prefer this
-over `ignore_error` when your clients surface warnings — you keep the
-availability without losing the signal.
+*Default: `false`.* Same effect, but errors become **warnings** on the response
+instead of being dropped. Prefer this if your clients surface warnings.
 
 ## HTTP client
 
@@ -360,15 +336,15 @@ http_client:
 
 `http_client` also inlines Prometheus'
 [`http_client_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_config)
-— `tls_config`, `basic_auth`, `authorization`, `bearer_token`,
-`bearer_token_file`, `proxy_url`, `follow_redirects`, … — plus a `sigv4` block
-for AWS-signed requests (Amazon Managed Prometheus).
+(`tls_config`, `basic_auth`, `authorization`, `bearer_token`,
+`bearer_token_file`, `proxy_url`, `follow_redirects`, …) plus a `sigv4` block
+for AWS-signed requests.
 
-**At most one** authentication method may be configured per group: `basic_auth`,
-`authorization`, `bearer_token`, `bearer_token_file`, or `sigv4`. Configuring
-more than one is a config error.
+**At most one** auth method per group — `basic_auth`, `authorization`,
+`bearer_token`, `bearer_token_file`, or `sigv4`. More than one is a config
+error.
 
 ## Full example
 
-See [`cmd/promxy/config.yaml`](../../cmd/promxy/config.yaml) for an annotated
-config exercising essentially every option above.
+[`cmd/promxy/config.yaml`](../../cmd/promxy/config.yaml) is an annotated config
+exercising essentially every option above.

--- a/docs/configuration/server-groups.md
+++ b/docs/configuration/server-groups.md
@@ -1,0 +1,374 @@
+# Server groups
+
+A **server group** is a set of Prometheus-API endpoints that hold the *same*
+data — the standard Prometheus HA pattern of N servers running an identical
+config. Promxy merges and deduplicates *within* a group, and scatter-gathers
+*across* groups.
+
+The single most important modelling rule:
+
+> Same data → same group. Different data → different groups.
+
+Putting servers with different data in one group causes silent
+under-counting, because promxy will dedup samples it believes are duplicates.
+Conversely, putting HA replicas in separate groups double-counts them.
+
+Configuration lives under `promxy.server_groups`:
+
+```yaml
+promxy:
+  server_groups:
+    - static_configs:
+        - targets: [prometheus-01:9090, prometheus-02:9090]
+      anti_affinity: 10s
+```
+
+Defaults below are from `servergroup.DefaultConfig`
+([`pkg/servergroup/config.go`](../../pkg/servergroup/config.go)).
+
+## Target discovery
+
+### Service discovery
+
+Any Prometheus service-discovery mechanism can be used inline, with the same
+markup as a Prometheus scrape config. The targets discovered are the
+**Prometheus servers**, not scrape targets.
+
+```yaml
+- kubernetes_sd_configs:
+    - role: pod
+      namespaces:
+        names: [monitoring]
+```
+
+Discovery is re-synced every 5s.
+
+### `relabel_configs`
+
+Identical in syntax to Prometheus' scrape `relabel_configs`, but applied to the
+*downstream Prometheus targets* of this group. Two effects:
+
+1. `keep`/`drop` decide which discovered hosts are in the group.
+2. Labels you set are added to every series returned by that target.
+
+```yaml
+relabel_configs:
+  - source_labels: [__meta_consul_tags]
+    regex: '.*,prod,.*'
+    action: keep
+  - source_labels: [__meta_consul_dc]
+    regex: '.+'
+    action: replace
+    target_label: datacenter
+```
+
+The special label `__path_prefix__` sets the per-target path prefix, letting you
+derive `path_prefix` from discovery metadata.
+
+### `path_prefix`
+
+Prefix prepended to all request paths for hosts in this group. Useful for
+Prometheus servers behind a path-routing reverse proxy, or Mimir/Cortex
+(`/prometheus`).
+
+```yaml
+path_prefix: /example/prefix
+```
+
+### `scheme`
+
+`http` (default) or `https`.
+
+### `name`
+
+Optional human-readable identifier. Shown in logs and exposed as the `name`
+label on the `server_group_targets` metric. The group's ordinal is always
+included regardless.
+
+```yaml
+name: primary-cluster
+```
+
+## Merging and result shaping
+
+### `anti_affinity`
+
+*Default: `10s`.*
+
+How large a gap in a timeseries must be before promxy will fill it with samples
+from another host in the same group. Best practice is to set this to your scrape
+interval. Full explanation: [HA and merging](../concepts/ha-and-merging.md).
+
+```yaml
+anti_affinity: 10s
+```
+
+### `anti_affinity_dynamic`
+
+*Default: `false`.*
+
+Infer the anti-affinity buffer per-series from the data's own inter-sample
+spacing (half the median gap), using `anti_affinity` only as a fallback when
+there are too few samples to estimate. Set this when a single group hosts
+metrics scraped at *different* intervals — a single static value is too tight
+for the slow series (gaps look like missed scrapes and get filled, doubling
+`count_over_time`) and too wide for the fast ones (fresh samples get deduped).
+See [issue #734](https://github.com/jacksontj/promxy/issues/734).
+
+### `prefer_max`
+
+*Default: `false`.*
+
+When two hosts have a sample at the same timestamp, prefer the larger value
+instead of the default choice.
+
+### `labels`
+
+A label set added to every series returned from this group. Strongly recommended
+whenever you have more than one group, so that label-less aggregations
+(`count(up)`) remain attributable.
+
+```yaml
+labels:
+  sg: localhost_9090
+```
+
+### `metrics_relabel_configs`
+
+Rewrites the labels of *returned series*. Unlike Prometheus' relabeling, these
+run in the query path, so every action must be **reversible** — promxy has to
+rewrite the incoming query's matchers to match. That restricts the supported
+actions to:
+
+| Action      | Effect |
+| ----------- | ------ |
+| `labeldrop` | Drop `source_label` from results |
+| `replace`   | Rename `source_label` to `target_label` |
+| `lowercase` | Lowercase `source_label` into `target_label` |
+| `uppercase` | Uppercase `source_label` into `target_label` |
+
+Rules execute in order and compound.
+
+```yaml
+metrics_relabel_configs:
+  # drop the `replica` label -> replica deduplication, thanos-style
+  - action: labeldrop
+    source_label: replica
+  # rename job -> scrape_job
+  - action: replace
+    source_label: job
+    target_label: scrape_job
+  # lowercase in place
+  - action: lowercase
+    source_label: branch
+    target_label: branch
+```
+
+## Query routing
+
+### `remote_read`
+
+*Default: `false`.*
+
+Fetch raw data (matrix selectors like `foo[1h]`) through Prometheus' remote_read
+API instead of the JSON HTTP API.
+
+**Pros:** `StaleNaN` markers survive, roughly 2x faster, and it is the only path
+that preserves native histograms losslessly.
+
+**Cons:** it is an "experimental" upstream API, protobuf marshalling on the
+Prometheus side doesn't stream (so the wire payload costs ~2x its in-memory size
+on the remote host), and some Prometheus-compatible backends don't implement it
+at all (notably VictoriaMetrics).
+
+```yaml
+remote_read: true
+remote_read_path: api/v1/read   # default
+```
+
+### `native_histogram`
+
+Controls how promxy serves native-histogram queries against this group. The
+zero value (block omitted entirely) is "AST-only detection, fail loud when
+remote_read can't preserve fidelity".
+
+```yaml
+native_histogram:
+  metadata_refresh: 5m
+  allow_lossy: false
+```
+
+- **`metadata_refresh`** *(default: unset/0)* — enables a metric-name → type
+  cache built from `/api/v1/metadata`, so queries touching histogram metrics
+  *without* calling a histogram-only function (e.g. `rate(my_hist[5m])`) are
+  also routed via remote_read. Unset means pure AST detection.
+- **`allow_lossy`** *(default: `false`)* — what to do when a histogram-bearing
+  query hits this group and `remote_read` is not configured. `false` errors out
+  before fan-out; `true` serves the query over the lossy JSON path anyway.
+
+Full explanation: [Native histograms](../guides/native-histograms.md).
+
+### `inject_matchers`
+
+Label matchers injected into **every** selector of every request sent to this
+group — including queries that never reference those labels (`count(up)` is sent
+downstream as `count(up{cluster="A"})`). Each entry is one matcher in PromQL
+syntax, without enclosing braces.
+
+```yaml
+inject_matchers:
+  - 'cluster="A"'
+  - 'region=~"us-.*"'
+```
+
+This effectively scopes the group to a subset of a shared downstream — the usual
+case is presenting a per-tenant view of a single merged backend (Mimir, Thanos,
+a big Prometheus). See [Multi-tenancy](../guides/multi-tenancy.md) and
+[issue #698](https://github.com/jacksontj/promxy/issues/698).
+
+> **Not a security boundary.** It only mutates request matchers and relies on
+> the downstream honouring them.
+
+### `label_filter`
+
+Restricts which queries are sent to this downstream at all, by maintaining an
+in-memory filter of the labels the downstream actually has and skipping queries
+whose matchers can't possibly match. See
+[Label filtering](../guides/label-filtering.md) for the full reference and
+caveats.
+
+```yaml
+label_filter:
+  dynamic_labels: [__name__, job]
+  sync_interval: 5m
+  static_labels_include:
+    instance: [instance1]
+  static_labels_exclude:
+    __name__: [up]
+  on_sync_error: abort   # abort | open | closed
+```
+
+### `relative_time_range` / `absolute_time_range`
+
+Declare what time range this group actually holds data for, so promxy can skip
+it for queries outside that window. Both are optional, and `start`/`end` are
+individually optional.
+
+```yaml
+# a group holding only the last 3h, excluding the last 1h
+relative_time_range:
+  start: -3h
+  end: -1h
+  truncate: false
+
+# a deprecated group that stopped receiving data
+absolute_time_range:
+  start: '2009-10-10T23:00:00Z'
+  end: '2009-10-11T23:00:00Z'
+  truncate: true
+```
+
+`truncate` clamps a query's range to the group's window rather than skipping the
+group when the ranges only partially overlap.
+
+### `query_params`
+
+Query parameters added to all HTTP calls to this downstream. The original
+use-case was `nocache=1` for VictoriaMetrics
+([issue #202](https://github.com/jacksontj/promxy/issues/202)).
+
+```yaml
+query_params:
+  nocache: 1
+```
+
+### `http_headers`
+
+HTTP headers added to calls to this downstream. Primarily `X-Scope-OrgID` for
+Mimir/Cortex multi-tenancy.
+
+```yaml
+http_headers:
+  X-Scope-OrgID: tenant-A
+```
+
+> A server group represents endpoints holding the **same** data. When fanning
+> out across several Mimir/Cortex tenants, model each `(backend, tenant)` pair
+> as its own group rather than listing multiple tenants in one header —
+> otherwise label-less aggregations get under-counted. See
+> [Multi-tenancy](../guides/multi-tenancy.md).
+
+### `align_query_range_with_step`
+
+*Default: `false`.*
+
+Declares that this backend snaps `query_range` results to the epoch step grid
+(`k*step`), as Mimir and Cortex do by default. Promxy then re-stamps returned
+samples onto the grid implied by the request start (`start + j*step`) so they
+line up with promxy's local evaluation grid.
+
+Leave it **off** for backends that don't step-align (vanilla Prometheus) — their
+samples already sit on the requested grid. Without it, an unaligned request
+(`start % step != 0`) whose off-grid distance exceeds the lookback delta yields
+no data from a step-aligning backend. See
+[issue #787](https://github.com/jacksontj/promxy/issues/787).
+
+## Error handling
+
+Promxy's default is to **return an error** when a group fails. If every node in
+a group is down, the result would be silently missing data — and since alerting
+may depend on it, an error is safer than a wrong answer.
+
+Two options trade consistency for availability:
+
+### `ignore_error`
+
+*Default: `false`.* Makes this group's response optional: if it errors and
+others don't, the overall query still succeeds. Errors are hidden entirely.
+
+### `downgrade_error`
+
+*Default: `false`.* Same availability effect, but errors are converted to
+**warnings** attached to the response rather than being dropped. Prefer this
+over `ignore_error` when your clients surface warnings — you keep the
+availability without losing the signal.
+
+## HTTP client
+
+```yaml
+timeout: 5s
+max_idle_conns: 20000
+max_idle_conns_per_host: 1000
+idle_conn_timeout: 300s
+http_client:
+  dial_timeout: 1s
+  dial_network: tcp
+  fallback_delay: 50ms
+  tls_config:
+    insecure_skip_verify: true
+```
+
+| Option | Default | Meaning |
+| ------ | ------- | ------- |
+| `timeout` | `0` (none) | Time to wait for response headers after fully writing the request. Does **not** include reading the response body. |
+| `max_idle_conns` | `20000` | Max idle connections kept open for the group. |
+| `max_idle_conns_per_host` | `1000` | Max idle connections per host. |
+| `idle_conn_timeout` | `5m` | How long an idle connection is kept. |
+| `http_client.dial_timeout` | `200ms` | Connection establishment timeout. |
+| `http_client.dial_network` | `tcp` | `tcp` (dual-stack), `tcp4`, or `tcp6`. Use `tcp4` to work around downstreams whose DNS resolves to an unreachable IPv6 address. |
+| `http_client.fallback_delay` | Go default (`300ms`) | RFC 6555 "Happy Eyeballs" delay before trying the other address family. Negative disables the fallback. Must be **shorter than `dial_timeout`** to have any effect. |
+
+`http_client` also inlines Prometheus'
+[`http_client_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_config)
+— `tls_config`, `basic_auth`, `authorization`, `bearer_token`,
+`bearer_token_file`, `proxy_url`, `follow_redirects`, … — plus a `sigv4` block
+for AWS-signed requests (Amazon Managed Prometheus).
+
+**At most one** authentication method may be configured per group: `basic_auth`,
+`authorization`, `bearer_token`, `bearer_token_file`, or `sigv4`. Configuring
+more than one is a config error.
+
+## Full example
+
+See [`cmd/promxy/config.yaml`](../../cmd/promxy/config.yaml) for an annotated
+config exercising essentially every option above.

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,47 +6,27 @@
 cd cmd/promxy && go build -mod=vendor -tags netgo,builtinassets
 ```
 
-Both build tags matter:
-
-- **`builtinassets`** embeds the Prometheus web UI assets. Without it the UI is
-  broken at runtime.
-- **`netgo`** uses the pure-Go resolver, producing a static binary.
-
-`-mod=vendor` is required — dependencies are vendored (see below).
-
-Release builds for all platforms:
+Both tags matter: `builtinassets` embeds the web UI assets (without it the UI
+is broken at runtime), `netgo` uses the pure-Go resolver for a static binary.
+`-mod=vendor` is required; dependencies are vendored.
 
 ```
-make release
-```
-
-which runs [`build.bash`](../build.bash) for both `cmd/promxy` and
-`cmd/remote_write_exporter`, writing to `build/`.
-
-Container image:
-
-```
+make release          # build.bash for both binaries -> build/
 docker build -t promxy .
 ```
 
-The [`Dockerfile`](../Dockerfile) cross-compiles both binaries and produces an
-Alpine image running as `nobody`.
+The [`Dockerfile`](../Dockerfile) cross-compiles both binaries into an Alpine
+image running as `nobody`.
 
 ## Testing
 
 ```
-make test
+make test   # go test -race -mod=vendor -tags netgo,builtinassets ./...
 ```
 
-which is:
-
-```
-go test -race -mod=vendor -tags netgo,builtinassets ./...
-```
-
-The `test/` directory holds the integration suite — PromQL correctness against
-real downstreams, remote_read, remote_write, exemplars, federation — plus
-benchmarks in `promql_bench_test.go`.
+`test/` holds the integration suite (PromQL correctness against real
+downstreams, remote_read, remote_write, exemplars, federation) plus benchmarks
+in `promql_bench_test.go`.
 
 ## Lint and formatting
 
@@ -58,14 +38,13 @@ make imports       # goimports -local=github.com/jacksontj/promxy
 make static-check  # staticcheck ./...
 ```
 
-`make fmt` and `make imports` rewrite files in place; CI runs them and then
+`make fmt` and `make imports` rewrite in place; CI runs them then
 `git diff --exit-code`, so an unformatted tree fails.
 
-`goimports` is configured with `-local=github.com/jacksontj/promxy`, which puts
-promxy's own packages in their own import group after third-party ones. Match
-the existing grouping in any file you touch.
+`-local=github.com/jacksontj/promxy` puts promxy's own packages in their own
+import group after third-party ones. Match the existing grouping.
 
-Install the tools with:
+Install the tools:
 
 ```
 go install golang.org/x/tools/cmd/goimports@latest
@@ -79,46 +58,37 @@ staticcheck, and tests on every push to `master` and every PR.
 [`.github/workflows/build.yml`](../.github/workflows/build.yml) builds the
 multi-arch image.
 
-The build cache is seeded from `master`: `master` runs write a fresh cache entry
-keyed by run ID, and PR runs restore the most recent one but never write. So
-every PR builds and tests off `master`'s warm cache and only recompiles what it
-changed.
+The build cache is seeded from `master`: `master` runs write a fresh entry keyed
+by run ID, PR runs restore the most recent one but never write. Every PR builds
+off `master`'s warm cache and only recompiles what it changed.
 
 ## The Prometheus fork
 
-Promxy uses a **fork** of Prometheus rather than upstream, because it needs
-hooks upstream doesn't expose — most importantly the PromQL engine's
-`NodeReplacer`, which is how promxy pushes query fragments down to its
-downstreams (see [Architecture](concepts/architecture.md)).
+Promxy uses a **fork** of Prometheus for hooks upstream doesn't expose, chiefly
+the PromQL engine's `NodeReplacer` (see
+[Architecture](concepts/architecture.md)).
 
-The fork is pinned via a `replace` directive in `go.mod`. To move to a new fork
-version:
+The fork is pinned by a `replace` in `go.mod`. To move to a new version:
 
 ```
 make update-prom-fork
 ```
 
-which edits the `replace` to point at the new
-`github.com/jacksontj/prometheus` tag and re-vendors. Update the tag inside the
-Makefile target when bumping.
+This repoints the `replace` at a `github.com/jacksontj/prometheus` tag and
+re-vendors; update the tag in the Makefile target when bumping.
 
-Bumping the fork usually also means re-vendoring the web UI assets — the
-`mantine-ui` build has to be present in the fork *and* in promxy's `vendor/`, or
+Bumping usually also means re-vendoring the web UI assets: the `mantine-ui`
+build must be present in the fork *and* in promxy's `vendor/`, or
 `builtinassets` builds produce a broken UI.
 
 ## Vendoring
 
-Dependencies are vendored and committed. After changing `go.mod`:
+Dependencies are vendored and committed. After changing `go.mod`, run
+`make vendor` (`go mod tidy` then `go mod vendor`) and commit `vendor/` along
+with `go.mod`/`go.sum`.
 
-```
-make vendor
-```
-
-which runs `go mod tidy` followed by `go mod vendor`. Commit the `vendor/`
-changes along with `go.mod`/`go.sum`.
-
-[`go_mod_tidy_hack.go`](../go_mod_tidy_hack.go) exists to keep `go mod tidy`
-from dropping dependencies that are only needed by the fork.
+[`go_mod_tidy_hack.go`](../go_mod_tidy_hack.go) keeps `go mod tidy` from
+dropping dependencies only the fork needs.
 
 ## Repository layout
 
@@ -128,7 +98,7 @@ from dropping dependencies that are only needed by the fork.
 | `cmd/remote_write_exporter` | Companion binary that re-exposes received remote_write on `/metrics` |
 | `pkg/config` | Top-level config: Prometheus config + the `promxy` section |
 | `pkg/servergroup` | Server group: discovery, per-target client stack, config |
-| `pkg/promclient` | The API client decorators — merging, relabeling, filtering, error handling, matcher injection |
+| `pkg/promclient` | API client decorators: merging, relabeling, filtering, error handling, matcher injection |
 | `pkg/proxystorage` | `storage.Storage` implementation; `NodeReplacer` pushdown; histogram routing |
 | `pkg/proxyquerier` | `storage.Querier` / `ChunkQuerier` over the server groups |
 | `pkg/promhttputil` | Merge primitives, including the anti-affinity algorithm |
@@ -142,20 +112,18 @@ from dropping dependencies that are only needed by the fork.
 | `test/` | Integration tests and benchmarks |
 | `deploy/` | docker-compose, Kubernetes manifests, Helm chart |
 
-Two places are worth reading before changing query behaviour:
+Read these before changing query behaviour:
 
-- `pkg/proxystorage/proxy.go` — `NodeReplacer`, and the rules governing when a
-  query fragment may be pushed down. The comments there carry the reasoning for
-  each non-obvious case.
+- `pkg/proxystorage/proxy.go` — `NodeReplacer` and the pushdown rules. The
+  comments carry the reasoning for each non-obvious case.
 - `pkg/promhttputil/merge.go` — `MergeSampleStream`, the anti-affinity merge.
   Subtle and heavily tested; change it with tests in hand.
 
 ## Contributing
 
-Feedback, bug reports, and feature requests are all welcome — open an
+Bug reports and feature requests welcome — open an
 [issue](https://github.com/jacksontj/promxy/issues).
 
 For pull requests: keep `make fmt`, `make imports`, `make static-check`, and
 `make test` green, and include tests for behaviour changes. If your change
-touches merging or pushdown, say explicitly in the PR what correctness argument
-makes it safe.
+touches merging or pushdown, state the correctness argument in the PR.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,161 @@
+# Development
+
+## Building
+
+```
+cd cmd/promxy && go build -mod=vendor -tags netgo,builtinassets
+```
+
+Both build tags matter:
+
+- **`builtinassets`** embeds the Prometheus web UI assets. Without it the UI is
+  broken at runtime.
+- **`netgo`** uses the pure-Go resolver, producing a static binary.
+
+`-mod=vendor` is required — dependencies are vendored (see below).
+
+Release builds for all platforms:
+
+```
+make release
+```
+
+which runs [`build.bash`](../build.bash) for both `cmd/promxy` and
+`cmd/remote_write_exporter`, writing to `build/`.
+
+Container image:
+
+```
+docker build -t promxy .
+```
+
+The [`Dockerfile`](../Dockerfile) cross-compiles both binaries and produces an
+Alpine image running as `nobody`.
+
+## Testing
+
+```
+make test
+```
+
+which is:
+
+```
+go test -race -mod=vendor -tags netgo,builtinassets ./...
+```
+
+The `test/` directory holds the integration suite — PromQL correctness against
+real downstreams, remote_read, remote_write, exemplars, federation — plus
+benchmarks in `promql_bench_test.go`.
+
+## Lint and formatting
+
+CI fails on any of these, so run them before pushing:
+
+```
+make fmt           # gofmt -w -s
+make imports       # goimports -local=github.com/jacksontj/promxy
+make static-check  # staticcheck ./...
+```
+
+`make fmt` and `make imports` rewrite files in place; CI runs them and then
+`git diff --exit-code`, so an unformatted tree fails.
+
+`goimports` is configured with `-local=github.com/jacksontj/promxy`, which puts
+promxy's own packages in their own import group after third-party ones. Match
+the existing grouping in any file you touch.
+
+Install the tools with:
+
+```
+go install golang.org/x/tools/cmd/goimports@latest
+go install honnef.co/go/tools/cmd/staticcheck@latest
+```
+
+## CI
+
+[`.github/workflows/go.yml`](../.github/workflows/go.yml) runs fmt, imports,
+staticcheck, and tests on every push to `master` and every PR.
+[`.github/workflows/build.yml`](../.github/workflows/build.yml) builds the
+multi-arch image.
+
+The build cache is seeded from `master`: `master` runs write a fresh cache entry
+keyed by run ID, and PR runs restore the most recent one but never write. So
+every PR builds and tests off `master`'s warm cache and only recompiles what it
+changed.
+
+## The Prometheus fork
+
+Promxy uses a **fork** of Prometheus rather than upstream, because it needs
+hooks upstream doesn't expose — most importantly the PromQL engine's
+`NodeReplacer`, which is how promxy pushes query fragments down to its
+downstreams (see [Architecture](concepts/architecture.md)).
+
+The fork is pinned via a `replace` directive in `go.mod`. To move to a new fork
+version:
+
+```
+make update-prom-fork
+```
+
+which edits the `replace` to point at the new
+`github.com/jacksontj/prometheus` tag and re-vendors. Update the tag inside the
+Makefile target when bumping.
+
+Bumping the fork usually also means re-vendoring the web UI assets — the
+`mantine-ui` build has to be present in the fork *and* in promxy's `vendor/`, or
+`builtinassets` builds produce a broken UI.
+
+## Vendoring
+
+Dependencies are vendored and committed. After changing `go.mod`:
+
+```
+make vendor
+```
+
+which runs `go mod tidy` followed by `go mod vendor`. Commit the `vendor/`
+changes along with `go.mod`/`go.sum`.
+
+[`go_mod_tidy_hack.go`](../go_mod_tidy_hack.go) exists to keep `go mod tidy`
+from dropping dependencies that are only needed by the fork.
+
+## Repository layout
+
+| Path | Contents |
+| ---- | -------- |
+| `cmd/promxy` | The promxy binary; flags, wiring, the annotated example config |
+| `cmd/remote_write_exporter` | Companion binary that re-exposes received remote_write on `/metrics` |
+| `pkg/config` | Top-level config: Prometheus config + the `promxy` section |
+| `pkg/servergroup` | Server group: discovery, per-target client stack, config |
+| `pkg/promclient` | The API client decorators — merging, relabeling, filtering, error handling, matcher injection |
+| `pkg/proxystorage` | `storage.Storage` implementation; `NodeReplacer` pushdown; histogram routing |
+| `pkg/proxyquerier` | `storage.Querier` / `ChunkQuerier` over the server groups |
+| `pkg/promhttputil` | Merge primitives, including the anti-affinity algorithm |
+| `pkg/promapi` | Low-level Prometheus API client and decoding |
+| `pkg/alertbackfill` | Recomputing alert state at startup (`--rules.alertbackfill`) |
+| `pkg/alerttemplate` | Configurable alert `GeneratorURL` templates |
+| `pkg/federate` | Promxy's `/federate` handler |
+| `pkg/server` | HTTP server, TLS/web config, access logging |
+| `pkg/middleware` | Header proxying (`--proxy-headers`) |
+| `pkg/logging` | Bridges the Prometheus libraries' loggers onto logrus |
+| `test/` | Integration tests and benchmarks |
+| `deploy/` | docker-compose, Kubernetes manifests, Helm chart |
+
+Two places are worth reading before changing query behaviour:
+
+- `pkg/proxystorage/proxy.go` — `NodeReplacer`, and the rules governing when a
+  query fragment may be pushed down. The comments there carry the reasoning for
+  each non-obvious case.
+- `pkg/promhttputil/merge.go` — `MergeSampleStream`, the anti-affinity merge.
+  Subtle and heavily tested; change it with tests in hand.
+
+## Contributing
+
+Feedback, bug reports, and feature requests are all welcome — open an
+[issue](https://github.com/jacksontj/promxy/issues).
+
+For pull requests: keep `make fmt`, `make imports`, `make static-check`, and
+`make test` green, and include tests for behaviour changes. If your change
+touches merging or pushdown, say explicitly in the PR what correctness argument
+makes it safe.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,8 +4,7 @@
 
 ### Release binary
 
-Prebuilt binaries for each release are on the
-[releases page](https://github.com/jacksontj/promxy/releases).
+Prebuilt binaries: [releases page](https://github.com/jacksontj/promxy/releases).
 
 ### Container image
 
@@ -13,8 +12,7 @@ Prebuilt binaries for each release are on the
 docker pull quay.io/jacksontj/promxy
 ```
 
-The image also ships `remote_write_exporter` at `/bin/remote_write_exporter`;
-the entrypoint is `/bin/promxy`.
+Entrypoint is `/bin/promxy`; the image also ships `/bin/remote_write_exporter`.
 
 ### From source
 
@@ -23,17 +21,14 @@ git clone git@github.com:jacksontj/promxy.git
 cd promxy/cmd/promxy && go build -mod=vendor -tags netgo,builtinassets
 ```
 
-Both build tags matter: `builtinassets` embeds the web UI (without it the UI
-returns errors), and `netgo` gives you a static binary. See
-[Development](development.md) for the full build/test workflow.
+Both tags matter: `builtinassets` embeds the web UI (without it the UI errors),
+`netgo` gives a static binary. See [Development](development.md).
 
 ## A minimal config
 
 Promxy's config file is a **Prometheus config file** with an extra top-level
-`promxy` key. That means `global`, `rule_files`, `alerting`, and `remote_write`
-all behave exactly as they do in Prometheus.
-
-The smallest useful config points at one group of Prometheus servers:
+`promxy` key, so `global`, `rule_files`, `alerting`, and `remote_write` behave
+as they do in Prometheus.
 
 ```yaml
 promxy:
@@ -45,12 +40,11 @@ promxy:
       anti_affinity: 10s
 ```
 
-Those two hosts are one *server group*: a set of Prometheus servers scraping
-the **same** targets with the **same** config (the standard Prometheus HA
-pattern). Promxy merges their data, filling gaps in one from the other. See
-[HA and merging](concepts/ha-and-merging.md).
+Those two hosts are one *server group*: Prometheus servers scraping the **same**
+targets with the **same** config. Promxy merges their data, filling gaps in one
+from the other. See [HA and merging](concepts/ha-and-merging.md).
 
-Validate it before starting:
+Validate before starting:
 
 ```
 ./promxy --config=config.yaml --check-config
@@ -62,21 +56,20 @@ Validate it before starting:
 ./promxy --config=config.yaml
 ```
 
-Promxy listens on `:8082` by default. Open <http://localhost:8082> for the
-Prometheus UI, or query the API directly:
+Promxy listens on `:8082`. Open <http://localhost:8082> for the Prometheus UI,
+or query directly:
 
 ```
 curl 'http://localhost:8082/api/v1/query?query=up'
 ```
 
-Point Grafana at `http://localhost:8082` as a Prometheus datasource and you get
-a single, globally-aggregatable view of every server group.
+Point Grafana at `http://localhost:8082` as a Prometheus datasource for a single
+aggregatable view of every server group.
 
 ## Adding more shards
 
-Each additional *shard* of your infrastructure is another server group. Add a
-`labels` block so results from different groups stay distinguishable — this
-matters for label-less aggregations like `count(up)`:
+Each shard is another server group. Add `labels` so results stay
+distinguishable — this is what keeps `count(up)` correct:
 
 ```yaml
 promxy:
@@ -96,14 +89,14 @@ promxy:
 
 Every query is scatter-gathered to all groups and the results merged.
 
-Any Prometheus service-discovery mechanism works in place of `static_configs`
-(`consul_sd_configs`, `kubernetes_sd_configs`, `file_sd_configs`, …) — the
+Any Prometheus service discovery works in place of `static_configs`
+(`consul_sd_configs`, `kubernetes_sd_configs`, `file_sd_configs`, …). The
 targets discovered are the *Prometheus servers*, not scrape targets.
 
-## Where to go next
+## Next
 
 - [Configuration overview](configuration/README.md) — the rest of the config file
 - [Server groups](configuration/server-groups.md) — every per-group option
-- [Rules and alerting](guides/rules-and-alerting.md) — note that recording rules
-  and alert-state metrics require a `remote_write` endpoint
+- [Rules and alerting](guides/rules-and-alerting.md) — recording rules and alert
+  state need a `remote_write` endpoint
 - [Running promxy](operations/running.md) — endpoints, reloads, shutdown

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,109 @@
+# Getting started
+
+## Install
+
+### Release binary
+
+Prebuilt binaries for each release are on the
+[releases page](https://github.com/jacksontj/promxy/releases).
+
+### Container image
+
+```
+docker pull quay.io/jacksontj/promxy
+```
+
+The image also ships `remote_write_exporter` at `/bin/remote_write_exporter`;
+the entrypoint is `/bin/promxy`.
+
+### From source
+
+```
+git clone git@github.com:jacksontj/promxy.git
+cd promxy/cmd/promxy && go build -mod=vendor -tags netgo,builtinassets
+```
+
+Both build tags matter: `builtinassets` embeds the web UI (without it the UI
+returns errors), and `netgo` gives you a static binary. See
+[Development](development.md) for the full build/test workflow.
+
+## A minimal config
+
+Promxy's config file is a **Prometheus config file** with an extra top-level
+`promxy` key. That means `global`, `rule_files`, `alerting`, and `remote_write`
+all behave exactly as they do in Prometheus.
+
+The smallest useful config points at one group of Prometheus servers:
+
+```yaml
+promxy:
+  server_groups:
+    - static_configs:
+        - targets:
+            - prometheus-01:9090
+            - prometheus-02:9090
+      anti_affinity: 10s
+```
+
+Those two hosts are one *server group*: a set of Prometheus servers scraping
+the **same** targets with the **same** config (the standard Prometheus HA
+pattern). Promxy merges their data, filling gaps in one from the other. See
+[HA and merging](concepts/ha-and-merging.md).
+
+Validate it before starting:
+
+```
+./promxy --config=config.yaml --check-config
+```
+
+## Run it
+
+```
+./promxy --config=config.yaml
+```
+
+Promxy listens on `:8082` by default. Open <http://localhost:8082> for the
+Prometheus UI, or query the API directly:
+
+```
+curl 'http://localhost:8082/api/v1/query?query=up'
+```
+
+Point Grafana at `http://localhost:8082` as a Prometheus datasource and you get
+a single, globally-aggregatable view of every server group.
+
+## Adding more shards
+
+Each additional *shard* of your infrastructure is another server group. Add a
+`labels` block so results from different groups stay distinguishable — this
+matters for label-less aggregations like `count(up)`:
+
+```yaml
+promxy:
+  server_groups:
+    - static_configs:
+        - targets: [prometheus-us-01:9090, prometheus-us-02:9090]
+      labels:
+        region: us
+      anti_affinity: 10s
+
+    - static_configs:
+        - targets: [prometheus-eu-01:9090, prometheus-eu-02:9090]
+      labels:
+        region: eu
+      anti_affinity: 10s
+```
+
+Every query is scatter-gathered to all groups and the results merged.
+
+Any Prometheus service-discovery mechanism works in place of `static_configs`
+(`consul_sd_configs`, `kubernetes_sd_configs`, `file_sd_configs`, …) — the
+targets discovered are the *Prometheus servers*, not scrape targets.
+
+## Where to go next
+
+- [Configuration overview](configuration/README.md) — the rest of the config file
+- [Server groups](configuration/server-groups.md) — every per-group option
+- [Rules and alerting](guides/rules-and-alerting.md) — note that recording rules
+  and alert-state metrics require a `remote_write` endpoint
+- [Running promxy](operations/running.md) — endpoints, reloads, shutdown

--- a/docs/guides/label-filtering.md
+++ b/docs/guides/label-filtering.md
@@ -1,16 +1,13 @@
 # Label filtering
 
-By default promxy scatter-gathers every query to every server group. That is
-usually fine — the fan-out is cheap and the downstreams answer in parallel — but
-when you have many shards and most queries only concern one of them, you are
-paying for a lot of requests that can only ever return nothing.
+Promxy scatter-gathers every query to every server group. With many shards,
+most of those requests can only ever return nothing.
 
 `label_filter` maintains an in-memory picture of which label values a downstream
-actually has, and skips groups whose filter proves the query can't match.
+has, and skips groups whose filter proves the query can't match.
 
-> **This is not a security mechanism.** It works entirely from the query's
-> matchers, so a caller can trivially sidestep it by matching on a different
-> label. See [Security](security.md) for real isolation.
+> **Not a security mechanism.** It works from the query's matchers, so a caller
+> can sidestep it by matching on a different label. See [Security](security.md).
 
 ## Configuration
 
@@ -20,21 +17,16 @@ promxy:
     - static_configs:
         - targets: [prom-us-01:9090]
       label_filter:
-        # learn these label values from the downstream
         dynamic_labels:
           - __name__
           - job
-        # how often to re-sync them
         sync_interval: 5m
-        # always in the filter, without polling
         static_labels_include:
           instance:
             - instance1
-        # removed from the filter, applied last
         static_labels_exclude:
           __name__:
             - up
-        # behavior before the first successful sync
         on_sync_error: abort
 ```
 
@@ -42,59 +34,54 @@ promxy:
 | ------ | ------- | ------- |
 | `dynamic_labels` | — | Labels whose values promxy queries from the downstream. |
 | `sync_interval` | — | Re-sync period for dynamic labels. |
-| `static_labels_include` | — | Label values always present in the filter, no polling needed. |
-| `static_labels_exclude` | — | Label values removed from the filter. Applied **last**, so it overrides both dynamic and static includes. |
+| `static_labels_include` | — | Label values always in the filter, no polling. |
+| `static_labels_exclude` | — | Label values removed from the filter. Applied **last**, overriding both dynamic and static includes. |
 | `on_sync_error` | `abort` | Behavior while no sync has ever succeeded. |
 
-`__name__` is usually the highest-value label to filter on: it is what most
-queries constrain, and its cardinality is small relative to the series space.
+`__name__` is usually the best label to filter on: most queries constrain it,
+and its cardinality is small relative to the series space.
 
 ## Startup behaviour: `on_sync_error`
 
-A dynamic filter is useless until it has synced at least once, and a downstream
-may be unreachable exactly when promxy starts. `on_sync_error` decides what
-happens in that window:
+A dynamic filter is useless until it has synced once, and a downstream may be
+unreachable exactly when promxy starts.
 
 | Value | Behaviour before the first successful sync |
 | ----- | ------------------------------------------ |
-| `abort` *(default)* | The sync fails, which propagates up and **blocks promxy startup** until a sync succeeds. Preserves historical behaviour. |
-| `open` | Startup proceeds with no filtering — every query is sent downstream. Fail-open. |
-| `closed` | Startup proceeds but the filter rejects everything — the target is skipped entirely. Fail-closed. |
+| `abort` *(default)* | Sync fails and **blocks promxy startup** until one succeeds. Historical behaviour. |
+| `open` | Startup proceeds unfiltered; all queries go downstream. |
+| `closed` | Startup proceeds but the filter rejects everything; the target is skipped. |
 
-`abort` is safest for correctness but means one unreachable downstream can stop
-promxy from starting at all. If that trade-off is wrong for you, `open` keeps
-promxy serving with the fan-out it would have had without `label_filter`
-configured, and starts filtering once the first sync lands.
+`abort` is safest but lets one unreachable downstream stop promxy from starting.
+`open` keeps promxy serving with the fan-out it would have had without
+`label_filter`, and starts filtering once the first sync lands.
 
-When no explicit `sync_interval` is set, promxy retries the initial sync every
-5s until it succeeds.
+With no `sync_interval` set, promxy retries the initial sync every 5s.
 
-This setting is about the *sync* path only. It is unrelated to the server
-group's `ignore_error` / `downgrade_error`, which govern the *query* path.
+This governs the *sync* path only, not the server group's `ignore_error` /
+`downgrade_error`, which govern the *query* path.
 
 ## Observability
 
-Three metrics track the filter — see [Metrics](../operations/metrics.md):
+See [Metrics](../operations/metrics.md):
 
-- `promxy_label_filter_sync_count_total{status}` — syncs completed, by outcome
+- `promxy_label_filter_sync_count_total{status}` — syncs completed
 - `promxy_label_filter_sync_duration_seconds{status}` — sync latency
-- `promxy_label_filter_filtered_count_total{type}` — requests filtered out, by
-  query type
+- `promxy_label_filter_filtered_count_total{type}` — requests filtered out
 
-If `promxy_label_filter_filtered_count_total` stays at zero, your filter isn't
-buying anything and the config is adding risk for no benefit. If queries return
-unexpectedly empty, check whether a stale or over-broad filter is dropping them
-before looking at the downstreams.
+If `promxy_label_filter_filtered_count_total` stays at zero, the filter isn't
+buying anything. If queries return unexpectedly empty, check for a stale filter
+before suspecting the downstreams.
 
 ## Related options
 
-`label_filter` only *skips* downstreams; it never changes the query that is
-sent. If you want to constrain what a group returns, see
-[`inject_matchers`](../configuration/server-groups.md#inject_matchers), and if
-you only need to know where a result came from, static
-[`labels`](../configuration/server-groups.md#labels) are simpler.
+`label_filter` only skips downstreams; it never changes the query sent. To
+constrain what a group returns, use
+[`inject_matchers`](../configuration/server-groups.md#inject_matchers); to just
+label where a result came from, use
+[`labels`](../configuration/server-groups.md#labels).
 
-Where the split is by *time* rather than by label — a long-term-storage group
-holding only data older than 3h, or a decommissioned group — use
-[`relative_time_range` / `absolute_time_range`](../configuration/server-groups.md#relative_time_range--absolute_time_range)
-instead. Those are exact, need no syncing, and can't go stale.
+For splits by *time* rather than label — long-term storage, a decommissioned
+group — use
+[`relative_time_range` / `absolute_time_range`](../configuration/server-groups.md#relative_time_range--absolute_time_range),
+which are exact and can't go stale.

--- a/docs/guides/label-filtering.md
+++ b/docs/guides/label-filtering.md
@@ -1,0 +1,100 @@
+# Label filtering
+
+By default promxy scatter-gathers every query to every server group. That is
+usually fine — the fan-out is cheap and the downstreams answer in parallel — but
+when you have many shards and most queries only concern one of them, you are
+paying for a lot of requests that can only ever return nothing.
+
+`label_filter` maintains an in-memory picture of which label values a downstream
+actually has, and skips groups whose filter proves the query can't match.
+
+> **This is not a security mechanism.** It works entirely from the query's
+> matchers, so a caller can trivially sidestep it by matching on a different
+> label. See [Security](security.md) for real isolation.
+
+## Configuration
+
+```yaml
+promxy:
+  server_groups:
+    - static_configs:
+        - targets: [prom-us-01:9090]
+      label_filter:
+        # learn these label values from the downstream
+        dynamic_labels:
+          - __name__
+          - job
+        # how often to re-sync them
+        sync_interval: 5m
+        # always in the filter, without polling
+        static_labels_include:
+          instance:
+            - instance1
+        # removed from the filter, applied last
+        static_labels_exclude:
+          __name__:
+            - up
+        # behavior before the first successful sync
+        on_sync_error: abort
+```
+
+| Option | Default | Meaning |
+| ------ | ------- | ------- |
+| `dynamic_labels` | — | Labels whose values promxy queries from the downstream. |
+| `sync_interval` | — | Re-sync period for dynamic labels. |
+| `static_labels_include` | — | Label values always present in the filter, no polling needed. |
+| `static_labels_exclude` | — | Label values removed from the filter. Applied **last**, so it overrides both dynamic and static includes. |
+| `on_sync_error` | `abort` | Behavior while no sync has ever succeeded. |
+
+`__name__` is usually the highest-value label to filter on: it is what most
+queries constrain, and its cardinality is small relative to the series space.
+
+## Startup behaviour: `on_sync_error`
+
+A dynamic filter is useless until it has synced at least once, and a downstream
+may be unreachable exactly when promxy starts. `on_sync_error` decides what
+happens in that window:
+
+| Value | Behaviour before the first successful sync |
+| ----- | ------------------------------------------ |
+| `abort` *(default)* | The sync fails, which propagates up and **blocks promxy startup** until a sync succeeds. Preserves historical behaviour. |
+| `open` | Startup proceeds with no filtering — every query is sent downstream. Fail-open. |
+| `closed` | Startup proceeds but the filter rejects everything — the target is skipped entirely. Fail-closed. |
+
+`abort` is safest for correctness but means one unreachable downstream can stop
+promxy from starting at all. If that trade-off is wrong for you, `open` keeps
+promxy serving with the fan-out it would have had without `label_filter`
+configured, and starts filtering once the first sync lands.
+
+When no explicit `sync_interval` is set, promxy retries the initial sync every
+5s until it succeeds.
+
+This setting is about the *sync* path only. It is unrelated to the server
+group's `ignore_error` / `downgrade_error`, which govern the *query* path.
+
+## Observability
+
+Three metrics track the filter — see [Metrics](../operations/metrics.md):
+
+- `promxy_label_filter_sync_count_total{status}` — syncs completed, by outcome
+- `promxy_label_filter_sync_duration_seconds{status}` — sync latency
+- `promxy_label_filter_filtered_count_total{type}` — requests filtered out, by
+  query type
+
+If `promxy_label_filter_filtered_count_total` stays at zero, your filter isn't
+buying anything and the config is adding risk for no benefit. If queries return
+unexpectedly empty, check whether a stale or over-broad filter is dropping them
+before looking at the downstreams.
+
+## Related options
+
+`label_filter` only *skips* downstreams; it never changes the query that is
+sent. If you want to constrain what a group returns, see
+[`inject_matchers`](../configuration/server-groups.md#inject_matchers), and if
+you only need to know where a result came from, static
+[`labels`](../configuration/server-groups.md#labels) are simpler.
+
+Where the split is by *time* rather than by label — a long-term-storage group
+holding only data older than 3h, or a decommissioned group — use
+[`relative_time_range` / `absolute_time_range`](../configuration/server-groups.md#relative_time_range--absolute_time_range)
+instead. Those are exact, need no syncing, and can't go stale.

--- a/docs/guides/multi-tenancy.md
+++ b/docs/guides/multi-tenancy.md
@@ -1,18 +1,17 @@
 # Multi-tenancy
 
 Multi-tenant backends (Mimir, Cortex, GEM) identify a dataset by
-`(endpoint, tenant)` rather than by endpoint alone. Since a promxy server group
-is defined as "endpoints holding the **same** data", the unit that maps onto a
-server group is the `(backend, tenant)` pair — not the backend.
+`(endpoint, tenant)`, not endpoint alone. Since a server group is "endpoints
+holding the **same** data", the unit that maps onto a group is the
+`(backend, tenant)` pair.
 
-Getting this wrong is quiet rather than loud: promxy will merge datasets it
-believes are replicas, and label-less aggregations like `count(up)` come back
-under-counted.
+Get this wrong and it fails quietly: promxy merges datasets it thinks are
+replicas, and `count(up)` comes back under-counted.
 
 ## One group per tenant
 
-Select the tenant with the `X-Scope-OrgID` header, and give each group a static
-label so its results stay distinguishable:
+Select the tenant with `X-Scope-OrgID`, and give each group a static label so
+its results stay distinguishable:
 
 ```yaml
 promxy:
@@ -36,19 +35,17 @@ promxy:
         dc: dc2
 ```
 
-**Do not** list several tenants in one `X-Scope-OrgID` header to save on groups.
-The backend will happily return the union, but promxy sees one dataset and
-merges within it — so replicas across tenants collapse and `count(up)` is wrong.
-See [issue #703](https://github.com/jacksontj/promxy/issues/703).
+**Do not** list several tenants in one `X-Scope-OrgID` header to save groups.
+The backend returns the union, but promxy sees one dataset and merges within it,
+so replicas across tenants collapse and `count(up)` is wrong. See
+[issue #703](https://github.com/jacksontj/promxy/issues/703).
 
 ## Replicated tenants
 
-When the *same* tenant is served by multiple backends, that genuinely is one
-dataset with HA replicas — so those endpoints belong in the same group, and
-promxy's anti-affinity merge does the right thing:
+When the *same* tenant is served by multiple backends, that is one dataset with
+HA replicas, so those endpoints belong in one group:
 
 ```yaml
-    # this tenant's data lives on both dc1 and dc2
     - http_headers:
         X-Scope-OrgID: google-us-dc1
       path_prefix: /prometheus
@@ -61,18 +58,18 @@ promxy's anti-affinity merge does the right thing:
         dc: google-us-dc1
 ```
 
-A complete worked topology is in
+A full worked topology:
 [`cmd/promxy/multi_tenant.conf`](../../cmd/promxy/multi_tenant.conf).
 
-## Slicing a single merged backend with `inject_matchers`
+## Slicing one backend with `inject_matchers`
 
-The other shape of this problem: one backend (a big Prometheus, a Thanos, a
-single-tenant Mimir) holds many logical clusters distinguished only by a label,
-and you want to present a per-tenant view of it.
+The other shape: a single backend (big Prometheus, Thanos, single-tenant Mimir)
+holds many logical clusters distinguished by a label, and you want a per-tenant
+view.
 
-`inject_matchers` adds matchers to **every** selector in every request sent to a
-group — including queries that never mention the label. With `cluster="A"`
-configured, `count(up)` goes downstream as `count(up{cluster="A"})`.
+`inject_matchers` adds matchers to **every** selector sent to a group, including
+queries that never mention the label. With `cluster="A"` configured, `count(up)`
+goes downstream as `count(up{cluster="A"})`.
 
 ```yaml
 promxy:
@@ -83,29 +80,26 @@ promxy:
         - 'cluster="A"'
 ```
 
-Each entry is one matcher in PromQL syntax without enclosing braces; regex
-matchers work (`'region=~"us-.*"'`). Matchers are validated at config load, so a
-syntax error fails startup rather than a later discovery sync.
+Each entry is one matcher in PromQL syntax without braces; regex matchers work
+(`'region=~"us-.*"'`). Matchers are validated at config load, so a syntax error
+fails startup rather than a later discovery sync.
 
-The usual deployment is one promxy per tenant, each with its own
-`inject_matchers`, in front of a shared backend. See
+Usual deployment: one promxy per tenant in front of a shared backend. See
 [issue #698](https://github.com/jacksontj/promxy/issues/698).
-
-### How it differs from the neighbouring options
 
 | Option | What it does |
 | ------ | ------------ |
-| `labels` | Adds labels to *responses*. Doesn't change what is queried. |
-| `label_filter` | *Skips* a downstream whose filter says it can't match. Doesn't change the query sent. |
-| `inject_matchers` | Always *adds matchers to the query itself*. |
+| `labels` | Adds labels to *responses*. Doesn't change the query. |
+| `label_filter` | *Skips* a downstream that can't match. Doesn't change the query. |
+| `inject_matchers` | Adds matchers to the query itself. |
 
 ## Security
 
-Neither `inject_matchers` nor `label_filter` is a security boundary. Both work
-by manipulating query matchers, and both rely on the downstream honouring them —
-a caller who controls the query text can work around them.
+Neither `inject_matchers` nor `label_filter` is a security boundary: both
+manipulate query matchers and rely on the downstream honouring them, and a
+caller who controls the query text can work around them.
 
-For genuine tenant isolation, put an authenticating proxy in front that injects
-a *trusted* label set, e.g.
+For real tenant isolation put an authenticating proxy in front that injects a
+*trusted* label set, e.g.
 [prom-label-proxy](https://github.com/prometheus-community/prom-label-proxy).
 See [Security](security.md).

--- a/docs/guides/multi-tenancy.md
+++ b/docs/guides/multi-tenancy.md
@@ -1,0 +1,111 @@
+# Multi-tenancy
+
+Multi-tenant backends (Mimir, Cortex, GEM) identify a dataset by
+`(endpoint, tenant)` rather than by endpoint alone. Since a promxy server group
+is defined as "endpoints holding the **same** data", the unit that maps onto a
+server group is the `(backend, tenant)` pair — not the backend.
+
+Getting this wrong is quiet rather than loud: promxy will merge datasets it
+believes are replicas, and label-less aggregations like `count(up)` come back
+under-counted.
+
+## One group per tenant
+
+Select the tenant with the `X-Scope-OrgID` header, and give each group a static
+label so its results stay distinguishable:
+
+```yaml
+promxy:
+  server_groups:
+    - http_headers:
+        X-Scope-OrgID: dc1
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets: [mimir.dc1.local:8080]
+      labels:
+        dc: dc1
+
+    - http_headers:
+        X-Scope-OrgID: dc2
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets: [mimir.dc2.local:8080]
+      labels:
+        dc: dc2
+```
+
+**Do not** list several tenants in one `X-Scope-OrgID` header to save on groups.
+The backend will happily return the union, but promxy sees one dataset and
+merges within it — so replicas across tenants collapse and `count(up)` is wrong.
+See [issue #703](https://github.com/jacksontj/promxy/issues/703).
+
+## Replicated tenants
+
+When the *same* tenant is served by multiple backends, that genuinely is one
+dataset with HA replicas — so those endpoints belong in the same group, and
+promxy's anti-affinity merge does the right thing:
+
+```yaml
+    # this tenant's data lives on both dc1 and dc2
+    - http_headers:
+        X-Scope-OrgID: google-us-dc1
+      path_prefix: /prometheus
+      scheme: https
+      static_configs:
+        - targets:
+            - mimir.dc1.local:8080
+            - mimir.dc2.local:8080
+      labels:
+        dc: google-us-dc1
+```
+
+A complete worked topology is in
+[`cmd/promxy/multi_tenant.conf`](../../cmd/promxy/multi_tenant.conf).
+
+## Slicing a single merged backend with `inject_matchers`
+
+The other shape of this problem: one backend (a big Prometheus, a Thanos, a
+single-tenant Mimir) holds many logical clusters distinguished only by a label,
+and you want to present a per-tenant view of it.
+
+`inject_matchers` adds matchers to **every** selector in every request sent to a
+group — including queries that never mention the label. With `cluster="A"`
+configured, `count(up)` goes downstream as `count(up{cluster="A"})`.
+
+```yaml
+promxy:
+  server_groups:
+    - static_configs:
+        - targets: [big-prometheus:9090]
+      inject_matchers:
+        - 'cluster="A"'
+```
+
+Each entry is one matcher in PromQL syntax without enclosing braces; regex
+matchers work (`'region=~"us-.*"'`). Matchers are validated at config load, so a
+syntax error fails startup rather than a later discovery sync.
+
+The usual deployment is one promxy per tenant, each with its own
+`inject_matchers`, in front of a shared backend. See
+[issue #698](https://github.com/jacksontj/promxy/issues/698).
+
+### How it differs from the neighbouring options
+
+| Option | What it does |
+| ------ | ------------ |
+| `labels` | Adds labels to *responses*. Doesn't change what is queried. |
+| `label_filter` | *Skips* a downstream whose filter says it can't match. Doesn't change the query sent. |
+| `inject_matchers` | Always *adds matchers to the query itself*. |
+
+## Security
+
+Neither `inject_matchers` nor `label_filter` is a security boundary. Both work
+by manipulating query matchers, and both rely on the downstream honouring them —
+a caller who controls the query text can work around them.
+
+For genuine tenant isolation, put an authenticating proxy in front that injects
+a *trusted* label set, e.g.
+[prom-label-proxy](https://github.com/prometheus-community/prom-label-proxy).
+See [Security](security.md).

--- a/docs/guides/native-histograms.md
+++ b/docs/guides/native-histograms.md
@@ -1,0 +1,106 @@
+# Native histograms
+
+Prometheus' JSON HTTP API cannot represent a native histogram without loss.
+Promxy's remote_read path can. That single fact drives all of the configuration
+below.
+
+Promxy's default posture is **fail loud**: if it can tell a query involves
+native histograms and the target server group has no `remote_read` configured,
+the query errors out before fan-out rather than quietly returning degraded data.
+Wrong data is worse than no data — especially when alerting rules consume it.
+
+## The fix
+
+Enable `remote_read` on every server group whose data includes native
+histograms:
+
+```yaml
+promxy:
+  server_groups:
+    - static_configs:
+        - targets: [prom-01:9090, prom-02:9090]
+      remote_read: true
+```
+
+That is the whole fix for most deployments. Note that some
+Prometheus-compatible backends don't implement remote_read at all (notably
+VictoriaMetrics); see [Escape hatch](#escape-hatch) below for those.
+
+## How promxy detects a histogram query
+
+### AST detection (always on)
+
+Promxy walks the query AST looking for calls to the PromQL functions that only
+operate on native histograms:
+
+`histogram_avg`, `histogram_count`, `histogram_sum`, `histogram_stddev`,
+`histogram_stdvar`, `histogram_fraction`
+
+A query containing any of these is unambiguously histogram-bearing, no metadata
+required.
+
+`histogram_quantile` is deliberately **not** in that set: it accepts both
+classic `_bucket` float series and native histograms, so on its own it says
+nothing about which you have.
+
+This costs nothing and needs no configuration, but it misses queries that touch
+a histogram metric without calling one of those functions — `rate(my_hist[5m])`
+being the obvious example.
+
+### Metadata detection (opt-in)
+
+To catch those, let promxy learn which metric *names* are histogram-typed:
+
+```yaml
+promxy:
+  server_groups:
+    - static_configs:
+        - targets: [prom-01:9090]
+      remote_read: true
+      native_histogram:
+        metadata_refresh: 5m
+```
+
+Promxy periodically calls `/api/v1/metadata` on the group, extracts the
+histogram-typed metric names, and consults the union of all groups' caches when
+classifying a query. The cache is keyed by metric *name*, not series, so its
+memory footprint scales with your histogram-name count (typically a low
+single-digit percentage of the name space) rather than cardinality.
+
+Set this whenever you have native histograms and want the safety net to be
+complete.
+
+## Escape hatch
+
+If a backend can't do remote_read and you accept the fidelity loss — say
+dashboards that only ever consume `histogram_quantile` output and don't care
+about sparse spans — opt in explicitly per group:
+
+```yaml
+native_histogram:
+  allow_lossy: true
+```
+
+The query then proceeds over the JSON API. This is a deliberate, per-group
+decision; there is no global switch, and the default stays `false`.
+
+## Behaviour summary
+
+| `remote_read` | `allow_lossy` | Histogram-bearing query |
+| ------------- | ------------- | ----------------------- |
+| `true` | *(any)* | Served losslessly via remote_read. |
+| `false` | `false` *(default)* | Errors before fan-out, naming the groups missing `remote_read`. |
+| `false` | `true` | Served via the JSON API; histogram samples are degraded. |
+
+Promxy also detects lossy histogram data arriving from a pushed-down query at
+runtime: if a downstream's response to a pushed-down aggregation contains a
+degraded histogram, promxy abandons the pushdown for that node and re-fetches
+raw data through the normal querier path, which routes via remote_read where
+configured.
+
+## Merging
+
+Float and histogram samples coexist on a series and are merged independently, so
+a series carrying both still deduplicates correctly through the anti-affinity
+merge. Histograms round-trip losslessly through that merge. See
+[HA and merging](../concepts/ha-and-merging.md).

--- a/docs/guides/native-histograms.md
+++ b/docs/guides/native-histograms.md
@@ -1,18 +1,15 @@
 # Native histograms
 
-Prometheus' JSON HTTP API cannot represent a native histogram without loss.
-Promxy's remote_read path can. That single fact drives all of the configuration
-below.
+Prometheus' JSON HTTP API cannot represent a native histogram without loss;
+remote_read can.
 
-Promxy's default posture is **fail loud**: if it can tell a query involves
-native histograms and the target server group has no `remote_read` configured,
-the query errors out before fan-out rather than quietly returning degraded data.
-Wrong data is worse than no data — especially when alerting rules consume it.
+By default promxy **fails loud**: if it detects a histogram-bearing query
+against a group with no `remote_read`, the query errors before fan-out rather
+than returning degraded data.
 
 ## The fix
 
-Enable `remote_read` on every server group whose data includes native
-histograms:
+Enable `remote_read` on every group whose data includes native histograms:
 
 ```yaml
 promxy:
@@ -22,67 +19,51 @@ promxy:
       remote_read: true
 ```
 
-That is the whole fix for most deployments. Note that some
-Prometheus-compatible backends don't implement remote_read at all (notably
-VictoriaMetrics); see [Escape hatch](#escape-hatch) below for those.
+Some Prometheus-compatible backends don't implement remote_read (notably
+VictoriaMetrics) — see [Escape hatch](#escape-hatch).
 
 ## How promxy detects a histogram query
 
 ### AST detection (always on)
 
-Promxy walks the query AST looking for calls to the PromQL functions that only
-operate on native histograms:
+Promxy looks for calls to the PromQL functions that only operate on native
+histograms:
 
 `histogram_avg`, `histogram_count`, `histogram_sum`, `histogram_stddev`,
 `histogram_stdvar`, `histogram_fraction`
 
-A query containing any of these is unambiguously histogram-bearing, no metadata
-required.
+`histogram_quantile` is deliberately excluded: it accepts both classic
+`_bucket` float series and native histograms, so it signals nothing on its own.
 
-`histogram_quantile` is deliberately **not** in that set: it accepts both
-classic `_bucket` float series and native histograms, so on its own it says
-nothing about which you have.
-
-This costs nothing and needs no configuration, but it misses queries that touch
-a histogram metric without calling one of those functions — `rate(my_hist[5m])`
-being the obvious example.
+AST detection is free and needs no config, but misses queries that touch a
+histogram metric without calling one of those functions, e.g.
+`rate(my_hist[5m])`.
 
 ### Metadata detection (opt-in)
 
-To catch those, let promxy learn which metric *names* are histogram-typed:
-
 ```yaml
-promxy:
-  server_groups:
-    - static_configs:
-        - targets: [prom-01:9090]
-      remote_read: true
-      native_histogram:
-        metadata_refresh: 5m
+native_histogram:
+  metadata_refresh: 5m
 ```
 
 Promxy periodically calls `/api/v1/metadata` on the group, extracts the
 histogram-typed metric names, and consults the union of all groups' caches when
-classifying a query. The cache is keyed by metric *name*, not series, so its
-memory footprint scales with your histogram-name count (typically a low
-single-digit percentage of the name space) rather than cardinality.
+classifying a query. The cache is keyed by metric *name*, so memory scales with
+histogram-name count rather than cardinality.
 
-Set this whenever you have native histograms and want the safety net to be
-complete.
+Set this if you have native histograms and want complete detection.
 
 ## Escape hatch
 
-If a backend can't do remote_read and you accept the fidelity loss — say
-dashboards that only ever consume `histogram_quantile` output and don't care
-about sparse spans — opt in explicitly per group:
+If a backend can't do remote_read and you accept the fidelity loss (e.g.
+dashboards that only consume `histogram_quantile` output), opt in per group:
 
 ```yaml
 native_histogram:
   allow_lossy: true
 ```
 
-The query then proceeds over the JSON API. This is a deliberate, per-group
-decision; there is no global switch, and the default stays `false`.
+There is no global switch; the default stays `false`.
 
 ## Behaviour summary
 
@@ -90,17 +71,15 @@ decision; there is no global switch, and the default stays `false`.
 | ------------- | ------------- | ----------------------- |
 | `true` | *(any)* | Served losslessly via remote_read. |
 | `false` | `false` *(default)* | Errors before fan-out, naming the groups missing `remote_read`. |
-| `false` | `true` | Served via the JSON API; histogram samples are degraded. |
+| `false` | `true` | Served via the JSON API; histogram samples degraded. |
 
-Promxy also detects lossy histogram data arriving from a pushed-down query at
-runtime: if a downstream's response to a pushed-down aggregation contains a
-degraded histogram, promxy abandons the pushdown for that node and re-fetches
-raw data through the normal querier path, which routes via remote_read where
+Promxy also catches this at runtime: if a pushed-down query's response contains
+a degraded histogram, promxy abandons the pushdown for that node and re-fetches
+raw data through the querier path, which routes via remote_read where
 configured.
 
 ## Merging
 
-Float and histogram samples coexist on a series and are merged independently, so
-a series carrying both still deduplicates correctly through the anti-affinity
-merge. Histograms round-trip losslessly through that merge. See
+Float and histogram samples merge independently, so a series carrying both
+deduplicates correctly and histograms round-trip losslessly. See
 [HA and merging](../concepts/ha-and-merging.md).

--- a/docs/guides/rules-and-alerting.md
+++ b/docs/guides/rules-and-alerting.md
@@ -1,0 +1,152 @@
+# Rules and alerting
+
+Promxy evaluates alerting rules against your **entire** infrastructure. That is
+the main reason to run rules here rather than on individual Prometheus servers:
+"the global error rate is above 10%" is impossible to express on a single shard
+without federation or re-scraping, and trivial in promxy.
+
+Rules are configured exactly as in Prometheus:
+
+```yaml
+global:
+  evaluation_interval: 30s
+
+rule_files:
+  - "rules/*.yml"
+
+alerting:
+  alertmanagers:
+    - scheme: http
+      static_configs:
+        - targets: [alertmanager:9093]
+```
+
+## Promxy has no local storage
+
+This is the one thing that genuinely differs, and it has two consequences.
+
+**Recording rules require `remote_write`.** Prometheus writes recording-rule
+output to its local TSDB. Promxy has no TSDB, so it needs somewhere to send
+them. Configuring a recording rule with no `remote_write` endpoint is a **fatal
+config error**.
+
+**Alerting rules should have `remote_write` too.** They work without it — alerts
+fire and reach Alertmanager — but the `ALERTS` and `ALERTS_FOR_STATE` series
+have nowhere to go, so you cannot query alert state and promxy logs a warning at
+startup.
+
+```yaml
+remote_write:
+  - url: http://localhost:8083/receive
+```
+
+Anything promxy would "write" (as opposed to proxy) goes here.
+
+### `max_samples_per_send`
+
+Promxy defaults `queue_config.max_samples_per_send` to **100**, where upstream
+Prometheus uses 2000. Recording-rule output over large or high-cardinality
+series can decompress past the 32 MiB snappy limit that Prometheus 3.5.3+
+enforces on the receiving side; the receiver then rejects the batch with
+`snappy: decoded length N exceeds limit 33554432` and the queue manager drops
+it. The lower default keeps requests comfortably under that limit.
+
+Set it explicitly to override:
+
+```yaml
+remote_write:
+  - url: http://localhost:8083/receive
+    queue_config:
+      max_samples_per_send: 500
+```
+
+### WAL durability
+
+Samples are appended to a WAL that the remote_write queue managers tail. Pass
+`--storage.path` to keep that WAL on disk across restarts; without it promxy
+uses a temporary directory that is deleted on shutdown, so anything not yet
+shipped is lost when promxy stops.
+
+## Where to send `remote_write`
+
+Any remote_write receiver works — a Prometheus with
+`--web.enable-remote-write-receiver`, VictoriaMetrics, Mimir, Cortex, Thanos
+Receive.
+
+If you just want the metrics to be scrapeable again, promxy ships a small
+companion binary, `remote_write_exporter`, that keeps the most recent value of
+each received series in memory and re-exposes it on `/metrics`:
+
+```
+remote_write_exporter --metric-ttl=5m
+```
+
+It listens on `:8083` and accepts remote_write at `/receive`. Flags are in the
+[CLI reference](../configuration/cli-flags.md#remote_write_exporter). It is a
+convenience, not a storage system — everything lives in memory behind a TTL
+sweep.
+
+A common loop is to point `remote_write` at `remote_write_exporter` and have one
+of your Prometheus servers scrape it, which puts recording-rule output back into
+the infrastructure promxy is querying.
+
+## Alert state across restarts
+
+Prometheus restores the `for` state of pending alerts at startup by querying
+`ALERTS_FOR_STATE`. Two flags tune that restoration:
+
+- `--rules.alert.for-outage-tolerance` (default `1h`) — how long an outage may
+  have been for restoration to still apply.
+- `--rules.alert.for-grace-period` (default `10m`) — minimum delay between an
+  alert firing and its restored `for` state; only applies to alerts whose `for`
+  exceeds this.
+
+If your `remote_write` target doesn't retain `ALERTS_FOR_STATE` — or you have no
+`remote_write` at all — promxy can instead **recompute** alert state at startup:
+
+```
+promxy --config=config.yaml --rules.alertbackfill
+```
+
+With `--rules.alertbackfill`, when the alert-state query returns nothing promxy
+re-runs the underlying alert expression over the relevant window against your
+downstreams and reconstructs the series. This costs queries at startup, but it
+means a promxy restart doesn't reset every pending alert's `for` timer.
+
+## `GeneratorURL`
+
+By default alerts carry a Prometheus-style `GeneratorURL` pointing at promxy's
+own graph page, built from `--web.external-url`. Set that flag if promxy sits
+behind a reverse proxy, or the link will point at promxy's hostname and port.
+
+To send alerts to Grafana, PagerDuty, or a runbook instead, see
+[Alert templates](../configuration/alert-templates.md).
+
+## Alertmanager authentication
+
+The `alerting.alertmanagers` block accepts the standard Prometheus HTTP client
+config (`basic_auth`, `authorization`, `tls_config`, …), plus custom headers for
+gateways that authenticate on a header:
+
+```yaml
+alerting:
+  alertmanagers:
+    - scheme: https
+      static_configs:
+        - targets: [alertmanager.example.com]
+      http_headers:
+        X-Gateway-Signature:
+          values: ["my-secret-token"]
+```
+
+`values`, `secrets`, and `files` are all supported for a header's value.
+
+## Tuning
+
+- `--alertmanager.notification-queue-capacity` (default `10000`) — pending
+  notification queue depth.
+- `--rules.alert.resend-delay` (default `1m`) — minimum interval before an alert
+  is resent.
+- `global.evaluation_interval` — how often rules run. Remember that every
+  evaluation is a scatter-gather across all your server groups, so this is
+  meaningfully more expensive than on a single Prometheus.

--- a/docs/guides/rules-and-alerting.md
+++ b/docs/guides/rules-and-alerting.md
@@ -1,9 +1,8 @@
 # Rules and alerting
 
-Promxy evaluates alerting rules against your **entire** infrastructure. That is
-the main reason to run rules here rather than on individual Prometheus servers:
-"the global error rate is above 10%" is impossible to express on a single shard
-without federation or re-scraping, and trivial in promxy.
+Promxy evaluates alerting rules across your entire infrastructure, so global
+rules ("error rate above 10% everywhere") that no single shard can express
+become trivial.
 
 Rules are configured exactly as in Prometheus:
 
@@ -23,35 +22,28 @@ alerting:
 
 ## Promxy has no local storage
 
-This is the one thing that genuinely differs, and it has two consequences.
-
 **Recording rules require `remote_write`.** Prometheus writes recording-rule
-output to its local TSDB. Promxy has no TSDB, so it needs somewhere to send
-them. Configuring a recording rule with no `remote_write` endpoint is a **fatal
-config error**.
+output to its local TSDB; promxy has none. A recording rule with no
+`remote_write` endpoint is a **fatal config error**.
 
-**Alerting rules should have `remote_write` too.** They work without it — alerts
-fire and reach Alertmanager — but the `ALERTS` and `ALERTS_FOR_STATE` series
-have nowhere to go, so you cannot query alert state and promxy logs a warning at
-startup.
+**Alerting rules should have it too.** They work without it — alerts fire and
+reach Alertmanager — but `ALERTS` and `ALERTS_FOR_STATE` have nowhere to go, so
+alert state isn't queryable. Promxy logs a warning at startup.
 
 ```yaml
 remote_write:
   - url: http://localhost:8083/receive
 ```
 
-Anything promxy would "write" (as opposed to proxy) goes here.
-
 ### `max_samples_per_send`
 
-Promxy defaults `queue_config.max_samples_per_send` to **100**, where upstream
-Prometheus uses 2000. Recording-rule output over large or high-cardinality
-series can decompress past the 32 MiB snappy limit that Prometheus 3.5.3+
-enforces on the receiving side; the receiver then rejects the batch with
-`snappy: decoded length N exceeds limit 33554432` and the queue manager drops
-it. The lower default keeps requests comfortably under that limit.
+Promxy defaults this to **100**, where upstream Prometheus uses 2000.
+Recording-rule output over high-cardinality series can decompress past the
+32 MiB snappy limit Prometheus 3.5.3+ enforces on the receiver, which then
+rejects the batch with `snappy: decoded length N exceeds limit 33554432` and the
+queue manager drops it.
 
-Set it explicitly to override:
+Override explicitly:
 
 ```yaml
 remote_write:
@@ -62,71 +54,67 @@ remote_write:
 
 ### WAL durability
 
-Samples are appended to a WAL that the remote_write queue managers tail. Pass
-`--storage.path` to keep that WAL on disk across restarts; without it promxy
-uses a temporary directory that is deleted on shutdown, so anything not yet
-shipped is lost when promxy stops.
+Samples go to a WAL that the queue managers tail. `--storage.path` keeps it on
+disk across restarts; without it promxy uses a temp directory deleted on
+shutdown, losing anything not yet shipped.
 
 ## Where to send `remote_write`
 
-Any remote_write receiver works — a Prometheus with
-`--web.enable-remote-write-receiver`, VictoriaMetrics, Mimir, Cortex, Thanos
-Receive.
+Any receiver works — Prometheus with `--web.enable-remote-write-receiver`,
+VictoriaMetrics, Mimir, Cortex, Thanos Receive.
 
-If you just want the metrics to be scrapeable again, promxy ships a small
-companion binary, `remote_write_exporter`, that keeps the most recent value of
-each received series in memory and re-exposes it on `/metrics`:
+To just make the metrics scrapeable again, promxy ships `remote_write_exporter`,
+which keeps the most recent value of each received series in memory and exposes
+it on `/metrics`:
 
 ```
 remote_write_exporter --metric-ttl=5m
 ```
 
-It listens on `:8083` and accepts remote_write at `/receive`. Flags are in the
-[CLI reference](../configuration/cli-flags.md#remote_write_exporter). It is a
-convenience, not a storage system — everything lives in memory behind a TTL
-sweep.
+It listens on `:8083`, accepts remote_write at `/receive`, and holds everything
+in memory behind a TTL sweep — a convenience, not storage. Flags:
+[CLI reference](../configuration/cli-flags.md#remote_write_exporter).
 
-A common loop is to point `remote_write` at `remote_write_exporter` and have one
-of your Prometheus servers scrape it, which puts recording-rule output back into
-the infrastructure promxy is querying.
+A common loop is to point `remote_write` at it and have one of your Prometheus
+servers scrape it, putting recording-rule output back into the infrastructure
+promxy queries.
 
 ## Alert state across restarts
 
-Prometheus restores the `for` state of pending alerts at startup by querying
-`ALERTS_FOR_STATE`. Two flags tune that restoration:
+Prometheus restores the `for` state of pending alerts by querying
+`ALERTS_FOR_STATE`:
 
 - `--rules.alert.for-outage-tolerance` (default `1h`) — how long an outage may
   have been for restoration to still apply.
 - `--rules.alert.for-grace-period` (default `10m`) — minimum delay between an
-  alert firing and its restored `for` state; only applies to alerts whose `for`
-  exceeds this.
+  alert firing and its restored `for` state; only for alerts whose `for` exceeds
+  this.
 
-If your `remote_write` target doesn't retain `ALERTS_FOR_STATE` — or you have no
-`remote_write` at all — promxy can instead **recompute** alert state at startup:
+If your `remote_write` target doesn't retain `ALERTS_FOR_STATE` — or you have
+none — promxy can recompute alert state at startup:
 
 ```
 promxy --config=config.yaml --rules.alertbackfill
 ```
 
-With `--rules.alertbackfill`, when the alert-state query returns nothing promxy
-re-runs the underlying alert expression over the relevant window against your
-downstreams and reconstructs the series. This costs queries at startup, but it
-means a promxy restart doesn't reset every pending alert's `for` timer.
+When the alert-state query returns nothing, promxy re-runs the alert expression
+over the relevant window against your downstreams and reconstructs the series.
+Costs queries at startup; keeps restarts from resetting every `for` timer.
 
 ## `GeneratorURL`
 
-By default alerts carry a Prometheus-style `GeneratorURL` pointing at promxy's
-own graph page, built from `--web.external-url`. Set that flag if promxy sits
-behind a reverse proxy, or the link will point at promxy's hostname and port.
+Alerts carry a Prometheus-style `GeneratorURL` pointing at promxy's graph page,
+built from `--web.external-url`. Set that flag if promxy sits behind a reverse
+proxy, or links point at promxy's own hostname and port.
 
-To send alerts to Grafana, PagerDuty, or a runbook instead, see
+For Grafana, PagerDuty, or runbook links instead, see
 [Alert templates](../configuration/alert-templates.md).
 
 ## Alertmanager authentication
 
-The `alerting.alertmanagers` block accepts the standard Prometheus HTTP client
-config (`basic_auth`, `authorization`, `tls_config`, …), plus custom headers for
-gateways that authenticate on a header:
+`alerting.alertmanagers` accepts the standard Prometheus HTTP client config
+(`basic_auth`, `authorization`, `tls_config`, …), plus custom headers for
+gateways that authenticate on one:
 
 ```yaml
 alerting:
@@ -139,14 +127,12 @@ alerting:
           values: ["my-secret-token"]
 ```
 
-`values`, `secrets`, and `files` are all supported for a header's value.
+`values`, `secrets`, and `files` are all supported.
 
 ## Tuning
 
 - `--alertmanager.notification-queue-capacity` (default `10000`) — pending
   notification queue depth.
-- `--rules.alert.resend-delay` (default `1m`) — minimum interval before an alert
-  is resent.
-- `global.evaluation_interval` — how often rules run. Remember that every
-  evaluation is a scatter-gather across all your server groups, so this is
-  meaningfully more expensive than on a single Prometheus.
+- `--rules.alert.resend-delay` (default `1m`) — minimum interval before resend.
+- `global.evaluation_interval` — every evaluation is a scatter-gather across all
+  server groups, so this costs more than on a single Prometheus.

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1,0 +1,167 @@
+# Security
+
+Promxy has two distinct security surfaces: **inbound** (clients talking to
+promxy) and **outbound** (promxy talking to your Prometheus servers). They are
+configured in different places.
+
+## Inbound: serving promxy over TLS
+
+Promxy uses the standard Prometheus
+[web configuration file](https://prometheus.io/docs/prometheus/latest/configuration/https/),
+passed via `--web.config.file`. The flag is marked experimental.
+
+```
+promxy --config=config.yaml --web.config.file=web.yml
+```
+
+```yaml
+# web.yml
+tls_server_config:
+  cert_file: server.crt
+  key_file: server.key
+  # optional mTLS
+  client_auth_type: RequireAndVerifyClientCert
+  client_ca_file: test-ca.crt
+```
+
+Relative `cert_file` / `key_file` paths resolve against the directory containing
+the web config file.
+
+The same file also carries:
+
+```yaml
+http_server_config:
+  headers:
+    Content-Security-Policy: "default-src 'self';"
+    X-Frame-Options: "sameorigin"
+
+basic_auth_users:
+  alice: $2y$10$...   # bcrypt hash
+```
+
+The file is validated at startup, so a broken web config fails fast rather than
+serving plaintext.
+
+> A `tls_server_config` key in promxy's **main** config file is accepted by the
+> parser but has no effect. TLS comes from `--web.config.file` only.
+
+### Legacy flat schema
+
+Before promxy delegated its web server to `exporter-toolkit`, TLS keys lived at
+the *top level* of the web config file rather than nested under
+`tls_server_config`:
+
+```yaml
+# deprecated
+cert_file: server.crt
+key_file: server.key
+```
+
+Promxy still serves this schema for backward compatibility, logging a
+deprecation warning at startup. Support will be removed in a future release —
+nest the keys under `tls_server_config:`.
+
+## Inbound: authentication and authorization
+
+**Promxy provides no authentication or authorization of its own** beyond the
+`basic_auth_users` supported by the web config file. There is no per-tenant
+access control, and nothing in promxy restricts which series a caller may query.
+
+For anything more than basic auth, put a proxy in front of promxy:
+
+- **Kubernetes ingress** — e.g. nginx ingress with an auth annotation
+- **A reverse proxy** — nginx/Envoy doing auth, as in the
+  [Prometheus basic-auth guide](https://prometheus.io/docs/guides/basic-auth/)
+- **[prom-label-proxy](https://github.com/prometheus-community/prom-label-proxy)**
+  — enforces a *trusted* label matcher on every query, which is the right tool
+  for real tenant isolation
+
+### Why `label_filter` and `inject_matchers` are not security features
+
+Both operate on the query's matchers, and both trust the downstream to honour
+them:
+
+- `label_filter` decides whether to *send* a query based on its matchers. A
+  caller who matches on a different label bypasses the filter.
+- `inject_matchers` *adds* matchers to the query, but a caller who controls the
+  query text can construct expressions that work around them.
+
+They are performance and scoping tools. Use a trusted-label proxy for isolation.
+See [Multi-tenancy](multi-tenancy.md).
+
+### CORS
+
+`--web.cors.origin` (default `.*`) is a fully-anchored regex for allowed
+origins. The default allows any origin; tighten it if promxy is reachable from a
+browser context you don't control.
+
+## Outbound: authenticating to downstreams
+
+Per server group, `http_client` inlines Prometheus'
+[HTTP client config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_config),
+plus a `sigv4` block for AWS-signed requests (Amazon Managed Prometheus):
+
+```yaml
+promxy:
+  server_groups:
+    - static_configs:
+        - targets: [prom-01:9090]
+      scheme: https
+      http_client:
+        tls_config:
+          ca_file: /etc/ssl/certs/internal-ca.crt
+          cert_file: /etc/promxy/client.crt
+          key_file: /etc/promxy/client.key
+        basic_auth:
+          username: promxy
+          password_file: /etc/promxy/password
+```
+
+**At most one** authentication method may be configured per group —
+`basic_auth`, `authorization`, `bearer_token`, `bearer_token_file`, or `sigv4`.
+Configuring more than one is a config error caught at load time.
+
+Prefer the `*_file` variants (`password_file`, `bearer_token_file`) so secrets
+aren't sitting in the config file that promxy serves back from
+`/api/v1/status/config`.
+
+### Forwarding caller credentials
+
+`--proxy-headers` forwards named headers from the incoming request to
+downstream server groups:
+
+```
+promxy --proxy-headers=Authorization --proxy-headers=X-Scope-OrgID
+```
+
+It can also be set via the `PROXY_HEADERS` environment variable. This lets an
+authenticating layer in front of promxy pass a caller's identity through to the
+backends, so the backends can enforce it.
+
+### Static headers
+
+For a fixed credential per group — the common case for Mimir/Cortex tenancy —
+use `http_headers`:
+
+```yaml
+http_headers:
+  X-Scope-OrgID: tenant-A
+```
+
+## Exposed endpoints
+
+Promxy exposes the full Prometheus UI and API, plus `/debug/pprof/*`. If promxy
+is reachable beyond your trusted network, restrict `/debug` at your proxy —
+pprof endpoints are a denial-of-service and information-disclosure surface.
+
+`--web.enable-lifecycle` adds `POST /-/reload`. Leave it off unless something
+needs it, and restrict it if on.
+
+`/api/v1/status/config` returns promxy's configuration, including any secrets
+inlined in the config file. This is another reason to prefer `*_file` secret
+references.
+
+## Container
+
+The published image runs as `nobody`. If you build your own, keep it that way —
+promxy needs no privileges.

--- a/docs/guides/security.md
+++ b/docs/guides/security.md
@@ -1,14 +1,13 @@
 # Security
 
-Promxy has two distinct security surfaces: **inbound** (clients talking to
-promxy) and **outbound** (promxy talking to your Prometheus servers). They are
-configured in different places.
+Two surfaces, configured in different places: **inbound** (clients → promxy) and
+**outbound** (promxy → your Prometheus servers).
 
-## Inbound: serving promxy over TLS
+## Inbound: TLS
 
 Promxy uses the standard Prometheus
-[web configuration file](https://prometheus.io/docs/prometheus/latest/configuration/https/),
-passed via `--web.config.file`. The flag is marked experimental.
+[web configuration file](https://prometheus.io/docs/prometheus/latest/configuration/https/)
+via `--web.config.file` (marked experimental).
 
 ```
 promxy --config=config.yaml --web.config.file=web.yml
@@ -22,14 +21,7 @@ tls_server_config:
   # optional mTLS
   client_auth_type: RequireAndVerifyClientCert
   client_ca_file: test-ca.crt
-```
 
-Relative `cert_file` / `key_file` paths resolve against the directory containing
-the web config file.
-
-The same file also carries:
-
-```yaml
 http_server_config:
   headers:
     Content-Security-Policy: "default-src 'self';"
@@ -39,17 +31,17 @@ basic_auth_users:
   alice: $2y$10$...   # bcrypt hash
 ```
 
-The file is validated at startup, so a broken web config fails fast rather than
-serving plaintext.
+Relative `cert_file` / `key_file` paths resolve against the web config file's
+directory. The file is validated at startup, so a broken config fails fast
+rather than serving plaintext.
 
-> A `tls_server_config` key in promxy's **main** config file is accepted by the
-> parser but has no effect. TLS comes from `--web.config.file` only.
+> A `tls_server_config` key in promxy's **main** config file is parsed but has
+> no effect. TLS comes from `--web.config.file` only.
 
 ### Legacy flat schema
 
 Before promxy delegated its web server to `exporter-toolkit`, TLS keys lived at
-the *top level* of the web config file rather than nested under
-`tls_server_config`:
+the top level of the web config file:
 
 ```yaml
 # deprecated
@@ -57,49 +49,48 @@ cert_file: server.crt
 key_file: server.key
 ```
 
-Promxy still serves this schema for backward compatibility, logging a
-deprecation warning at startup. Support will be removed in a future release —
-nest the keys under `tls_server_config:`.
+Still served for backward compatibility, with a deprecation warning at startup.
+Support will be removed in a future release — nest the keys under
+`tls_server_config:`.
 
-## Inbound: authentication and authorization
+## Inbound: authentication
 
-**Promxy provides no authentication or authorization of its own** beyond the
-`basic_auth_users` supported by the web config file. There is no per-tenant
-access control, and nothing in promxy restricts which series a caller may query.
+**Promxy has no authentication or authorization of its own** beyond
+`basic_auth_users` in the web config file. Nothing restricts which series a
+caller may query.
 
-For anything more than basic auth, put a proxy in front of promxy:
+For more than basic auth, put a proxy in front:
 
-- **Kubernetes ingress** — e.g. nginx ingress with an auth annotation
-- **A reverse proxy** — nginx/Envoy doing auth, as in the
+- **Kubernetes ingress** with an auth annotation
+- **nginx/Envoy**, as in the
   [Prometheus basic-auth guide](https://prometheus.io/docs/guides/basic-auth/)
 - **[prom-label-proxy](https://github.com/prometheus-community/prom-label-proxy)**
-  — enforces a *trusted* label matcher on every query, which is the right tool
-  for real tenant isolation
+  — enforces a *trusted* label matcher on every query; the right tool for tenant
+  isolation
 
 ### Why `label_filter` and `inject_matchers` are not security features
 
-Both operate on the query's matchers, and both trust the downstream to honour
-them:
+Both operate on query matchers and trust the downstream to honour them:
 
-- `label_filter` decides whether to *send* a query based on its matchers. A
-  caller who matches on a different label bypasses the filter.
-- `inject_matchers` *adds* matchers to the query, but a caller who controls the
-  query text can construct expressions that work around them.
+- `label_filter` decides whether to *send* a query. A caller matching on a
+  different label bypasses it.
+- `inject_matchers` *adds* matchers, but a caller who controls the query text
+  can construct expressions around them.
 
-They are performance and scoping tools. Use a trusted-label proxy for isolation.
-See [Multi-tenancy](multi-tenancy.md).
+They are performance and scoping tools. See
+[Multi-tenancy](multi-tenancy.md).
 
 ### CORS
 
-`--web.cors.origin` (default `.*`) is a fully-anchored regex for allowed
-origins. The default allows any origin; tighten it if promxy is reachable from a
-browser context you don't control.
+`--web.cors.origin` (default `.*`) is a fully-anchored regex. The default allows
+any origin; tighten it if promxy is reachable from a browser context you don't
+control.
 
 ## Outbound: authenticating to downstreams
 
-Per server group, `http_client` inlines Prometheus'
+Per group, `http_client` inlines Prometheus'
 [HTTP client config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_config),
-plus a `sigv4` block for AWS-signed requests (Amazon Managed Prometheus):
+plus `sigv4` for AWS-signed requests (Amazon Managed Prometheus):
 
 ```yaml
 promxy:
@@ -117,31 +108,26 @@ promxy:
           password_file: /etc/promxy/password
 ```
 
-**At most one** authentication method may be configured per group —
-`basic_auth`, `authorization`, `bearer_token`, `bearer_token_file`, or `sigv4`.
-Configuring more than one is a config error caught at load time.
+**At most one** auth method per group — `basic_auth`, `authorization`,
+`bearer_token`, `bearer_token_file`, or `sigv4`. More than one is a config error
+at load time.
 
-Prefer the `*_file` variants (`password_file`, `bearer_token_file`) so secrets
-aren't sitting in the config file that promxy serves back from
-`/api/v1/status/config`.
+Prefer the `*_file` variants so secrets aren't inlined in the config file promxy
+serves back from `/api/v1/status/config`.
 
 ### Forwarding caller credentials
 
-`--proxy-headers` forwards named headers from the incoming request to
-downstream server groups:
+`--proxy-headers` (or `PROXY_HEADERS`) forwards named request headers to
+downstream groups, letting an authenticating layer in front of promxy pass a
+caller's identity through for the backends to enforce:
 
 ```
 promxy --proxy-headers=Authorization --proxy-headers=X-Scope-OrgID
 ```
 
-It can also be set via the `PROXY_HEADERS` environment variable. This lets an
-authenticating layer in front of promxy pass a caller's identity through to the
-backends, so the backends can enforce it.
-
 ### Static headers
 
-For a fixed credential per group — the common case for Mimir/Cortex tenancy —
-use `http_headers`:
+For a fixed per-group credential, typically Mimir/Cortex tenancy:
 
 ```yaml
 http_headers:
@@ -150,18 +136,12 @@ http_headers:
 
 ## Exposed endpoints
 
-Promxy exposes the full Prometheus UI and API, plus `/debug/pprof/*`. If promxy
-is reachable beyond your trusted network, restrict `/debug` at your proxy —
-pprof endpoints are a denial-of-service and information-disclosure surface.
-
-`--web.enable-lifecycle` adds `POST /-/reload`. Leave it off unless something
-needs it, and restrict it if on.
-
-`/api/v1/status/config` returns promxy's configuration, including any secrets
-inlined in the config file. This is another reason to prefer `*_file` secret
-references.
+- `/debug/pprof/*` — a DoS and information-disclosure surface. Restrict at your
+  proxy if promxy is reachable beyond your trusted network.
+- `/api/v1/status/config` — returns promxy's config, including inlined secrets.
+- `/-/reload` — only with `--web.enable-lifecycle`. Leave it off unless needed.
 
 ## Container
 
-The published image runs as `nobody`. If you build your own, keep it that way —
+The published image runs as `nobody`. Keep it that way in your own builds;
 promxy needs no privileges.

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -1,0 +1,141 @@
+# Metrics
+
+Promxy exposes its own metrics on `/metrics` (configurable with
+`--metrics-path`). They fall into three groups: promxy's own, the Prometheus
+libraries promxy embeds, and the usual Go/process metrics.
+
+Note that label-bearing metrics only appear **after their first observation** —
+`server_group_request_duration_seconds` is absent until promxy has made a
+downstream request, and the `promxy_label_filter_*` metrics are absent until a
+`label_filter` is configured and has run.
+
+## Promxy's own
+
+### `server_group_targets`
+
+Gauge. Number of targets currently discovered for a server group.
+
+Labels: `ordinal` (the group's index in the config, always unique), `name` (the
+optional `name:` from the config; empty when unset).
+
+```
+server_group_targets{name="g1",ordinal="0"} 2
+```
+
+This is the single most valuable promxy alert. A group that discovers zero
+targets answers every query with an error — or, with `ignore_error`, silently
+contributes nothing:
+
+```yaml
+- alert: PromxyServerGroupEmpty
+  expr: server_group_targets == 0
+  for: 5m
+  annotations:
+    summary: "promxy server group {{ $labels.ordinal }} ({{ $labels.name }}) has no targets"
+```
+
+Promxy also logs a warning whenever a group transitions to zero targets, and at
+startup if a group begins with none.
+
+### `server_group_request_duration_seconds`
+
+Summary. Latency of calls promxy makes to individual downstream targets.
+
+Labels:
+
+- `host` — the downstream target
+- `call` — `query`, `query_range`, `get_value`, `series`, `label_names`,
+  `label_values`, `query_exemplars`
+- `status` — `success` or `error`
+
+```
+server_group_request_duration_seconds_count{call="query",host="prom-01:9090",status="error"} 1
+```
+
+Downstream error rate:
+
+```promql
+sum(rate(server_group_request_duration_seconds_count{status="error"}[5m])) by (host)
+  /
+sum(rate(server_group_request_duration_seconds_count[5m])) by (host)
+```
+
+`get_value` is the raw-data fetch used when a query could not be pushed down. A
+high `get_value` share relative to `query`/`query_range` means promxy is pulling
+raw series back and evaluating locally — see
+[Architecture](../concepts/architecture.md#query-pushdown-nodereplacer).
+
+### `promxy_label_filter_sync_count_total`
+
+Counter, labelled by `status`. Syncs completed by a `label_filter`.
+
+### `promxy_label_filter_sync_duration_seconds`
+
+Summary, labelled by `status`. Sync latency.
+
+### `promxy_label_filter_filtered_count_total`
+
+Counter, labelled by `type` (query type). Requests the filter prevented from
+being sent downstream. If this stays at zero, your `label_filter` is buying
+nothing. See [Label filtering](../guides/label-filtering.md).
+
+### Config reload
+
+- `prometheus_config_last_reload_successful` — `1` or `0`
+- `prometheus_config_last_reload_success_timestamp_seconds`
+- `process_reload_time_seconds` — timestamp of the last `SIGHUP`
+
+```yaml
+- alert: PromxyConfigReloadFailed
+  expr: prometheus_config_last_reload_successful == 0
+  for: 5m
+```
+
+### `promxy_build_info`
+
+Constant `1`, labelled with `version`, `revision`, `branch`, `goversion`,
+`goos`, `goarch`.
+
+## Inherited from the Prometheus libraries
+
+Promxy embeds Prometheus' query engine, rule manager, notifier, service
+discovery, and remote_write, and they register their usual metrics. These behave
+exactly as documented upstream.
+
+| Family | Covers |
+| ------ | ------ |
+| `prometheus_engine_*` | Query duration, samples, concurrency (`prometheus_engine_query_duration_seconds`, `prometheus_engine_query_samples_total`, `prometheus_engine_queries`, `prometheus_engine_queries_concurrent_max`) |
+| `prometheus_rule_*` | Rule evaluation (`prometheus_rule_evaluation_duration_seconds`, `prometheus_rule_evaluation_failures_total`, `prometheus_rule_group_iterations_missed_total`) |
+| `prometheus_notifications_*` | Alertmanager delivery (`prometheus_notifications_dropped_total`, `prometheus_notifications_queue_length`, `prometheus_notifications_queue_capacity`, `prometheus_notifications_alertmanagers_discovered`) |
+| `prometheus_remote_storage_*` | `remote_write` shipping (`prometheus_remote_storage_samples_pending`, `prometheus_remote_storage_samples_failed_total`, `prometheus_remote_storage_shards`, `prometheus_remote_storage_sent_batch_duration_seconds`) |
+| `prometheus_agent_*`, `prometheus_wal_*` | The WAL backing `remote_write` |
+| `prometheus_sd_*` | Service discovery (`prometheus_sd_discovered_targets`, `prometheus_sd_failed_configs`, per-mechanism failure counters) |
+| `prometheus_http_*`, `prometheus_api_*` | Promxy's own HTTP surface |
+
+Useful alerts from these:
+
+```yaml
+- alert: PromxyAlertNotificationsDropped
+  expr: rate(prometheus_notifications_dropped_total[5m]) > 0
+
+- alert: PromxyRuleEvaluationFailures
+  expr: rate(prometheus_rule_evaluation_failures_total[5m]) > 0
+
+- alert: PromxyRemoteWriteFallingBehind
+  expr: prometheus_remote_storage_samples_pending > 0 and rate(prometheus_remote_storage_samples_failed_total[5m]) > 0
+
+- alert: PromxyMissedRuleEvaluations
+  expr: rate(prometheus_rule_group_iterations_missed_total[5m]) > 0
+```
+
+## Go and process metrics
+
+The standard `go_*`, `process_*`, and `promhttp_*` collectors. Watch
+`process_open_fds` against `process_max_fds` — each server group holds up to
+`max_idle_conns` (default 20000) idle connections.
+
+## Dashboard
+
+A Grafana dashboard for promxy is included at the repo root:
+[`grafana.dashboard`](../../grafana.dashboard). It is marked WIP — treat it as a
+starting point rather than a finished product.

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -1,13 +1,11 @@
 # Metrics
 
-Promxy exposes its own metrics on `/metrics` (configurable with
-`--metrics-path`). They fall into three groups: promxy's own, the Prometheus
-libraries promxy embeds, and the usual Go/process metrics.
+Promxy exposes metrics on `/metrics` (path set by `--metrics-path`): its own,
+those of the Prometheus libraries it embeds, and the usual Go/process ones.
 
-Note that label-bearing metrics only appear **after their first observation** —
+Label-bearing metrics only appear **after their first observation**.
 `server_group_request_duration_seconds` is absent until promxy has made a
-downstream request, and the `promxy_label_filter_*` metrics are absent until a
-`label_filter` is configured and has run.
+downstream request; `promxy_label_filter_*` until a `label_filter` has run.
 
 ## Promxy's own
 
@@ -15,16 +13,15 @@ downstream request, and the `promxy_label_filter_*` metrics are absent until a
 
 Gauge. Number of targets currently discovered for a server group.
 
-Labels: `ordinal` (the group's index in the config, always unique), `name` (the
-optional `name:` from the config; empty when unset).
+Labels: `ordinal` (the group's index in the config, always unique) and `name`
+(the optional `name:`, empty when unset).
 
 ```
 server_group_targets{name="g1",ordinal="0"} 2
 ```
 
-This is the single most valuable promxy alert. A group that discovers zero
-targets answers every query with an error — or, with `ignore_error`, silently
-contributes nothing:
+The most valuable promxy alert. A group with zero targets errors every query,
+or with `ignore_error` silently contributes nothing:
 
 ```yaml
 - alert: PromxyServerGroupEmpty
@@ -34,8 +31,8 @@ contributes nothing:
     summary: "promxy server group {{ $labels.ordinal }} ({{ $labels.name }}) has no targets"
 ```
 
-Promxy also logs a warning whenever a group transitions to zero targets, and at
-startup if a group begins with none.
+Promxy also logs a warning when a group transitions to zero targets, and at
+startup if one begins with none.
 
 ### `server_group_request_duration_seconds`
 
@@ -60,9 +57,9 @@ sum(rate(server_group_request_duration_seconds_count{status="error"}[5m])) by (h
 sum(rate(server_group_request_duration_seconds_count[5m])) by (host)
 ```
 
-`get_value` is the raw-data fetch used when a query could not be pushed down. A
-high `get_value` share relative to `query`/`query_range` means promxy is pulling
-raw series back and evaluating locally — see
+`get_value` is the raw-data fetch used when a query couldn't be pushed down. A
+high `get_value` share relative to `query`/`query_range` means promxy is
+evaluating locally — see
 [Architecture](../concepts/architecture.md#query-pushdown-nodereplacer).
 
 ### `promxy_label_filter_sync_count_total`
@@ -75,9 +72,9 @@ Summary, labelled by `status`. Sync latency.
 
 ### `promxy_label_filter_filtered_count_total`
 
-Counter, labelled by `type` (query type). Requests the filter prevented from
-being sent downstream. If this stays at zero, your `label_filter` is buying
-nothing. See [Label filtering](../guides/label-filtering.md).
+Counter, labelled by `type` (query type). Requests the filter kept from going
+downstream. Zero means the filter is buying nothing. See
+[Label filtering](../guides/label-filtering.md).
 
 ### Config reload
 
@@ -99,8 +96,8 @@ Constant `1`, labelled with `version`, `revision`, `branch`, `goversion`,
 ## Inherited from the Prometheus libraries
 
 Promxy embeds Prometheus' query engine, rule manager, notifier, service
-discovery, and remote_write, and they register their usual metrics. These behave
-exactly as documented upstream.
+discovery, and remote_write; each registers its usual metrics, which behave as
+documented upstream.
 
 | Family | Covers |
 | ------ | ------ |
@@ -130,12 +127,11 @@ Useful alerts from these:
 
 ## Go and process metrics
 
-The standard `go_*`, `process_*`, and `promhttp_*` collectors. Watch
-`process_open_fds` against `process_max_fds` — each server group holds up to
+The standard `go_*`, `process_*`, `promhttp_*` collectors. Watch
+`process_open_fds` against `process_max_fds`: each group holds up to
 `max_idle_conns` (default 20000) idle connections.
 
 ## Dashboard
 
-A Grafana dashboard for promxy is included at the repo root:
-[`grafana.dashboard`](../../grafana.dashboard). It is marked WIP — treat it as a
-starting point rather than a finished product.
+[`grafana.dashboard`](../../grafana.dashboard) at the repo root. Marked WIP —
+a starting point, not a finished product.

--- a/docs/operations/running.md
+++ b/docs/operations/running.md
@@ -1,0 +1,119 @@
+# Running promxy
+
+## HTTP endpoints
+
+Promxy serves the full Prometheus web UI and v1 API, plus a few endpoints of its
+own. Everything is under `--web.route-prefix` (which defaults to the path of
+`--web.external-url`).
+
+| Endpoint | Notes |
+| -------- | ----- |
+| `/` and the rest of the UI | The Prometheus UI, served from assets embedded by the `builtinassets` build tag. |
+| `/api/v1/*` | The Prometheus v1 API — `query`, `query_range`, `series`, `labels`, `label/<name>/values`, `read`, `rules`, `alerts`, `targets`, … |
+| `/api/v1/status/config` | Promxy's own handler, returning promxy's config rather than a Prometheus one. |
+| `/api/v1/metadata` | Promxy's own handler, aggregating metadata across server groups. |
+| `/federate` | Promxy's own federation handler, with a faster text encoder. |
+| `/metrics` | Promxy's own metrics. Path configurable with `--metrics-path`. |
+| `/-/ready` | Readiness. Returns `503` once promxy is shutting down. |
+| `/debug/pprof/*` | Go pprof handlers. Restrict these if promxy is exposed. |
+| `/-/reload` | Config reload. Only with `--web.enable-lifecycle`. |
+
+Promxy also implements the **remote_read** API, so another Prometheus (or a
+second promxy) can use promxy as a remote_read backend. It serves the
+`STREAMED_XOR_CHUNKS` response type that a stock Prometheus client negotiates by
+default. `--remote-read.max-concurrency` (default `10`) bounds concurrent reads.
+
+## Layering promxy
+
+Promxy aggregates Prometheus-compatible API endpoints, so a promxy can be a
+downstream of another promxy. You can also mix implementations in one
+deployment — Prometheus, promxy, VictoriaMetrics, Mimir, Thanos — since they all
+expose a compatible API.
+
+## Configuration reload
+
+Two ways to reload:
+
+```
+kill -HUP $(pidof promxy)
+```
+
+```
+curl -XPOST http://localhost:8082/-/reload    # requires --web.enable-lifecycle
+```
+
+Reloads are atomic and safe: promxy builds the entire new state (server groups,
+discovery, rule manager, remote_write, alert templates), waits for every group
+to become ready, and only then swaps it in and cancels the old one. If any part
+fails to apply, the new state is discarded and the previous configuration keeps
+serving.
+
+Two metrics track this:
+
+- `prometheus_config_last_reload_successful` — `1`/`0`
+- `prometheus_config_last_reload_success_timestamp_seconds`
+- `process_reload_time_seconds` — timestamp of the last `SIGHUP`
+
+A failed reload also raises a banner in the UI via the notifications API, which
+is cleared on the next success.
+
+Validate before reloading:
+
+```
+promxy --config=config.yaml --check-config
+```
+
+## Graceful shutdown
+
+On `SIGTERM` or `SIGINT`, promxy shuts down in stages:
+
+1. Start failing `/-/ready` with `503`, and publish a "shutting down" notice to
+   connected UIs.
+2. Stop the alert notifier and the rule manager.
+3. Sleep for `--http.shutdown-delay` (default `10s`) while still serving
+   traffic. This is the drain window — it gives load balancers time to notice
+   the failing health check and stop sending new requests.
+4. Shut the HTTP server down gracefully, waiting up to
+   `--http.shutdown-timeout` (default `60s`) for in-flight requests.
+
+Match `--http.shutdown-delay` to your load balancer's health-check interval
+times its unhealthy threshold, or you will drop requests during rollouts. Make
+sure your orchestrator's termination grace period exceeds
+`shutdown-delay + shutdown-timeout` — in Kubernetes that is
+`terminationGracePeriodSeconds`, which defaults to 30s and is therefore *too
+short* for promxy's defaults.
+
+Note that `/-/quit` is routed by the embedded Prometheus web handler when
+`--web.enable-lifecycle` is set, but promxy does not act on it. Use `SIGTERM`.
+
+## Deployment shape
+
+Promxy is stateless, so run several replicas behind a load balancer and let them
+all share the same config.
+
+The one caveat is **rules**. Every replica evaluates every rule independently, so
+N replicas send N copies of each alert. Alertmanager deduplicates identical
+alerts, so this is normally fine and is in fact how you get HA alerting — but it
+does multiply the query load of rule evaluation across your downstreams, and it
+multiplies recording-rule writes to `remote_write`.
+
+## Resource notes
+
+- **CPU** scales with query volume and with how much of each query promxy has to
+  evaluate locally rather than push down. See
+  [Architecture](../concepts/architecture.md#query-pushdown-nodereplacer).
+- **Memory** scales with the raw data pulled back for locally-evaluated queries.
+  `--query.max-samples` (default 50M) is the backstop.
+- **File descriptors**: each server group keeps up to `max_idle_conns` (default
+  20000) idle connections, `max_idle_conns_per_host` (default 1000) per host.
+  Raise your process limits accordingly, or lower these if you have many groups.
+
+## Deployment manifests
+
+- [`deploy/docker`](../../deploy/docker) — docker-compose stack with
+  VictoriaMetrics and Alertmanager
+- [`deploy/k8s/promxy.yaml`](../../deploy/k8s/promxy.yaml) — plain Kubernetes
+  manifests (namespace, RBAC for `kubernetes_sd_configs`, ConfigMap, Deployment)
+- [`deploy/k8s/helm-charts/promxy`](../../deploy/k8s/helm-charts/promxy) — Helm
+  chart, with optional PDB, HPA, VPA, ingress, and a configmap-reload sidecar
+  that triggers promxy's reload when the config changes

--- a/docs/operations/running.md
+++ b/docs/operations/running.md
@@ -2,118 +2,104 @@
 
 ## HTTP endpoints
 
-Promxy serves the full Prometheus web UI and v1 API, plus a few endpoints of its
-own. Everything is under `--web.route-prefix` (which defaults to the path of
+Promxy serves the full Prometheus web UI and v1 API plus a few of its own
+endpoints, all under `--web.route-prefix` (defaults to the path of
 `--web.external-url`).
 
 | Endpoint | Notes |
 | -------- | ----- |
-| `/` and the rest of the UI | The Prometheus UI, served from assets embedded by the `builtinassets` build tag. |
-| `/api/v1/*` | The Prometheus v1 API — `query`, `query_range`, `series`, `labels`, `label/<name>/values`, `read`, `rules`, `alerts`, `targets`, … |
-| `/api/v1/status/config` | Promxy's own handler, returning promxy's config rather than a Prometheus one. |
-| `/api/v1/metadata` | Promxy's own handler, aggregating metadata across server groups. |
+| `/` and the UI | Prometheus UI, from assets embedded by the `builtinassets` build tag. |
+| `/api/v1/*` | Prometheus v1 API — `query`, `query_range`, `series`, `labels`, `label/<name>/values`, `read`, `rules`, `alerts`, `targets`, … |
+| `/api/v1/status/config` | Promxy's own handler, returning promxy's config. |
+| `/api/v1/metadata` | Promxy's own handler, aggregating metadata across groups. |
 | `/federate` | Promxy's own federation handler, with a faster text encoder. |
-| `/metrics` | Promxy's own metrics. Path configurable with `--metrics-path`. |
-| `/-/ready` | Readiness. Returns `503` once promxy is shutting down. |
-| `/debug/pprof/*` | Go pprof handlers. Restrict these if promxy is exposed. |
-| `/-/reload` | Config reload. Only with `--web.enable-lifecycle`. |
+| `/metrics` | Promxy's metrics. Path set by `--metrics-path`. |
+| `/-/ready` | Readiness. `503` once shutting down. |
+| `/debug/pprof/*` | Go pprof. Restrict if promxy is exposed. |
+| `/-/reload` | Config reload. Requires `--web.enable-lifecycle`. |
 
-Promxy also implements the **remote_read** API, so another Prometheus (or a
-second promxy) can use promxy as a remote_read backend. It serves the
-`STREAMED_XOR_CHUNKS` response type that a stock Prometheus client negotiates by
-default. `--remote-read.max-concurrency` (default `10`) bounds concurrent reads.
+Promxy also implements **remote_read**, so another Prometheus (or promxy) can
+use it as a remote_read backend. It serves the `STREAMED_XOR_CHUNKS` response
+type a stock Prometheus client negotiates by default;
+`--remote-read.max-concurrency` (default `10`) bounds concurrent reads.
 
-## Layering promxy
-
-Promxy aggregates Prometheus-compatible API endpoints, so a promxy can be a
-downstream of another promxy. You can also mix implementations in one
-deployment — Prometheus, promxy, VictoriaMetrics, Mimir, Thanos — since they all
-expose a compatible API.
+Promxy can be a downstream of another promxy, and you can mix implementations —
+Prometheus, promxy, VictoriaMetrics, Mimir, Thanos — since all expose a
+compatible API.
 
 ## Configuration reload
 
-Two ways to reload:
-
 ```
 kill -HUP $(pidof promxy)
-```
-
-```
 curl -XPOST http://localhost:8082/-/reload    # requires --web.enable-lifecycle
 ```
 
-Reloads are atomic and safe: promxy builds the entire new state (server groups,
+Reloads are atomic: promxy builds the entire new state (server groups,
 discovery, rule manager, remote_write, alert templates), waits for every group
-to become ready, and only then swaps it in and cancels the old one. If any part
-fails to apply, the new state is discarded and the previous configuration keeps
-serving.
+to be ready, then swaps it in and cancels the old one. If any part fails to
+apply, the new state is discarded and the previous config keeps serving.
 
-Two metrics track this:
+Metrics:
 
 - `prometheus_config_last_reload_successful` — `1`/`0`
 - `prometheus_config_last_reload_success_timestamp_seconds`
 - `process_reload_time_seconds` — timestamp of the last `SIGHUP`
 
-A failed reload also raises a banner in the UI via the notifications API, which
-is cleared on the next success.
+A failed reload also raises a UI banner via the notifications API, cleared on
+the next success.
 
-Validate before reloading:
-
-```
-promxy --config=config.yaml --check-config
-```
+Validate first with `promxy --config=config.yaml --check-config`.
 
 ## Graceful shutdown
 
-On `SIGTERM` or `SIGINT`, promxy shuts down in stages:
+On `SIGTERM` / `SIGINT`:
 
-1. Start failing `/-/ready` with `503`, and publish a "shutting down" notice to
+1. `/-/ready` starts returning `503`, and a "shutting down" notice goes to
    connected UIs.
-2. Stop the alert notifier and the rule manager.
-3. Sleep for `--http.shutdown-delay` (default `10s`) while still serving
-   traffic. This is the drain window — it gives load balancers time to notice
-   the failing health check and stop sending new requests.
-4. Shut the HTTP server down gracefully, waiting up to
+2. The alert notifier and rule manager stop.
+3. Promxy keeps serving for `--http.shutdown-delay` (default `10s`) — the drain
+   window, letting load balancers notice the failing health check.
+4. The HTTP server shuts down gracefully, waiting up to
    `--http.shutdown-timeout` (default `60s`) for in-flight requests.
 
-Match `--http.shutdown-delay` to your load balancer's health-check interval
-times its unhealthy threshold, or you will drop requests during rollouts. Make
-sure your orchestrator's termination grace period exceeds
-`shutdown-delay + shutdown-timeout` — in Kubernetes that is
-`terminationGracePeriodSeconds`, which defaults to 30s and is therefore *too
-short* for promxy's defaults.
+Two things to get right:
 
-Note that `/-/quit` is routed by the embedded Prometheus web handler when
-`--web.enable-lifecycle` is set, but promxy does not act on it. Use `SIGTERM`.
+- `--http.shutdown-delay` ≥ your health-check interval × unhealthy threshold,
+  or you drop requests during rollouts.
+- Your orchestrator's grace period must exceed
+  `shutdown-delay + shutdown-timeout`. Kubernetes'
+  `terminationGracePeriodSeconds` defaults to 30s — shorter than promxy's
+  `10s + 60s`.
+
+`/-/quit` is routed when `--web.enable-lifecycle` is set but promxy does not act
+on it. Use `SIGTERM`.
 
 ## Deployment shape
 
-Promxy is stateless, so run several replicas behind a load balancer and let them
-all share the same config.
+Promxy is stateless: run several replicas behind a load balancer sharing one
+config.
 
-The one caveat is **rules**. Every replica evaluates every rule independently, so
-N replicas send N copies of each alert. Alertmanager deduplicates identical
-alerts, so this is normally fine and is in fact how you get HA alerting — but it
-does multiply the query load of rule evaluation across your downstreams, and it
-multiplies recording-rule writes to `remote_write`.
+The caveat is **rules**. Every replica evaluates every rule, so N replicas send
+N copies of each alert. Alertmanager deduplicates them — this is how you get HA
+alerting — but it multiplies rule-evaluation query load on your downstreams and
+recording-rule writes to `remote_write`.
 
 ## Resource notes
 
-- **CPU** scales with query volume and with how much of each query promxy has to
-  evaluate locally rather than push down. See
+- **CPU** scales with query volume and with how much promxy evaluates locally
+  rather than pushing down. See
   [Architecture](../concepts/architecture.md#query-pushdown-nodereplacer).
-- **Memory** scales with the raw data pulled back for locally-evaluated queries.
+- **Memory** scales with raw data pulled back for local evaluation.
   `--query.max-samples` (default 50M) is the backstop.
-- **File descriptors**: each server group keeps up to `max_idle_conns` (default
-  20000) idle connections, `max_idle_conns_per_host` (default 1000) per host.
-  Raise your process limits accordingly, or lower these if you have many groups.
+- **File descriptors**: each group keeps up to `max_idle_conns` (default 20000)
+  idle connections, `max_idle_conns_per_host` (default 1000) per host. Raise
+  process limits, or lower these if you have many groups.
 
 ## Deployment manifests
 
-- [`deploy/docker`](../../deploy/docker) — docker-compose stack with
-  VictoriaMetrics and Alertmanager
-- [`deploy/k8s/promxy.yaml`](../../deploy/k8s/promxy.yaml) — plain Kubernetes
-  manifests (namespace, RBAC for `kubernetes_sd_configs`, ConfigMap, Deployment)
+- [`deploy/docker`](../../deploy/docker) — docker-compose with VictoriaMetrics
+  and Alertmanager
+- [`deploy/k8s/promxy.yaml`](../../deploy/k8s/promxy.yaml) — namespace, RBAC for
+  `kubernetes_sd_configs`, ConfigMap, Deployment
 - [`deploy/k8s/helm-charts/promxy`](../../deploy/k8s/helm-charts/promxy) — Helm
-  chart, with optional PDB, HPA, VPA, ingress, and a configmap-reload sidecar
-  that triggers promxy's reload when the config changes
+  chart with optional PDB, HPA, VPA, ingress, and a configmap-reload sidecar

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,234 @@
+# Troubleshooting
+
+## Reading promxy's errors
+
+Promxy annotates errors as they propagate up the client stack, so a downstream
+failure names the exact target and the exact group:
+
+```json
+{
+  "status": "error",
+  "errorType": "execution",
+  "error": "error in servergroup ord=0: error in target=http://127.0.0.1:19090: Post \"http://127.0.0.1:19090/api/v1/query\": dial tcp 127.0.0.1:19090: connect: connection refused"
+}
+```
+
+`ord=0` is the server group's index in your config — the same value as the
+`ordinal` label on `server_group_targets`. Give your groups a `name:` and it
+also shows up in logs and that metric.
+
+`--log-level=debug` logs every downstream request, including the rewritten query
+promxy actually sent, which is the fastest way to see what pushdown did.
+
+## Promxy won't start
+
+### It hangs at startup with no error
+
+Most likely a `label_filter` with the default `on_sync_error: abort`. Promxy
+blocks until the filter's first sync from the downstream succeeds, retrying
+every 5s, so one unreachable downstream stops startup entirely.
+
+Either fix the downstream, or choose an explicit failure mode:
+
+```yaml
+label_filter:
+  on_sync_error: open    # serve unfiltered until the first sync lands
+```
+
+See [Label filtering](../guides/label-filtering.md#startup-behaviour-on_sync_error).
+
+### `promxy doesn't support recording rules`
+
+Promxy has no local TSDB, so recording rules need somewhere to write. Add a
+`remote_write` endpoint. See
+[Rules and alerting](../guides/rules-and-alerting.md).
+
+### `--storage.path must be set if you wish to enable max query concurrency limits`
+
+`--query.max-concurrency` needs the active query tracker, which is a file on
+disk. Either set `--storage.path` or leave concurrency unlimited (`-1`, the
+default).
+
+### `--storage.tsdb.path and --storage.path are mutually exclusive`
+
+`--storage.tsdb.path` is a deprecated alias — promxy has no TSDB and the flag is
+misnamed. Use `--storage.path` alone.
+
+### `at most one of basic_auth, authorization, bearer_token, bearer_token_file, sigv4 must be configured`
+
+A server group's `http_client` has more than one authentication method. Pick
+one.
+
+## Queries fail or return errors
+
+### One dead shard fails every query
+
+That is the default, and it is deliberate: a missing shard means silently
+missing data, and promxy would rather error than hand alerting rules a wrong
+answer.
+
+To opt a group out, per group:
+
+- `downgrade_error: true` — errors become warnings on the response. Preferred.
+- `ignore_error: true` — errors are dropped entirely.
+
+See [HA and merging](../concepts/ha-and-merging.md#availability-vs-correctness).
+
+### Errors mentioning histogram fidelity
+
+A query involving native histograms hit a group with no `remote_read`. Promxy
+fails loud rather than serve degraded histogram data.
+
+```yaml
+remote_read: true
+```
+
+Or accept the loss explicitly with `native_histogram.allow_lossy: true`. See
+[Native histograms](../guides/native-histograms.md).
+
+### Queries time out
+
+Check `server_group_request_duration_seconds` by `host` to find the slow
+downstream. Promxy's goal is to be no slower than the slowest server it has to
+talk to, so a slow query here is usually a slow query *there*.
+
+The relevant knobs are `--query.timeout` (default `2m`) on promxy, and per
+group, `timeout` (response headers) and `http_client.dial_timeout` (default
+`200ms` — low enough that a slow-to-accept downstream will fail).
+
+If promxy is meaningfully slower than a downstream for the same query, that is
+worth [an issue](https://github.com/jacksontj/promxy/issues).
+
+## Wrong data
+
+### `count(up)` and other label-less aggregations are too low
+
+Two server groups are returning data promxy considers duplicates. Either:
+
+- Two groups genuinely hold the same series and lack distinguishing `labels` —
+  add a static label per group.
+- You put several tenants in one group (e.g. multiple tenants in a single
+  `X-Scope-OrgID` header). Model each `(backend, tenant)` pair as its own group.
+  See [Multi-tenancy](../guides/multi-tenancy.md).
+
+### `count_over_time` is roughly double
+
+`anti_affinity` is too small, so skewed duplicates from HA replicas are
+surviving the merge. Set it to your scrape interval.
+
+If a single group hosts metrics scraped at *different* intervals, no single
+value is right — set `anti_affinity_dynamic: true`. See
+[HA and merging](../concepts/ha-and-merging.md).
+
+### Series look thinned out / samples are missing
+
+`anti_affinity` is too large: legitimately-spaced samples are being treated as
+duplicates and dropped. It should be your scrape interval, not a multiple of it.
+
+### HA replicas aren't being merged at all
+
+Your Prometheus servers are probably adding a distinguishing external label
+(`replica`, `prometheus_replica`). Different label sets means different series,
+so there is nothing to merge. Drop it in the query path:
+
+```yaml
+metrics_relabel_configs:
+  - action: labeldrop
+    source_label: replica
+```
+
+### A Mimir/Cortex group returns nothing for `query_range`
+
+Mimir and Cortex snap `query_range` output to the epoch step grid. If the
+request start isn't a multiple of the step, the returned samples can sit far
+enough off promxy's grid that the lookback delta doesn't reach them.
+
+```yaml
+align_query_range_with_step: true
+```
+
+Set this only for backends that actually step-align — vanilla Prometheus does
+not. See [issue #787](https://github.com/jacksontj/promxy/issues/787).
+
+### A group returns nothing and you're using `label_filter`
+
+The filter may be stale or wrong. Check
+`promxy_label_filter_filtered_count_total`, and remember that
+`static_labels_exclude` is applied **last**, overriding both dynamic and static
+includes.
+
+## Discovery
+
+### A group has zero targets
+
+`server_group_targets{ordinal="N"} == 0`, and promxy logs a warning. Usually
+either service discovery isn't returning anything or a `relabel_configs` `keep`
+rule is dropping everything. Alert on this — see
+[Metrics](metrics.md#server_group_targets).
+
+### Downstreams resolve to an unreachable IPv6 address
+
+```yaml
+http_client:
+  dial_network: tcp4
+```
+
+Alternatively tune the dual-stack fallback with `fallback_delay` — but it must
+be **shorter than `dial_timeout`** (default `200ms`) or the dial times out
+before the fallback is ever attempted.
+
+## remote_write
+
+### `snappy: decoded length N exceeds limit 33554432`
+
+Batches are too large for the receiver's 32 MiB decompression limit. Promxy
+already defaults `max_samples_per_send` to 100 for this reason; if you raised
+it, lower it again.
+
+### Samples are lost across restarts
+
+Without `--storage.path` the remote_write WAL lives in a temp directory that is
+deleted on shutdown. Set `--storage.path` for a durable WAL.
+
+## Web UI
+
+### The UI is blank or errors
+
+The binary was built without the `builtinassets` tag, which embeds the web
+assets:
+
+```
+go build -mod=vendor -tags netgo,builtinassets
+```
+
+See [Development](../development.md).
+
+### `/-/quit` doesn't stop promxy
+
+It is routed by the embedded Prometheus web handler when
+`--web.enable-lifecycle` is set, but promxy doesn't act on it. Use `SIGTERM`.
+
+### TLS deprecation warning at startup
+
+Your `--web.config.file` uses the old flat schema. Nest the keys under
+`tls_server_config:` — see [Security](../guides/security.md#legacy-flat-schema).
+
+## Shutdown
+
+### Requests are dropped during rollouts
+
+Promxy fails `/-/ready` and then keeps serving for `--http.shutdown-delay`
+(default `10s`) so load balancers can drain. Two things to check:
+
+1. The delay is at least your health-check interval × unhealthy threshold.
+2. Your orchestrator's grace period exceeds
+   `shutdown-delay + shutdown-timeout`. Kubernetes'
+   `terminationGracePeriodSeconds` defaults to 30s, which is shorter than
+   promxy's `10s + 60s` defaults.
+
+## Still stuck?
+
+Open an [issue](https://github.com/jacksontj/promxy/issues). Include your
+config (with secrets removed), the promxy version (`promxy --version`), the
+downstream implementation and version, and debug-level logs for the failing
+query.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -13,22 +13,20 @@ failure names the exact target and the exact group:
 }
 ```
 
-`ord=0` is the server group's index in your config — the same value as the
-`ordinal` label on `server_group_targets`. Give your groups a `name:` and it
-also shows up in logs and that metric.
+`ord=0` is the group's index in your config, matching the `ordinal` label on
+`server_group_targets`. Setting `name:` on a group adds it to logs and that
+metric too.
 
-`--log-level=debug` logs every downstream request, including the rewritten query
-promxy actually sent, which is the fastest way to see what pushdown did.
+`--log-level=debug` logs every downstream request including the rewritten query,
+the fastest way to see what pushdown did.
 
 ## Promxy won't start
 
 ### It hangs at startup with no error
 
-Most likely a `label_filter` with the default `on_sync_error: abort`. Promxy
-blocks until the filter's first sync from the downstream succeeds, retrying
-every 5s, so one unreachable downstream stops startup entirely.
-
-Either fix the downstream, or choose an explicit failure mode:
+Most likely a `label_filter` with the default `on_sync_error: abort`: promxy
+blocks until the first sync succeeds, retrying every 5s, so one unreachable
+downstream stops startup. Fix the downstream, or pick an explicit failure mode:
 
 ```yaml
 label_filter:
@@ -39,20 +37,17 @@ See [Label filtering](../guides/label-filtering.md#startup-behaviour-on_sync_err
 
 ### `promxy doesn't support recording rules`
 
-Promxy has no local TSDB, so recording rules need somewhere to write. Add a
-`remote_write` endpoint. See
+Recording rules need somewhere to write. Add a `remote_write` endpoint — see
 [Rules and alerting](../guides/rules-and-alerting.md).
 
 ### `--storage.path must be set if you wish to enable max query concurrency limits`
 
-`--query.max-concurrency` needs the active query tracker, which is a file on
-disk. Either set `--storage.path` or leave concurrency unlimited (`-1`, the
-default).
+The active query tracker is a file on disk. Set `--storage.path`, or leave
+concurrency unlimited (`-1`, the default).
 
 ### `--storage.tsdb.path and --storage.path are mutually exclusive`
 
-`--storage.tsdb.path` is a deprecated alias — promxy has no TSDB and the flag is
-misnamed. Use `--storage.path` alone.
+`--storage.tsdb.path` is a deprecated, misnamed alias. Use `--storage.path`.
 
 ### `at most one of basic_auth, authorization, bearer_token, bearer_token_file, sigv4 must be configured`
 
@@ -63,11 +58,8 @@ one.
 
 ### One dead shard fails every query
 
-That is the default, and it is deliberate: a missing shard means silently
-missing data, and promxy would rather error than hand alerting rules a wrong
-answer.
-
-To opt a group out, per group:
+Deliberate: a missing shard means silently missing data, and an error beats a
+wrong answer that alerting depends on. To opt a group out:
 
 - `downgrade_error: true` — errors become warnings on the response. Preferred.
 - `ignore_error: true` — errors are dropped entirely.
@@ -76,8 +68,7 @@ See [HA and merging](../concepts/ha-and-merging.md#availability-vs-correctness).
 
 ### Errors mentioning histogram fidelity
 
-A query involving native histograms hit a group with no `remote_read`. Promxy
-fails loud rather than serve degraded histogram data.
+A histogram-bearing query hit a group with no `remote_read`.
 
 ```yaml
 remote_read: true
@@ -89,12 +80,11 @@ Or accept the loss explicitly with `native_histogram.allow_lossy: true`. See
 ### Queries time out
 
 Check `server_group_request_duration_seconds` by `host` to find the slow
-downstream. Promxy's goal is to be no slower than the slowest server it has to
-talk to, so a slow query here is usually a slow query *there*.
+downstream — a slow query here is usually a slow query *there*.
 
-The relevant knobs are `--query.timeout` (default `2m`) on promxy, and per
-group, `timeout` (response headers) and `http_client.dial_timeout` (default
-`200ms` — low enough that a slow-to-accept downstream will fail).
+Knobs: `--query.timeout` (default `2m`), and per group `timeout` (response
+headers) and `http_client.dial_timeout` (default `200ms`, low enough that a
+slow-to-accept downstream fails).
 
 If promxy is meaningfully slower than a downstream for the same query, that is
 worth [an issue](https://github.com/jacksontj/promxy/issues).
@@ -103,33 +93,30 @@ worth [an issue](https://github.com/jacksontj/promxy/issues).
 
 ### `count(up)` and other label-less aggregations are too low
 
-Two server groups are returning data promxy considers duplicates. Either:
+Promxy is treating data from two groups as duplicates. Either:
 
-- Two groups genuinely hold the same series and lack distinguishing `labels` —
-  add a static label per group.
-- You put several tenants in one group (e.g. multiple tenants in a single
+- Two groups hold the same series and lack distinguishing `labels` — add a
+  static label per group.
+- Several tenants are in one group (e.g. multiple tenants in one
   `X-Scope-OrgID` header). Model each `(backend, tenant)` pair as its own group.
   See [Multi-tenancy](../guides/multi-tenancy.md).
 
 ### `count_over_time` is roughly double
 
-`anti_affinity` is too small, so skewed duplicates from HA replicas are
-surviving the merge. Set it to your scrape interval.
-
-If a single group hosts metrics scraped at *different* intervals, no single
-value is right — set `anti_affinity_dynamic: true`. See
-[HA and merging](../concepts/ha-and-merging.md).
+`anti_affinity` is too small, so skewed duplicates survive the merge. Set it to
+your scrape interval, or `anti_affinity_dynamic: true` if the group hosts mixed
+scrape intervals. See [HA and merging](../concepts/ha-and-merging.md).
 
 ### Series look thinned out / samples are missing
 
-`anti_affinity` is too large: legitimately-spaced samples are being treated as
-duplicates and dropped. It should be your scrape interval, not a multiple of it.
+`anti_affinity` is too large, so legitimately-spaced samples are dropped as
+duplicates. It should be your scrape interval, not a multiple of it.
 
 ### HA replicas aren't being merged at all
 
-Your Prometheus servers are probably adding a distinguishing external label
-(`replica`, `prometheus_replica`). Different label sets means different series,
-so there is nothing to merge. Drop it in the query path:
+Your servers are probably adding a distinguishing external label (`replica`,
+`prometheus_replica`). Different label sets are different series, so there is
+nothing to merge. Drop it in the query path:
 
 ```yaml
 metrics_relabel_configs:
@@ -140,15 +127,15 @@ metrics_relabel_configs:
 ### A Mimir/Cortex group returns nothing for `query_range`
 
 Mimir and Cortex snap `query_range` output to the epoch step grid. If the
-request start isn't a multiple of the step, the returned samples can sit far
-enough off promxy's grid that the lookback delta doesn't reach them.
+request start isn't a multiple of the step, samples can land far enough off
+promxy's grid that the lookback delta doesn't reach them.
 
 ```yaml
 align_query_range_with_step: true
 ```
 
-Set this only for backends that actually step-align — vanilla Prometheus does
-not. See [issue #787](https://github.com/jacksontj/promxy/issues/787).
+Only for backends that actually step-align; vanilla Prometheus does not. See
+[issue #787](https://github.com/jacksontj/promxy/issues/787).
 
 ### A group returns nothing and you're using `label_filter`
 
@@ -162,8 +149,8 @@ includes.
 ### A group has zero targets
 
 `server_group_targets{ordinal="N"} == 0`, and promxy logs a warning. Usually
-either service discovery isn't returning anything or a `relabel_configs` `keep`
-rule is dropping everything. Alert on this — see
+service discovery is returning nothing, or a `relabel_configs` `keep` rule is
+dropping everything. Alert on this — see
 [Metrics](metrics.md#server_group_targets).
 
 ### Downstreams resolve to an unreachable IPv6 address
@@ -173,17 +160,16 @@ http_client:
   dial_network: tcp4
 ```
 
-Alternatively tune the dual-stack fallback with `fallback_delay` — but it must
-be **shorter than `dial_timeout`** (default `200ms`) or the dial times out
-before the fallback is ever attempted.
+Or tune the dual-stack fallback with `fallback_delay`, which must be **shorter
+than `dial_timeout`** (default `200ms`) or the dial times out before the
+fallback is attempted.
 
 ## remote_write
 
 ### `snappy: decoded length N exceeds limit 33554432`
 
-Batches are too large for the receiver's 32 MiB decompression limit. Promxy
-already defaults `max_samples_per_send` to 100 for this reason; if you raised
-it, lower it again.
+Batches exceed the receiver's 32 MiB decompression limit. Promxy defaults
+`max_samples_per_send` to 100 for this reason; if you raised it, lower it.
 
 ### Samples are lost across restarts
 
@@ -194,8 +180,7 @@ deleted on shutdown. Set `--storage.path` for a durable WAL.
 
 ### The UI is blank or errors
 
-The binary was built without the `builtinassets` tag, which embeds the web
-assets:
+The binary was built without the `builtinassets` tag:
 
 ```
 go build -mod=vendor -tags netgo,builtinassets
@@ -205,8 +190,8 @@ See [Development](../development.md).
 
 ### `/-/quit` doesn't stop promxy
 
-It is routed by the embedded Prometheus web handler when
-`--web.enable-lifecycle` is set, but promxy doesn't act on it. Use `SIGTERM`.
+It is routed when `--web.enable-lifecycle` is set, but promxy doesn't act on
+it. Use `SIGTERM`.
 
 ### TLS deprecation warning at startup
 
@@ -217,8 +202,8 @@ Your `--web.config.file` uses the old flat schema. Nest the keys under
 
 ### Requests are dropped during rollouts
 
-Promxy fails `/-/ready` and then keeps serving for `--http.shutdown-delay`
-(default `10s`) so load balancers can drain. Two things to check:
+Promxy fails `/-/ready` then keeps serving for `--http.shutdown-delay`
+(default `10s`) so load balancers can drain. Check both:
 
 1. The delay is at least your health-check interval × unhealthy threshold.
 2. Your orchestrator's grace period exceeds


### PR DESCRIPTION
Until now the only user-facing documentation was the README (overview + FAQ) and the ~300 lines of YAML comments in `cmd/promxy/config.yaml`. A number of things that exist in code had no prose documentation at all: the CLI flags, the query path, the metrics promxy exposes, the feature guides, and the `remote_write_exporter` binary.

This adds `docs/` as plain markdown — no site generator, nothing new to maintain in CI.

## Layout

| Path | Contents |
| ---- | -------- |
| `docs/README.md` | Index |
| `docs/getting-started.md` | Install → minimal config → first query |
| `docs/configuration/` | Config file anatomy, every `server_groups` option, every CLI flag, alert templates |
| `docs/concepts/` | Query path and pushdown rules; the anti-affinity merge algorithm |
| `docs/guides/` | Multi-tenancy, rules and alerting, native histograms, label filtering, security |
| `docs/operations/` | Endpoints and shutdown, metrics, troubleshooting |
| `docs/development.md` | Build tags, vendoring, the prometheus fork, repo layout |

`configuration/README.md` rather than `index.md` so GitHub auto-renders it when browsing the directory.

## What is *not* changed

- The README keeps its overview, quickstart and FAQ, and gains a Documentation section linking into `docs/`.
- `cmd/promxy/config.yaml` stays as the annotated example and is linked from the docs.
- Nothing was moved or deleted, so existing links and anchors still resolve.

## On accuracy

Content was written against the source rather than paraphrased from the config comments. The metrics reference in particular was checked against a **running promxy**, so the metric names, label sets (`server_group_request_duration_seconds{host,call,status}`, `server_group_targets{ordinal,name}`) and the note about which series only appear after their first observation reflect actual `/metrics` output. The error format quoted in the troubleshooting doc is copied from live output too.

All ~60 internal links and anchors were verified to resolve, using GitHub's slug rules.

## Three things documented as-is that may be worth fixing separately

1. **`Config.WebConfig` is dead config.** `pkg/config/config.go:103` parses a top-level `tls_server_config` key in the main config file, but nothing reads it — `pkg/server/api.go` is driven entirely by `--web.config.file`. A user setting it today gets silent plaintext. Documented as having no effect.
2. **`/-/quit` is routed but inert.** The vendored web handler registers it under `--web.enable-lifecycle` and closes `quitCh`, but `main.go` never selects on `webHandler.Quit()`. It answers "Goodbye!" and keeps running. Documented as "use SIGTERM".
3. **`label_filter`'s default `on_sync_error: abort` blocks startup silently** when a downstream is unreachable — no log output at default level, so it looks like a hang. (Hit this accidentally while testing.) The retry loop is intentional and documented, but a periodic "blocked waiting on label_filter sync" warning would help.

Also worth noting: the README FAQ's version claims ("a fork based on prometheus 2.24", "as recent as 2.13") look stale against the current `go.mod` fork pin. I left the README prose alone and did not repeat those claims in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SskNFpr2yDqGLR2NYA6yW
