### PR TITLE
fix(promapi): decode API timestamps from their decimal text, not via float64

### DIFF
--- a/pkg/promapi/decode.go
+++ b/pkg/promapi/decode.go
@@ -1,6 +1,7 @@
 package promapi
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -215,7 +216,8 @@ func decodeResult(resultType string, body []byte) ([]storage.Series, error) {
 	case "matrix":
 		return decodeMatrix(iter), iter.Error
 	case "scalar":
-		t, f := decodeSamplePair(iter)
+		scratch := make([]byte, 0, 32)
+		t, f := decodeSamplePair(iter, &scratch)
 		return []storage.Series{NewSeries(labels.EmptyLabels(), []chunks.Sample{floatSample{t, f}})}, iter.Error
 	case "string":
 		// strings carry no series; the model.Value path didn't support them either.
@@ -228,6 +230,7 @@ func decodeResult(resultType string, body []byte) ([]storage.Series, error) {
 func decodeVector(iter *jsoniter.Iterator) []storage.Series {
 	var out []storage.Series
 	var b labels.ScratchBuilder
+	scratch := make([]byte, 0, 32)
 	for iter.ReadArray() {
 		b.Reset()
 		var sample chunks.Sample
@@ -236,10 +239,10 @@ func decodeVector(iter *jsoniter.Iterator) []storage.Series {
 			case "metric":
 				readMetric(iter, &b)
 			case "value":
-				t, f := decodeSamplePair(iter)
+				t, f := decodeSamplePair(iter, &scratch)
 				sample = floatSample{t, f}
 			case "histogram":
-				t, fh := decodeHistogramPair(iter)
+				t, fh := decodeHistogramPair(iter, &scratch)
 				sample = histSample{t, fh}
 			default:
 				iter.Skip()
@@ -254,6 +257,7 @@ func decodeVector(iter *jsoniter.Iterator) []storage.Series {
 func decodeMatrix(iter *jsoniter.Iterator) []storage.Series {
 	var out []storage.Series
 	var b labels.ScratchBuilder
+	scratch := make([]byte, 0, 32)
 	for iter.ReadArray() {
 		b.Reset()
 		var samples []chunks.Sample
@@ -264,13 +268,13 @@ func decodeMatrix(iter *jsoniter.Iterator) []storage.Series {
 				readMetric(iter, &b)
 			case "values":
 				for iter.ReadArray() {
-					t, f := decodeSamplePair(iter)
+					t, f := decodeSamplePair(iter, &scratch)
 					samples = append(samples, floatSample{t, f})
 				}
 			case "histograms":
 				hadHist = true
 				for iter.ReadArray() {
-					t, fh := decodeHistogramPair(iter)
+					t, fh := decodeHistogramPair(iter, &scratch)
 					samples = append(samples, histSample{t, fh})
 				}
 			default:
@@ -295,11 +299,105 @@ func readMetric(iter *jsoniter.Iterator, b *labels.ScratchBuilder) {
 	}
 }
 
+// millisPerSecond and dotPrecision mirror prometheus/common's model.Time: the
+// API's timestamps are Unix seconds with at most millisecond precision.
+const (
+	millisPerSecond = 1000
+	dotPrecision    = 3
+)
+
+// decodeTimestamp reads the API's <unix-seconds>[.<fraction>] number as a
+// millisecond timestamp.
+//
+// The number is parsed from its decimal text rather than via float64, the same
+// way prometheus/common's model.Time.UnmarshalJSON does, because
+// float64(seconds)*1000 does not reliably land on the integer millisecond the
+// text named: the product can fall a hair short and truncate away the
+// millisecond. Whether it does depends on the binade, so it is easy to miss by
+// sampling -- current-era timestamps are unaffected, 2038-era ones are not.
+//
+// A fraction longer than millisecond precision is truncated, not rounded,
+// matching every other client of this API. Exponent notation is not something
+// the API emits; if a downstream sends it anyway, fall back to the float path
+// rather than reject the response.
+func decodeTimestamp(iter *jsoniter.Iterator, scratch *[]byte) int64 {
+	*scratch = iter.SkipAndAppendBytes((*scratch)[:0])
+	ms, err := unixSecondsToMillis(*scratch)
+	if err != nil {
+		iter.ReportError("decodeTimestamp", err.Error())
+		return 0
+	}
+	return ms
+}
+
+func unixSecondsToMillis(b []byte) (int64, error) {
+	if bytes.ContainsAny(b, "eE") {
+		f, err := strconv.ParseFloat(string(b), 64)
+		if err != nil {
+			return 0, err
+		}
+		return int64(f * millisPerSecond), nil
+	}
+
+	// Handle the sign separately and parse the magnitude. prometheus/common
+	// applies the sign only after summing the two halves, which loses it for
+	// pre-epoch sub-second times (it decodes -59.200 as -58800 rather than
+	// -59200); doing it here keeps such timestamps correct.
+	neg := false
+	if len(b) > 0 && (b[0] == '-' || b[0] == '+') {
+		neg = b[0] == '-'
+		b = b[1:]
+	}
+
+	secs, frac, _ := bytes.Cut(b, []byte("."))
+	v, err := parseDigits(secs)
+	if err != nil {
+		return 0, err
+	}
+	v *= millisPerSecond
+
+	if len(frac) > dotPrecision {
+		frac = frac[:dotPrecision]
+	}
+	if len(frac) > 0 {
+		fv, err := parseDigits(frac)
+		if err != nil {
+			return 0, err
+		}
+		// Scale a short fraction up to milliseconds ("1" -> 100, "12" -> 120).
+		for i := len(frac); i < dotPrecision; i++ {
+			fv *= 10
+		}
+		v += fv
+	}
+
+	if neg {
+		v = -v
+	}
+	return v, nil
+}
+
+// parseDigits is strconv.ParseInt for an unsigned decimal run, without the
+// string conversion that would allocate on this path.
+func parseDigits(b []byte) (int64, error) {
+	if len(b) == 0 {
+		return 0, fmt.Errorf("expected digits")
+	}
+	var v int64
+	for _, c := range b {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("invalid digit %q in timestamp", c)
+		}
+		v = v*10 + int64(c-'0')
+	}
+	return v, nil
+}
+
 // decodeSamplePair reads a [<unix-seconds-float>, "<value>"] pair and returns a
 // millisecond timestamp and float value (NaN/+Inf/-Inf handled by ParseFloat).
-func decodeSamplePair(iter *jsoniter.Iterator) (int64, float64) {
+func decodeSamplePair(iter *jsoniter.Iterator, scratch *[]byte) (int64, float64) {
 	iter.ReadArray()
-	ts := iter.ReadFloat64()
+	ts := decodeTimestamp(iter, scratch)
 	iter.ReadArray()
 	vs := iter.ReadString()
 	iter.ReadArray() // consume closing ]
@@ -307,25 +405,25 @@ func decodeSamplePair(iter *jsoniter.Iterator) (int64, float64) {
 	if err != nil {
 		iter.ReportError("decodeSamplePair", err.Error())
 	}
-	return int64(ts * 1000), f
+	return ts, f
 }
 
 // decodeHistogramPair reads a [<unix-seconds-float>, {histogram}] pair. The
 // histogram object is decoded into a model.SampleHistogram (its JSON shape) and
 // converted to a histogram.FloatHistogram via the same path the model.Value
 // iterator uses, so the result is identical.
-func decodeHistogramPair(iter *jsoniter.Iterator) (int64, *histogram.FloatHistogram) {
+func decodeHistogramPair(iter *jsoniter.Iterator, scratch *[]byte) (int64, *histogram.FloatHistogram) {
 	iter.ReadArray()
-	ts := iter.ReadFloat64()
+	ts := decodeTimestamp(iter, scratch)
 	iter.ReadArray()
 	objBytes := iter.SkipAndReturnBytes()
 	iter.ReadArray() // consume closing ]
 	var sh model.SampleHistogram
 	if err := jsonCfg.Unmarshal(objBytes, &sh); err != nil {
 		iter.ReportError("decodeHistogramPair", err.Error())
-		return int64(ts * 1000), nil
+		return ts, nil
 	}
-	return int64(ts * 1000), sampleHistogramToFloatHistogram(&sh)
+	return ts, sampleHistogramToFloatHistogram(&sh)
 }
 
 // sampleHistogramToFloatHistogram converts the API's model.SampleHistogram

--- a/pkg/promapi/timestamp_test.go
+++ b/pkg/promapi/timestamp_test.go
@@ -1,0 +1,179 @@
+package promapi
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+// Any Prometheus-API-compatible downstream (prometheus, VictoriaMetrics, Mimir,
+// Thanos, ...) is decoded by this path, so it has to agree with the reference
+// decoder every other client of that API uses. Sub-millisecond digits are
+// truncated, not rounded, and that has to stay true.
+//
+// Negative timestamps are excluded: model.Time applies the sign only after
+// summing the two halves and so loses it for pre-epoch sub-second times
+// (decoding "-59.200" as -58800 rather than -59200). TestUnixSecondsToMillisNegative
+// pins the behavior we want there instead.
+func TestUnixSecondsToMillisMatchesModelTime(t *testing.T) {
+	inputs := []string{
+		"0", "1", "1.1", "1.12", "1.123", "1.0", "1.001", "1.010", "1.100",
+		"0.999", "0.0001", "1.2345", "1.9999", "1.0009",
+		"1700000000", "1700000000.5", "1700000000.123", "1700000000.1235",
+		"2147557428.503", "4318490558.624", "9999999999.999",
+	}
+	rng := rand.New(rand.NewSource(7))
+	for i := 0; i < 20000; i++ {
+		// Mix millisecond-precision values with deliberately over-precise ones,
+		// which is where truncate-vs-round actually diverges.
+		ms := rng.Int63n(4_000_000_000_000)
+		switch i % 3 {
+		case 0:
+			inputs = append(inputs, strconv.FormatFloat(float64(ms)/1000, 'f', -1, 64))
+		case 1:
+			inputs = append(inputs, strconv.FormatFloat(float64(ms)/1000, 'f', 3, 64))
+		case 2:
+			inputs = append(inputs, fmt.Sprintf("%d.%06d", ms/1000, rng.Intn(1000000)))
+		}
+	}
+
+	for _, in := range inputs {
+		var want model.Time
+		if err := want.UnmarshalJSON([]byte(in)); err != nil {
+			t.Fatalf("model.Time.UnmarshalJSON(%q): %v", in, err)
+		}
+		got, err := unixSecondsToMillis([]byte(in))
+		if err != nil {
+			t.Fatalf("unixSecondsToMillis(%q): %v", in, err)
+		}
+		if got != int64(want) {
+			t.Errorf("unixSecondsToMillis(%q) = %d, model.Time gives %d", in, got, int64(want))
+		}
+	}
+}
+
+// The bug this replaces: reading the timestamp as a float64 and multiplying by
+// 1000 does not reliably land on the integer millisecond the text named. The
+// product can fall a hair short, and int64() truncates the millisecond away.
+// Whether it does depends on the binade, so a sample of current-era timestamps
+// looks clean while 2038-era ones are not.
+func TestDecodeTimestampExactAcrossEras(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		lo, hi int64
+	}{
+		{"2023-2027", 1_700_000_000_000, 1_800_000_000_000},
+		{"2036-2039", 2_100_000_000_000, 2_200_000_000_000},
+		{"across the 2038 rollover", 2_147_000_000_000, 2_148_000_000_000},
+		{"2096-2099", 4_000_000_000_000, 4_100_000_000_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rng := rand.New(rand.NewSource(1))
+			for i := 0; i < 200_000; i++ {
+				ms := tc.lo + rng.Int63n(tc.hi-tc.lo)
+				wire := strconv.FormatFloat(float64(ms)/1000, 'f', -1, 64)
+				got, err := unixSecondsToMillis([]byte(wire))
+				if err != nil {
+					t.Fatalf("unixSecondsToMillis(%q): %v", wire, err)
+				}
+				if got != ms {
+					t.Fatalf("unixSecondsToMillis(%q) = %d, want %d (off by %d)", wire, got, ms, got-ms)
+				}
+			}
+		})
+	}
+}
+
+func TestUnixSecondsToMillisExact(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want int64
+	}{
+		{"0", 0},
+		{"1", 1000},
+		{"1.5", 1500},
+		{"1.001", 1001},
+		{"1.999", 1999},
+		{"1.1", 1100},
+		{"1.12", 1120},
+		// Over-precise input truncates, as model.Time does.
+		{"1.2345", 1234},
+		{"1.9999", 1999},
+		{"1.0009", 1000},
+		{"1700000000.123", 1700000000123},
+		// Values the float path decoded a millisecond early.
+		{"2147557428.503", 2147557428503},
+		{"4318490558.624", 4318490558624},
+		// Exponent notation isn't emitted by this API, but must not be rejected.
+		{"1.7e9", 1700000000000},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := unixSecondsToMillis([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("unixSecondsToMillis(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("unixSecondsToMillis(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Pre-epoch sub-second timestamps: the sign applies to the whole value.
+// prometheus/common gets this wrong (it decodes "-59.200" as -58800), which is
+// what promclient.hasNegativeFractionalSecond documents; don't inherit that.
+func TestUnixSecondsToMillisNegative(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want int64
+	}{
+		{"-1", -1000},
+		{"-1.5", -1500},
+		{"-59.200", -59200},
+		{"-0.001", -1},
+		{"-0.5", -500},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			got, err := unixSecondsToMillis([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("unixSecondsToMillis(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("unixSecondsToMillis(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The decoded SeriesSet must carry the millisecond the wire format named.
+func TestDecodeSeriesSetTimestampPrecision(t *testing.T) {
+	const wantMs = int64(2147557428503)
+
+	body := []byte(`{"status":"success","data":{"resultType":"matrix","result":[` +
+		`{"metric":{"__name__":"foo"},"values":[[2147557428.503,"1"]]}]}}`)
+
+	ss := DecodeSeriesSet(body)
+	if err := ss.Err(); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !ss.Next() {
+		t.Fatal("no series decoded")
+	}
+	it := ss.At().Iterator(nil)
+	if vt := it.Next(); vt != chunkenc.ValFloat {
+		t.Fatalf("first sample type = %v, want float", vt)
+	}
+	if gotMs, _ := it.At(); gotMs != wantMs {
+		t.Errorf("decoded timestamp = %d, want %d (off by %d)", gotMs, wantMs, gotMs-wantMs)
+	}
+	if it.Next() != chunkenc.ValNone {
+		t.Error("expected exactly one sample")
+	}
+	if ss.Next() {
+		t.Error("expected exactly one series")
+	}
+}


### PR DESCRIPTION
> Reworked after review: the first version of this used `math.Round`, which was the wrong fix. See "Why not just round" below.

`decodeSamplePair` and `decodeHistogramPair` read the timestamp as a `float64` of Unix seconds and convert with `int64(ts * 1000)`.

Prometheus emits timestamps with at most three decimal places, so every value on the wire is a whole number of milliseconds — but the product can land a hair below that integer, and the conversion truncates toward zero and loses the millisecond.

Whether it does depends on the binade, which is why this is easy to miss. Sampling 10M random millisecond timestamps per era, round-tripped through the JSON representation the API actually emits:

| era | Unix seconds | mismatches |
|---|---|---|
| 2023–2027 | 1.7e9 | 0 |
| 2036–2039 | 2.15e9 | **12.4%** |
| 2096–2099 | 4.0e9 | 0 |

The failure band is the binade the epoch crosses in 2038. Small timestamps are affected too — `1.001` seconds decoded to `1000ms`, and that's the range the promql test corpus works in.

### Why not just round

Rounding is the obvious one-line fix and it's wrong here, because promxy decodes responses from **any** implementation of this API — VictoriaMetrics, Mimir, Thanos — not just Prometheus.

Upstream `model.Time.UnmarshalJSON` splits the decimal text and **truncates** anything past millisecond precision:

```go
prec := dotPrecision - len(p[1])
if prec < 0 {
    p[1] = p[1][:dotPrecision]
}
```

So `math.Round` would make promxy disagree with every other client of this API the moment a downstream sent more than three decimal places (`1.2345` → 1235 rounded vs 1234 truncated). Introducing rounding semantics into a decoder shared with third-party backends is a worse problem than the one being fixed.

### What this does instead

Parses the decimal text directly, removing the float from the path entirely rather than papering over it. `TestUnixSecondsToMillisMatchesModelTime` asserts agreement with `model.Time.UnmarshalJSON` across ~20k inputs, two thirds of them deliberately over-precise, so the truncation contract is pinned.

**One deliberate divergence:** negative timestamps. `model.Time` applies the sign only after summing the two halves, so it decodes `-59.200` as `-58800` rather than `-59200` — the bug `promclient.hasNegativeFractionalSecond` already documents and works around. The float path being replaced handled that case *correctly*, so this applies the sign to the whole value rather than inheriting the regression.

### Cost

Timestamps are read through a reused scratch buffer, so the exact parse adds no per-sample allocation:

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 3,692,040 | 2,529,017 | 120,006 |
| after | 4,094,439 | 2,529,085 | 120,007 |

`BenchmarkDecodeSeriesSet`, 5000-sample matrix. The ~11% is jsoniter's float fast path being quicker than skip-and-parse; the one extra allocation is the scratch buffer itself, once per decode call rather than per sample.

If that 11% isn't worth it to you given the bug doesn't bite in the current era, closing this is a perfectly reasonable call — the decode path is hot and the failure is a decade out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
