### PR TITLE
fix(promclient): dedupe exemplars, and fan out in completion order

### DIFF
--- a/pkg/promclient/multi_api.go
+++ b/pkg/promclient/multi_api.go
@@ -139,11 +139,12 @@ func (m *MultiAPI) LabelValues(ctx context.Context, label string, matchers []str
 		ls       model.Fingerprint
 	}
 
-	resultChans := make([]chan chanResult, len(m.apis))
+	// Buffered to len(apis): the loop below can return before draining, and a
+	// blocked sender would leak its goroutine.
+	resultChan := make(chan chanResult, len(m.apis))
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	for i, api := range m.apis {
-		resultChans[i] = make(chan chanResult, 1)
 		outstandingRequests[m.apiFingerprints[i]]++
 		go func(i int, retChan chan chanResult, api API, label string) {
 			start := time.Now()
@@ -160,10 +161,9 @@ func (m *MultiAPI) LabelValues(ctx context.Context, label string, matchers []str
 				err:      NormalizePromError(err),
 				ls:       m.apiFingerprints[i],
 			}
-		}(i, resultChans[i], api, label)
+		}(i, resultChan, api, label)
 	}
 
-	// Wait for results as we get them
 	var result []model.LabelValue
 	warnings := make(promhttputil.WarningSet)
 	var lastError error
@@ -173,7 +173,7 @@ func (m *MultiAPI) LabelValues(ctx context.Context, label string, matchers []str
 		case <-ctx.Done():
 			return nil, warnings.Warnings(), ctx.Err()
 
-		case ret := <-resultChans[i]:
+		case ret := <-resultChan:
 			warnings.AddWarnings(ret.warnings)
 			outstandingRequests[ret.ls]--
 			if ret.err != nil {
@@ -217,11 +217,12 @@ func (m *MultiAPI) LabelNames(ctx context.Context, matchers []string, startTime 
 		ls       model.Fingerprint
 	}
 
-	resultChans := make([]chan chanResult, len(m.apis))
+	// Buffered to len(apis): the loop below can return before draining, and a
+	// blocked sender would leak its goroutine.
+	resultChan := make(chan chanResult, len(m.apis))
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	for i, api := range m.apis {
-		resultChans[i] = make(chan chanResult, 1)
 		outstandingRequests[m.apiFingerprints[i]]++
 		go func(i int, retChan chan chanResult, api API) {
 			start := time.Now()
@@ -238,10 +239,9 @@ func (m *MultiAPI) LabelNames(ctx context.Context, matchers []string, startTime 
 				err:      NormalizePromError(err),
 				ls:       m.apiFingerprints[i],
 			}
-		}(i, resultChans[i], api)
+		}(i, resultChan, api)
 	}
 
-	// Wait for results as we get them
 	result := make(map[string]struct{})
 	warnings := make(promhttputil.WarningSet)
 	var lastError error
@@ -251,7 +251,7 @@ func (m *MultiAPI) LabelNames(ctx context.Context, matchers []string, startTime 
 		case <-ctx.Done():
 			return nil, warnings.Warnings(), ctx.Err()
 
-		case ret := <-resultChans[i]:
+		case ret := <-resultChan:
 			warnings.AddWarnings(ret.warnings)
 			outstandingRequests[ret.ls]--
 			if ret.err != nil {
@@ -295,14 +295,16 @@ func (m *MultiAPI) scatterMerge(ctx context.Context, op string, call func(contex
 	defer childContextCancel()
 
 	type chanResult struct {
+		i  int // index of the API that produced this result
 		ss storage.SeriesSet
 		ls model.Fingerprint
 	}
-	resultChans := make([]chan chanResult, len(m.apis))
+	// Buffered to len(apis): the loop below can return before draining, and a
+	// blocked sender would leak its goroutine.
+	resultChan := make(chan chanResult, len(m.apis))
 	outstandingRequests := make(map[model.Fingerprint]int)
 
 	for i, api := range m.apis {
-		resultChans[i] = make(chan chanResult, 1)
 		outstandingRequests[m.apiFingerprints[i]]++
 		go func(i int, retChan chan chanResult, api API) {
 			start := time.Now()
@@ -313,11 +315,14 @@ func (m *MultiAPI) scatterMerge(ctx context.Context, op string, call func(contex
 				status = "error"
 			}
 			m.recordMetric(i, op, status, took.Seconds())
-			retChan <- chanResult{ss: ss, ls: m.apiFingerprints[i]}
-		}(i, resultChans[i], api)
+			retChan <- chanResult{i: i, ss: ss, ls: m.apiFingerprints[i]}
+		}(i, resultChan, api)
 	}
 
-	var sets []storage.SeriesSet
+	// Parked in slots and merged below in API order: mergeAntiAffinity
+	// resolves duplicate samples in the order it receives the sets, so the
+	// result must not depend on which replica answered first.
+	slots := make([]storage.SeriesSet, len(m.apis))
 	var warnings annotations.Annotations
 	var lastError error
 	successMap := make(map[model.Fingerprint]int)
@@ -326,7 +331,7 @@ func (m *MultiAPI) scatterMerge(ctx context.Context, op string, call func(contex
 		case <-ctx.Done():
 			return promapi.NewSeriesSet(nil, warnings, ctx.Err())
 
-		case ret := <-resultChans[i]:
+		case ret := <-resultChan:
 			outstandingRequests[ret.ls]--
 			warnings = MergeAnnotations(warnings, ret.ss.Warnings())
 			if err := NormalizePromError(ret.ss.Err()); err != nil {
@@ -336,7 +341,7 @@ func (m *MultiAPI) scatterMerge(ctx context.Context, op string, call func(contex
 				lastError = err
 			} else {
 				successMap[ret.ls]++
-				sets = append(sets, ret.ss)
+				slots[ret.i] = ret.ss
 			}
 		}
 	}
@@ -344,6 +349,13 @@ func (m *MultiAPI) scatterMerge(ctx context.Context, op string, call func(contex
 	for k := range outstandingRequests {
 		if successMap[k] < m.requiredCount {
 			return promapi.NewSeriesSet(nil, warnings, errors.Wrap(lastError, "Unable to fetch from downstream servers"))
+		}
+	}
+
+	sets := make([]storage.SeriesSet, 0, len(slots))
+	for _, ss := range slots {
+		if ss != nil {
+			sets = append(sets, ss)
 		}
 	}
 
@@ -369,17 +381,19 @@ func (m *MultiAPI) Series(ctx context.Context, matches []string, startTime time.
 	defer childContextCancel()
 
 	type chanResult struct {
+		i        int // index of the API that produced this result
 		v        []model.LabelSet
 		warnings v1.Warnings
 		err      error
 		ls       model.Fingerprint
 	}
 
-	resultChans := make([]chan chanResult, len(m.apis))
+	// Buffered to len(apis): the loop below can return before draining, and a
+	// blocked sender would leak its goroutine.
+	resultChan := make(chan chanResult, len(m.apis))
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	for i, api := range m.apis {
-		resultChans[i] = make(chan chanResult, 1)
 		outstandingRequests[m.apiFingerprints[i]]++
 		go func(i int, retChan chan chanResult, api API) {
 			start := time.Now()
@@ -391,16 +405,20 @@ func (m *MultiAPI) Series(ctx context.Context, matches []string, startTime time.
 				m.recordMetric(i, "series", "success", took.Seconds())
 			}
 			retChan <- chanResult{
+				i:        i,
 				v:        result,
 				warnings: w,
 				err:      NormalizePromError(err),
 				ls:       m.apiFingerprints[i],
 			}
-		}(i, resultChans[i], api)
+		}(i, resultChan, api)
 	}
 
-	// Wait for results as we get them
-	var result []model.LabelSet
+	// Parked in slots and merged below in API order: the result is unsorted
+	// and MergeLabelSets keeps the first labelset per fingerprint, so the
+	// merge order is observable.
+	slots := make([][]model.LabelSet, len(m.apis))
+	responded := make([]bool, len(m.apis))
 	warnings := make(promhttputil.WarningSet)
 	var lastError error
 	successMap := make(map[model.Fingerprint]int) // fingerprint -> success
@@ -409,7 +427,7 @@ func (m *MultiAPI) Series(ctx context.Context, matches []string, startTime time.
 		case <-ctx.Done():
 			return nil, warnings.Warnings(), ctx.Err()
 
-		case ret := <-resultChans[i]:
+		case ret := <-resultChan:
 			warnings.AddWarnings(ret.warnings)
 			outstandingRequests[ret.ls]--
 			if ret.err != nil {
@@ -420,11 +438,8 @@ func (m *MultiAPI) Series(ctx context.Context, matches []string, startTime time.
 				lastError = ret.err
 			} else {
 				successMap[ret.ls]++
-				if result == nil {
-					result = ret.v
-				} else {
-					result = MergeLabelSets(result, ret.v)
-				}
+				slots[ret.i] = ret.v
+				responded[ret.i] = true
 			}
 		}
 	}
@@ -433,6 +448,20 @@ func (m *MultiAPI) Series(ctx context.Context, matches []string, startTime time.
 	for k := range outstandingRequests {
 		if successMap[k] < m.requiredCount {
 			return nil, warnings.Warnings(), errors.Wrap(lastError, "Unable to fetch from downstream servers")
+		}
+	}
+
+	var result []model.LabelSet
+	var haveResult bool
+	for i, v := range slots {
+		if !responded[i] {
+			continue
+		}
+		if !haveResult {
+			result = v
+			haveResult = true
+		} else {
+			result = MergeLabelSets(result, v)
 		}
 	}
 
@@ -452,16 +481,18 @@ func (m *MultiAPI) Metadata(ctx context.Context, metric, limit string) (map[stri
 	defer childContextCancel()
 
 	type chanResult struct {
+		i   int // index of the API that produced this result
 		v   map[string][]v1.Metadata
 		err error
 		ls  model.Fingerprint
 	}
 
-	resultChans := make([]chan chanResult, len(m.apis))
+	// Buffered to len(apis): the loop below can return before draining, and a
+	// blocked sender would leak its goroutine.
+	resultChan := make(chan chanResult, len(m.apis))
 	outstandingRequests := make(map[model.Fingerprint]int) // fingerprint -> outstanding
 
 	for i, api := range m.apis {
-		resultChans[i] = make(chan chanResult, 1)
 		outstandingRequests[m.apiFingerprints[i]]++
 		go func(i int, retChan chan chanResult, api API, metric, limit string) {
 			start := time.Now()
@@ -473,15 +504,19 @@ func (m *MultiAPI) Metadata(ctx context.Context, metric, limit string) (map[stri
 				m.recordMetric(i, "query", "success", took.Seconds())
 			}
 			retChan <- chanResult{
+				i:   i,
 				v:   result,
 				err: NormalizePromError(err),
 				ls:  m.apiFingerprints[i],
 			}
-		}(i, resultChans[i], api, metric, limit)
+		}(i, resultChan, api, metric, limit)
 	}
 
-	// Wait for results as we get them
-	var result map[string][]v1.Metadata
+	// Parked in slots and merged below in API order: the merge is
+	// first-writer-wins per metric name, so the merge order decides which
+	// downstream's metadata wins.
+	slots := make([]map[string][]v1.Metadata, len(m.apis))
+	responded := make([]bool, len(m.apis))
 	var lastError error
 	successMap := make(map[model.Fingerprint]int) // fingerprint -> success
 	for i := 0; i < len(m.apis); i++ {
@@ -489,7 +524,7 @@ func (m *MultiAPI) Metadata(ctx context.Context, metric, limit string) (map[stri
 		case <-ctx.Done():
 			return nil, ctx.Err()
 
-		case ret := <-resultChans[i]:
+		case ret := <-resultChan:
 			outstandingRequests[ret.ls]--
 			if ret.err != nil {
 				// If there aren't enough outstanding requests to possibly succeed, no reason to wait
@@ -499,16 +534,8 @@ func (m *MultiAPI) Metadata(ctx context.Context, metric, limit string) (map[stri
 				lastError = ret.err
 			} else {
 				successMap[ret.ls]++
-				if result == nil {
-					result = ret.v
-				} else {
-					// Merge metadata!
-					for k, v := range ret.v {
-						if _, ok := result[k]; !ok {
-							result[k] = v
-						}
-					}
-				}
+				slots[ret.i] = ret.v
+				responded[ret.i] = true
 			}
 		}
 	}
@@ -520,13 +547,47 @@ func (m *MultiAPI) Metadata(ctx context.Context, metric, limit string) (map[stri
 		}
 	}
 
+	var result map[string][]v1.Metadata
+	var haveResult bool
+	for i, v := range slots {
+		if !responded[i] {
+			continue
+		}
+		if !haveResult {
+			result = v
+			haveResult = true
+		} else {
+			// Merge metadata!
+			for k, vv := range v {
+				if _, ok := result[k]; !ok {
+					result[k] = vv
+				}
+			}
+		}
+	}
+
 	return result, nil
 }
 
+// exemplarKey is the identity of a single exemplar within a series. Prometheus
+// identifies an exemplar by its timestamp, value and labels; a series may
+// legitimately carry multiple exemplars at the same timestamp (with different
+// trace IDs), so all three are part of the key.
+type exemplarKey struct {
+	ts     model.Time
+	value  model.SampleValue
+	labels string
+}
+
+func newExemplarKey(e v1.Exemplar) exemplarKey {
+	// model.LabelSet.String() sorts label names, so it is a stable key.
+	return exemplarKey{ts: e.Timestamp, value: e.Value, labels: e.Labels.String()}
+}
+
 // QueryExemplars performs a query for exemplars by the given query and time range.
-// We fan the query out to every server-group and concatenate the per-series
-// exemplar lists, deduplicating by series labels (sum-style merge — the union of
-// exemplars from all server-groups for the same series).
+// We fan the query out to every server-group and merge the per-series exemplar
+// lists (set-style union -- the same exemplar returned by multiple downstreams,
+// e.g. HA replicas of the same prometheus, is returned only once).
 func (m *MultiAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
 	childContext, childContextCancel := context.WithCancel(ctx)
 	defer childContextCancel()
@@ -537,11 +598,12 @@ func (m *MultiAPI) QueryExemplars(ctx context.Context, query string, startTime, 
 		ls  model.Fingerprint
 	}
 
-	resultChans := make([]chan chanResult, len(m.apis))
+	// Buffered to len(apis): the loop below can return before draining, and a
+	// blocked sender would leak its goroutine.
+	resultChan := make(chan chanResult, len(m.apis))
 	outstandingRequests := make(map[model.Fingerprint]int)
 
 	for i, api := range m.apis {
-		resultChans[i] = make(chan chanResult, 1)
 		outstandingRequests[m.apiFingerprints[i]]++
 		go func(i int, retChan chan chanResult, api API) {
 			start := time.Now()
@@ -557,11 +619,14 @@ func (m *MultiAPI) QueryExemplars(ctx context.Context, query string, startTime, 
 				err: NormalizePromError(err),
 				ls:  m.apiFingerprints[i],
 			}
-		}(i, resultChans[i], api)
+		}(i, resultChan, api)
 	}
 
-	// Wait for results, merging by series labels.
+	// Merge by series labels.
 	merged := map[model.Fingerprint]*v1.ExemplarQueryResult{}
+	// Per-series set of exemplars we've already collected, used to drop the
+	// duplicates that the fan-out across HA replicas necessarily returns.
+	seen := map[model.Fingerprint]map[exemplarKey]struct{}{}
 	var lastError error
 	successMap := make(map[model.Fingerprint]int)
 	for i := 0; i < len(m.apis); i++ {
@@ -569,7 +634,7 @@ func (m *MultiAPI) QueryExemplars(ctx context.Context, query string, startTime, 
 		case <-ctx.Done():
 			return nil, ctx.Err()
 
-		case ret := <-resultChans[i]:
+		case ret := <-resultChan:
 			outstandingRequests[ret.ls]--
 			if ret.err != nil {
 				if (outstandingRequests[ret.ls] + successMap[ret.ls]) < m.requiredCount {
@@ -584,11 +649,19 @@ func (m *MultiAPI) QueryExemplars(ctx context.Context, query string, startTime, 
 				fp := qr.SeriesLabels.Fingerprint()
 				existing, ok := merged[fp]
 				if !ok {
-					cp := qr
-					merged[fp] = &cp
-					continue
+					existing = &v1.ExemplarQueryResult{SeriesLabels: qr.SeriesLabels}
+					merged[fp] = existing
+					seen[fp] = make(map[exemplarKey]struct{}, len(qr.Exemplars))
 				}
-				existing.Exemplars = append(existing.Exemplars, qr.Exemplars...)
+				seenSeries := seen[fp]
+				for _, e := range qr.Exemplars {
+					k := newExemplarKey(e)
+					if _, dup := seenSeries[k]; dup {
+						continue
+					}
+					seenSeries[k] = struct{}{}
+					existing.Exemplars = append(existing.Exemplars, e)
+				}
 			}
 		}
 	}
@@ -601,7 +674,30 @@ func (m *MultiAPI) QueryExemplars(ctx context.Context, query string, startTime, 
 
 	out := make([]v1.ExemplarQueryResult, 0, len(merged))
 	for _, qr := range merged {
+		// The downstream API returns exemplars ordered by timestamp; preserve
+		// that ordering after merging results from multiple downstreams.
+		SortExemplars(qr.Exemplars)
 		out = append(out, *qr)
 	}
+	// Map iteration order is random, so sort by series labels to make repeated
+	// identical requests return identical results.
+	sort.Slice(out, func(i, j int) bool { return out[i].SeriesLabels.String() < out[j].SeriesLabels.String() })
 	return out, nil
+}
+
+// SortExemplars orders exemplars by timestamp, then value, then labels. The
+// ordering must be total -- over exactly the fields exemplarKey identifies an
+// exemplar by -- because downstream responses are merged in completion order,
+// so timestamp alone would leave ties resolved by whichever replica was first.
+func SortExemplars(exemplars []v1.Exemplar) {
+	sort.Slice(exemplars, func(i, j int) bool {
+		a, b := exemplars[i], exemplars[j]
+		if a.Timestamp != b.Timestamp {
+			return a.Timestamp < b.Timestamp
+		}
+		if a.Value != b.Value {
+			return a.Value < b.Value
+		}
+		return a.Labels.String() < b.Labels.String()
+	})
 }

--- a/pkg/promclient/multi_api_test.go
+++ b/pkg/promclient/multi_api_test.go
@@ -3,10 +3,12 @@ package promclient
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -690,4 +692,392 @@ func TestMultiAPIQueryExemplarsMerging(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMultiAPIQueryExemplarsDedup(t *testing.T) {
+	ex := func(traceID string, val float64, ts int64) v1.Exemplar {
+		e := v1.Exemplar{Value: model.SampleValue(val), Timestamp: model.Time(ts)}
+		if traceID != "" {
+			e.Labels = model.LabelSet{"trace_id": model.LabelValue(traceID)}
+		}
+		return e
+	}
+	result := func(series model.LabelSet, exemplars ...v1.Exemplar) v1.ExemplarQueryResult {
+		return v1.ExemplarQueryResult{SeriesLabels: series, Exemplars: exemplars}
+	}
+	stub := func(results ...v1.ExemplarQueryResult) API {
+		return &stubAPI{queryExemplars: func() []v1.ExemplarQueryResult { return results }}
+	}
+	foo := model.LabelSet{"__name__": "foo"}
+	bar := model.LabelSet{"__name__": "bar"}
+
+	tests := []struct {
+		name string
+		apis []API
+		want []v1.ExemplarQueryResult
+	}{
+		{
+			// HA replicas of the same prometheus observed the same exemplar;
+			// it must be returned exactly once.
+			name: "identical exemplar from two replicas is deduplicated",
+			apis: []API{
+				stub(result(foo, ex("a", 1, 100))),
+				stub(result(foo, ex("a", 1, 100))),
+			},
+			want: []v1.ExemplarQueryResult{result(foo, ex("a", 1, 100))},
+		},
+		{
+			// Same timestamp, different trace IDs -- legitimately distinct
+			// exemplars, both must be kept.
+			name: "same timestamp with different labels are both kept",
+			apis: []API{
+				stub(result(foo, ex("a", 1, 100))),
+				stub(result(foo, ex("b", 1, 100))),
+			},
+			want: []v1.ExemplarQueryResult{result(foo, ex("a", 1, 100), ex("b", 1, 100))},
+		},
+		{
+			// Same timestamp and labels but a different value is a distinct exemplar.
+			name: "same timestamp and labels with different values are both kept",
+			apis: []API{
+				stub(result(foo, ex("a", 1, 100))),
+				stub(result(foo, ex("a", 2, 100))),
+			},
+			want: []v1.ExemplarQueryResult{result(foo, ex("a", 1, 100), ex("a", 2, 100))},
+		},
+		{
+			name: "exemplars are sorted by timestamp",
+			apis: []API{
+				stub(result(foo, ex("c", 3, 300), ex("a", 1, 100))),
+				stub(result(foo, ex("d", 4, 400), ex("b", 2, 200))),
+			},
+			want: []v1.ExemplarQueryResult{
+				result(foo, ex("a", 1, 100), ex("b", 2, 200), ex("c", 3, 300), ex("d", 4, 400)),
+			},
+		},
+		{
+			name: "different series stay separate and are sorted by series labels",
+			apis: []API{
+				stub(result(foo, ex("a", 1, 100)), result(bar, ex("b", 2, 200))),
+				stub(result(foo, ex("a", 1, 100)), result(bar, ex("b", 2, 200))),
+			},
+			want: []v1.ExemplarQueryResult{
+				result(bar, ex("b", 2, 200)),
+				result(foo, ex("a", 1, 100)),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			api := NewMustMultiAPI(tc.apis, model.Time(0), false, nil, 1, false)
+			got, err := api.QueryExemplars(context.Background(), `foo`, time.Unix(0, 0), time.Unix(1, 0))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("result mismatch\nwant: %+v\ngot:  %+v", tc.want, got)
+			}
+		})
+	}
+}
+
+// Metadata returns metadata about metrics currently scraped by the metric name.
+func (s *errorAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.API.Metadata(ctx, metric, limit)
+}
+
+// blockingAPI blocks every call until release is closed (or the context is
+// cancelled). It's used to prove that the MultiAPI fan-out consumes results in
+// completion order rather than in index order.
+type blockingAPI struct {
+	API
+	release <-chan struct{}
+}
+
+func (s *blockingAPI) Key() model.LabelSet {
+	if apiLabels, ok := s.API.(APILabels); ok {
+		return apiLabels.Key()
+	}
+	return nil
+}
+
+func (s *blockingAPI) wait(ctx context.Context) error {
+	select {
+	case <-s.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *blockingAPI) LabelNames(ctx context.Context, matchers []string, startTime time.Time, endTime time.Time) ([]string, v1.Warnings, error) {
+	if err := s.wait(ctx); err != nil {
+		return nil, nil, err
+	}
+	return s.API.LabelNames(ctx, matchers, startTime, endTime)
+}
+
+func (s *blockingAPI) LabelValues(ctx context.Context, label string, matchers []string, startTime time.Time, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	if err := s.wait(ctx); err != nil {
+		return nil, nil, err
+	}
+	return s.API.LabelValues(ctx, label, matchers, startTime, endTime)
+}
+
+func (s *blockingAPI) Query(ctx context.Context, query string, ts time.Time) storage.SeriesSet {
+	if err := s.wait(ctx); err != nil {
+		return storage.ErrSeriesSet(err)
+	}
+	return s.API.Query(ctx, query, ts)
+}
+
+func (s *blockingAPI) QueryRange(ctx context.Context, query string, r v1.Range) storage.SeriesSet {
+	if err := s.wait(ctx); err != nil {
+		return storage.ErrSeriesSet(err)
+	}
+	return s.API.QueryRange(ctx, query, r)
+}
+
+func (s *blockingAPI) Series(ctx context.Context, matches []string, startTime time.Time, endTime time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	if err := s.wait(ctx); err != nil {
+		return nil, nil, err
+	}
+	return s.API.Series(ctx, matches, startTime, endTime)
+}
+
+func (s *blockingAPI) GetValue(ctx context.Context, start, end time.Time, matchers []*labels.Matcher) storage.SeriesSet {
+	if err := s.wait(ctx); err != nil {
+		return storage.ErrSeriesSet(err)
+	}
+	return s.API.GetValue(ctx, start, end, matchers)
+}
+
+func (s *blockingAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	if err := s.wait(ctx); err != nil {
+		return nil, err
+	}
+	return s.API.Metadata(ctx, metric, limit)
+}
+
+func (s *blockingAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
+	if err := s.wait(ctx); err != nil {
+		return nil, err
+	}
+	return s.API.QueryExemplars(ctx, query, startTime, endTime)
+}
+
+// TestMultiAPIEarlyReturnOnLaterIndexFailure asserts that a fatal failure from
+// a later-indexed API aborts the fan-out immediately, instead of waiting for a
+// slow earlier-indexed API to finish first. Index 0 blocks for the whole
+// duration of the call (it is only released on the way out of the subtest) and
+// index 1 fails right away; with requiredCount=2 that single failure makes the
+// result impossible to assemble, so every method must return promptly.
+func TestMultiAPIEarlyReturnOnLaterIndexFailure(t *testing.T) {
+	const timeout = 10 * time.Second
+
+	run := func(t *testing.T, call func(api *MultiAPI) error) {
+		t.Helper()
+
+		release := make(chan struct{})
+		// The blocked index-0 goroutine is only ever released here, so it
+		// cannot leak past the subtest -- and the call under test must have
+		// returned before this runs.
+		defer close(release)
+
+		// Neither API has a Key(), so both land in a single fingerprint
+		// bucket; requiredCount=2 makes one error fatal for that bucket.
+		api := NewMustMultiAPI([]API{
+			&blockingAPI{API: &stubAPI{}, release: release},
+			&errorAPI{API: &stubAPI{}, err: fmt.Errorf("boom")},
+		}, model.Time(0), false, nil, 2, false)
+
+		done := make(chan error, 1)
+		go func() { done <- call(api) }()
+
+		select {
+		case err := <-done:
+			if err == nil {
+				t.Fatalf("expected an error from the failing index-1 API, got nil")
+			}
+		case <-time.After(timeout):
+			t.Fatalf("call did not return within %s: it is waiting on the slow index-0 API instead of consuming results as they arrive", timeout)
+		}
+	}
+
+	t.Run("LabelValues", func(t *testing.T) {
+		run(t, func(api *MultiAPI) error {
+			_, _, err := api.LabelValues(context.Background(), "a", nil, time.Time{}, time.Time{})
+			return err
+		})
+	})
+
+	t.Run("LabelNames", func(t *testing.T) {
+		run(t, func(api *MultiAPI) error {
+			_, _, err := api.LabelNames(context.Background(), nil, time.Time{}, time.Time{})
+			return err
+		})
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		run(t, func(api *MultiAPI) error {
+			return api.Query(context.Background(), "testmetric", time.Now()).Err()
+		})
+	})
+
+	t.Run("QueryRange", func(t *testing.T) {
+		run(t, func(api *MultiAPI) error {
+			return api.QueryRange(context.Background(), "testmetric", v1.Range{}).Err()
+		})
+	})
+
+	t.Run("GetValue", func(t *testing.T) {
+		run(t, func(api *MultiAPI) error {
+			return api.GetValue(context.Background(), time.Now(), time.Now(), nil).Err()
+		})
+	})
+
+	t.Run("Series", func(t *testing.T) {
+		run(t, func(api *MultiAPI) error {
+			_, _, err := api.Series(context.Background(), []string{"testmetric"}, time.Now(), time.Now())
+			return err
+		})
+	})
+
+	t.Run("Metadata", func(t *testing.T) {
+		run(t, func(api *MultiAPI) error {
+			_, err := api.Metadata(context.Background(), "testmetric", "")
+			return err
+		})
+	})
+
+	t.Run("QueryExemplars", func(t *testing.T) {
+		run(t, func(api *MultiAPI) error {
+			_, err := api.QueryExemplars(context.Background(), "testmetric", time.Unix(0, 0), time.Unix(1, 0))
+			return err
+		})
+	})
+}
+
+// TestMultiAPIMergeIndependentOfCompletionOrder asserts that consuming results
+// out of index order doesn't change the merged output: index 0 is held back so
+// index 1's result lands first, and the merged result must match the merge of
+// the same two APIs completing in index order.
+func TestMultiAPIMergeIndependentOfCompletionOrder(t *testing.T) {
+	const timeout = 10 * time.Second
+
+	getSample := func(ls model.LabelSet) *model.Sample {
+		return &model.Sample{
+			Metric:    model.Metric(ls),
+			Value:     model.SampleValue(1),
+			Timestamp: model.Time(100),
+		}
+	}
+	mkStub := func(v model.LabelValue) API {
+		return &AddLabelClient{&stubAPI{
+			labelNames:  func() []string { return []string{"a"} },
+			labelValues: func(_ string) model.LabelValues { return model.LabelValues{} },
+			query: func() model.Value {
+				return model.Vector{getSample(model.LabelSet{model.MetricNameLabel: "testmetric"})}
+			},
+			queryRange: func(_ string, _ v1.Range) model.Value {
+				return model.Vector{getSample(model.LabelSet{model.MetricNameLabel: "testmetric"})}
+			},
+			series: func() []model.LabelSet {
+				return []model.LabelSet{{model.MetricNameLabel: "testmetric"}}
+			},
+			getValue: func() model.Value {
+				return model.Vector{getSample(model.LabelSet{model.MetricNameLabel: "testmetric"})}
+			},
+		}, model.LabelSet{"a": v}}
+	}
+
+	run := func(t *testing.T, call func(api *MultiAPI) any) {
+		t.Helper()
+
+		// Baseline: both APIs complete in index order.
+		want := call(NewMustMultiAPI([]API{mkStub("1"), mkStub("2")}, model.Time(0), false, nil, 1, false))
+
+		release := make(chan struct{})
+		var once sync.Once
+		releaseFn := func() { once.Do(func() { close(release) }) }
+		defer releaseFn()
+
+		delayed := NewMustMultiAPI([]API{
+			&blockingAPI{API: mkStub("1"), release: release},
+			mkStub("2"),
+		}, model.Time(0), false, nil, 1, false)
+
+		done := make(chan any, 1)
+		go func() { done <- call(delayed) }()
+
+		// Let index 1's result land in the shared channel first, then let
+		// index 0 proceed.
+		time.Sleep(50 * time.Millisecond)
+		releaseFn()
+
+		select {
+		case got := <-done:
+			if !reflect.DeepEqual(want, got) {
+				t.Fatalf("out-of-order merge differs from in-order merge\nin-order    =%#v\nout-of-order=%#v", want, got)
+			}
+		case <-time.After(timeout):
+			t.Fatalf("call did not return within %s", timeout)
+		}
+	}
+
+	t.Run("LabelValues", func(t *testing.T) {
+		run(t, func(api *MultiAPI) any {
+			v, _, err := api.LabelValues(context.Background(), "a", nil, time.Time{}, time.Time{})
+			if err != nil {
+				return err.Error()
+			}
+			return v
+		})
+	})
+
+	t.Run("LabelNames", func(t *testing.T) {
+		run(t, func(api *MultiAPI) any {
+			v, _, err := api.LabelNames(context.Background(), nil, time.Time{}, time.Time{})
+			if err != nil {
+				return err.Error()
+			}
+			return v
+		})
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		run(t, func(api *MultiAPI) any {
+			return ssDataStrings(api.Query(context.Background(), "testmetric", time.Now()))
+		})
+	})
+
+	t.Run("QueryRange", func(t *testing.T) {
+		run(t, func(api *MultiAPI) any {
+			return ssDataStrings(api.QueryRange(context.Background(), "testmetric", v1.Range{}))
+		})
+	})
+
+	t.Run("GetValue", func(t *testing.T) {
+		run(t, func(api *MultiAPI) any {
+			return ssDataStrings(api.GetValue(context.Background(), time.Now(), time.Now(), []*labels.Matcher{{
+				Type:  labels.MatchEqual,
+				Name:  "__name__",
+				Value: "testmetric",
+			}}))
+		})
+	})
+
+	t.Run("Series", func(t *testing.T) {
+		run(t, func(api *MultiAPI) any {
+			v, _, err := api.Series(context.Background(), []string{"testmetric"}, time.Now(), time.Now())
+			if err != nil {
+				return err.Error()
+			}
+			return v
+		})
+	})
 }

--- a/pkg/proxystorage/exemplar_querier.go
+++ b/pkg/proxystorage/exemplar_querier.go
@@ -2,6 +2,7 @@ package proxystorage
 
 import (
 	"context"
+	"sort"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -34,6 +35,12 @@ func (q *proxyExemplarQuerier) Select(start, end int64, matchers ...[]*labels.Ma
 	// multiple selectors that match the same series, and we'd otherwise
 	// emit duplicates that grafana then has to dedup itself.
 	merged := map[uint64]*exemplar.QueryResult{}
+	// Per-series set of exemplars already collected. The same exemplar can be
+	// returned for more than one of the extracted selectors, and an exemplar is
+	// only a duplicate when its timestamp, value AND labels all match -- a
+	// series may legitimately have several exemplars at one timestamp with
+	// different trace IDs.
+	seen := map[uint64]map[exemplarKey]struct{}{}
 	for _, ms := range matchers {
 		query, err := promhttputil.MatcherToString(ms)
 		if err != nil {
@@ -51,23 +58,59 @@ func (q *proxyExemplarQuerier) Select(start, end int64, matchers ...[]*labels.Ma
 			if !ok {
 				existing = &exemplar.QueryResult{SeriesLabels: lbls}
 				merged[fp] = existing
+				seen[fp] = make(map[exemplarKey]struct{}, len(r.Exemplars))
 			}
+			seenSeries := seen[fp]
 			for _, ex := range r.Exemplars {
-				existing.Exemplars = append(existing.Exemplars, exemplar.Exemplar{
+				e := exemplar.Exemplar{
 					Labels: labelSetToLabels(ex.Labels),
 					Value:  float64(ex.Value),
 					Ts:     int64(ex.Timestamp),
 					HasTs:  true,
-				})
+				}
+				// labels.Labels are sorted, so String() is a stable key.
+				k := exemplarKey{ts: e.Ts, value: e.Value, labels: e.Labels.String()}
+				if _, dup := seenSeries[k]; dup {
+					continue
+				}
+				seenSeries[k] = struct{}{}
+				existing.Exemplars = append(existing.Exemplars, e)
 			}
 		}
 	}
 
 	out := make([]exemplar.QueryResult, 0, len(merged))
 	for _, r := range merged {
+		// The downstream API returns exemplars ordered by timestamp; restore
+		// that ordering after merging across selectors. The comparison is a
+		// total order over exactly the fields exemplarKey identifies an
+		// exemplar by, so the result doesn't depend on the (unordered) order
+		// the merged-in results arrived in.
+		exemplars := r.Exemplars
+		sort.Slice(exemplars, func(i, j int) bool {
+			a, b := exemplars[i], exemplars[j]
+			if a.Ts != b.Ts {
+				return a.Ts < b.Ts
+			}
+			if a.Value != b.Value {
+				return a.Value < b.Value
+			}
+			return a.Labels.String() < b.Labels.String()
+		})
 		out = append(out, *r)
 	}
+	// Map iteration order is random, so sort by series labels to make repeated
+	// identical requests return identical results.
+	sort.Slice(out, func(i, j int) bool { return labels.Compare(out[i].SeriesLabels, out[j].SeriesLabels) < 0 })
 	return out, nil
+}
+
+// exemplarKey is the identity of a single exemplar within a series: timestamp,
+// value and labels together.
+type exemplarKey struct {
+	ts     int64
+	value  float64
+	labels string
 }
 
 func labelSetToLabels(ls model.LabelSet) labels.Labels {

--- a/pkg/proxystorage/exemplar_querier_test.go
+++ b/pkg/proxystorage/exemplar_querier_test.go
@@ -146,3 +146,118 @@ func TestProxyExemplarQuerier_DeduplicatesAcrossSelectors(t *testing.T) {
 		t.Fatalf("want 2 exemplars on the merged series, got %d", len(got[0].Exemplars))
 	}
 }
+
+func TestProxyExemplarQuerier_DedupAndOrdering(t *testing.T) {
+	v1Ex := func(traceID string, val float64, ts int64) v1.Exemplar {
+		e := v1.Exemplar{Value: model.SampleValue(val), Timestamp: model.Time(ts)}
+		if traceID != "" {
+			e.Labels = model.LabelSet{"trace_id": model.LabelValue(traceID)}
+		}
+		return e
+	}
+	wantEx := func(traceID string, val float64, ts int64) exemplar.Exemplar {
+		e := exemplar.Exemplar{Value: val, Ts: ts, HasTs: true}
+		if traceID != "" {
+			e.Labels = labels.FromStrings("trace_id", traceID)
+		} else {
+			e.Labels = labels.EmptyLabels()
+		}
+		return e
+	}
+	fooSet := model.LabelSet{"__name__": "foo"}
+	barSet := model.LabelSet{"__name__": "bar"}
+	fooLbls := labels.FromStrings("__name__", "foo")
+	barLbls := labels.FromStrings("__name__", "bar")
+
+	// Two selectors that both match the same underlying series; the stub
+	// stands in for a downstream that returns the same exemplars for both.
+	aMatchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "__name__", "foo"),
+		labels.MustNewMatcher(labels.MatchEqual, "job", "a"),
+	}
+	bMatchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "__name__", "foo"),
+		labels.MustNewMatcher(labels.MatchEqual, "job", "b"),
+	}
+	aQuery := `{__name__="foo",job="a"}`
+	bQuery := `{__name__="foo",job="b"}`
+
+	tests := []struct {
+		name     string
+		resps    map[string][]v1.ExemplarQueryResult
+		matchers [][]*labels.Matcher
+		want     []exemplar.QueryResult
+	}{
+		{
+			// The same exemplar returned for both selectors must only be
+			// emitted once.
+			name: "identical exemplar from two selectors is deduplicated",
+			resps: map[string][]v1.ExemplarQueryResult{
+				aQuery: {{SeriesLabels: fooSet, Exemplars: []v1.Exemplar{v1Ex("a", 1, 100)}}},
+				bQuery: {{SeriesLabels: fooSet, Exemplars: []v1.Exemplar{v1Ex("a", 1, 100)}}},
+			},
+			matchers: [][]*labels.Matcher{aMatchers, bMatchers},
+			want: []exemplar.QueryResult{
+				{SeriesLabels: fooLbls, Exemplars: []exemplar.Exemplar{wantEx("a", 1, 100)}},
+			},
+		},
+		{
+			name: "same timestamp with different labels are both kept",
+			resps: map[string][]v1.ExemplarQueryResult{
+				aQuery: {{SeriesLabels: fooSet, Exemplars: []v1.Exemplar{v1Ex("a", 1, 100)}}},
+				bQuery: {{SeriesLabels: fooSet, Exemplars: []v1.Exemplar{v1Ex("b", 1, 100)}}},
+			},
+			matchers: [][]*labels.Matcher{aMatchers, bMatchers},
+			want: []exemplar.QueryResult{
+				{SeriesLabels: fooLbls, Exemplars: []exemplar.Exemplar{wantEx("a", 1, 100), wantEx("b", 1, 100)}},
+			},
+		},
+		{
+			name: "exemplars are sorted by timestamp",
+			resps: map[string][]v1.ExemplarQueryResult{
+				aQuery: {{SeriesLabels: fooSet, Exemplars: []v1.Exemplar{v1Ex("c", 3, 300), v1Ex("a", 1, 100)}}},
+				bQuery: {{SeriesLabels: fooSet, Exemplars: []v1.Exemplar{v1Ex("d", 4, 400), v1Ex("b", 2, 200)}}},
+			},
+			matchers: [][]*labels.Matcher{aMatchers, bMatchers},
+			want: []exemplar.QueryResult{
+				{SeriesLabels: fooLbls, Exemplars: []exemplar.Exemplar{
+					wantEx("a", 1, 100), wantEx("b", 2, 200), wantEx("c", 3, 300), wantEx("d", 4, 400),
+				}},
+			},
+		},
+		{
+			name: "different series stay separate and are sorted by series labels",
+			resps: map[string][]v1.ExemplarQueryResult{
+				aQuery: {
+					{SeriesLabels: fooSet, Exemplars: []v1.Exemplar{v1Ex("a", 1, 100)}},
+					{SeriesLabels: barSet, Exemplars: []v1.Exemplar{v1Ex("b", 2, 200)}},
+				},
+				bQuery: {
+					{SeriesLabels: fooSet, Exemplars: []v1.Exemplar{v1Ex("a", 1, 100)}},
+					{SeriesLabels: barSet, Exemplars: []v1.Exemplar{v1Ex("b", 2, 200)}},
+				},
+			},
+			matchers: [][]*labels.Matcher{aMatchers, bMatchers},
+			want: []exemplar.QueryResult{
+				{SeriesLabels: barLbls, Exemplars: []exemplar.Exemplar{wantEx("b", 2, 200)}},
+				{SeriesLabels: fooLbls, Exemplars: []exemplar.Exemplar{wantEx("a", 1, 100)}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q := &proxyExemplarQuerier{
+				ctx:    context.Background(),
+				client: &exemplarStubAPI{resps: tc.resps},
+			}
+			got, err := q.Select(0, 1000, tc.matchers...)
+			if err != nil {
+				t.Fatalf("Select: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("result mismatch\nwant: %+v\ngot:  %+v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two changes that have to land together, because the second exposes a latent ordering assumption in the first.

### Exemplars are unioned across HA replicas without deduplication

`MultiAPI.QueryExemplars` grouped results by series fingerprint and then concatenated the exemplar lists:

```go
existing.Exemplars = append(existing.Exemplars, qr.Exemplars...)
```

Inside a server group the fan-out is across HA replicas of the same Prometheus, which observed the same exemplars — so every exemplar came back once per replica. Every other fan-out path in the codebase applies anti-affinity or set semantics; this one did not. `proxyExemplarQuerier.Select` one layer up has the same shape, so nothing downstream collapsed them either.

Dedupe on `(timestamp, value, labels)` — the identity Prometheus itself uses — not on timestamp alone, since a series legitimately carries several exemplars at one timestamp with different trace IDs.

Also fixed while in there: the first-result path took a shortcut that both skipped dedupe and aliased the downstream's exemplar slice.

### The fan-out received in index order

All six fan-out methods allocated one channel per API and received from them in index order, under a comment reading `// Wait for results as we get them`. Total latency was unaffected — every request is already in flight — but the early abort was: each method can return the moment enough replicas of one HA bucket have failed that the result can't be assembled, and that check couldn't run for a fast-failing target at index 5 until slow targets 0–4 returned. The doomed query stayed open with its sibling requests still running.

Now a single channel buffered to `len(apis)`, received in completion order.

**Three methods still need index ordering for their *merge*,** which I did not expect and which two existing tests caught immediately (`TestMultiAPIMerging/9/Series` and one of the new exemplar tests). They park results in per-API slots and merge after the receive loop, so the early abort is preserved:

- `Series` and `Metadata` are first-writer-wins, so arrival order leaked into which downstream won.
- `scatterMerge`'s output is globally label-sorted, but `mergeAntiAffinity` resolves duplicate samples across HA replicas in the order sets are handed to it, so arrival order could change which replica's samples are returned. Latent, wasn't covered by a test.

`LabelValues` and `LabelNames` sort at the end and are provably order-independent.

Finally, the exemplar sort was keyed on `Timestamp` alone, which was deterministic only because results used to arrive in index order. It's now a total order over the same fields the dedupe key uses.

### Testing

`TestMultiAPIEarlyReturnOnLaterIndexFailure` blocks index 0 and fails index 1; reverting to per-index channels makes all 8 subtests time out. `TestMultiAPIMergeIndependentOfCompletionOrder` computes an in-order baseline then reruns with index 0 held back, requiring identical output.

`go test -race -mod=vendor -tags netgo,builtinassets ./pkg/...` passes, including `-count=5` on `./pkg/promclient/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
