### PR TITLE
perf(promclient): index the label filter instead of scanning it

### DIFF
--- a/pkg/promclient/labelfilter.go
+++ b/pkg/promclient/labelfilter.go
@@ -437,23 +437,96 @@ func (l *FilterLabelVisitor) Visit(node parser.Node, path []parser.Node) (w pars
 	return l, nil
 }
 
+// FilterLabelMatchers returns whether the given matcher can be satisfied by the
+// filter; meaning whether at least one value in the filter's value-set for
+// `matcher.Name` matches. If the filter has no entry at all for the matcher's
+// label name then we know nothing about that label, so we return true (meaning
+// "don't filter this out").
+//
+// This is semantically identical to scanning the value set calling
+// `matcher.Matches(v)` on every value, but avoids doing so wherever the answer
+// can be computed from map lookups instead -- the value sets here can be very
+// large (e.g. every `__name__` on the downstream) and this is called per
+// matcher, per target, per query, before any I/O is done.
+//
 // TODO: better name, this is to check if a matcher is in the filter
 func FilterLabelMatchers(filter map[string]map[string]struct{}, matcher *labels.Matcher) bool {
-	for labelName, labelFilter := range filter {
-		if matcher.Name == labelName {
-			match := false
-			// Check that there is a match somewhere!
-			for v := range labelFilter {
-				if matcher.Matches(v) {
-					match = true
-					break
+	labelFilter, ok := filter[matcher.Name]
+	// If we have no filter for this label; we have nothing to say about it
+	if !ok {
+		return true
+	}
+
+	switch matcher.Type {
+	// An equality matcher matches exactly one value; so this is a single lookup
+	case labels.MatchEqual:
+		_, ok := labelFilter[matcher.Value]
+		return ok
+
+	// A not-equal matcher matches every value *except* one; so it is satisfied
+	// as long as the set holds something other than that one value
+	case labels.MatchNotEqual:
+		switch len(labelFilter) {
+		case 0:
+			return false
+		case 1:
+			// The lone value in the set is either the excluded one (no match) or
+			// something else (match)
+			_, ok := labelFilter[matcher.Value]
+			return !ok
+		default:
+			// More than one distinct value; at least one of them isn't the
+			// excluded one
+			return true
+		}
+
+	// For regexes upstream can often tell us the exact set of literal values the
+	// pattern matches (e.g. `a|b|c`); which turns this back into map lookups
+	case labels.MatchRegexp:
+		if setMatches := matcher.SetMatches(); len(setMatches) > 0 {
+			for _, v := range setMatches {
+				if _, ok := labelFilter[v]; ok {
+					return true
 				}
 			}
-			if !match {
-				return match
-			}
+			return false
+		}
+
+	case labels.MatchNotRegexp:
+		if setMatches := matcher.SetMatches(); len(setMatches) > 0 {
+			// The matcher matches everything *except* setMatches; so it is
+			// satisfied iff the filter holds some value outside of that set
+			return countPresent(labelFilter, setMatches) < len(labelFilter)
 		}
 	}
 
-	return true
+	// A genuine regex; we have no choice but to check the values in the set
+	for v := range labelFilter {
+		if matcher.Matches(v) {
+			return true
+		}
+	}
+	return false
+}
+
+// countPresent returns how many *distinct* values from `values` are present in
+// `set`. `set` is never mutated (it is shared across goroutines).
+func countPresent(set map[string]struct{}, values []string) int {
+	count := 0
+	// Only allocated if we actually find duplicates worth tracking
+	var seen map[string]struct{}
+	for i, v := range values {
+		if _, ok := set[v]; !ok {
+			continue
+		}
+		if seen == nil {
+			// The first hit can't be a duplicate; subsequent ones might be
+			seen = make(map[string]struct{}, len(values)-i)
+		} else if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		count++
+	}
+	return count
 }

--- a/pkg/promclient/labelfilter_test.go
+++ b/pkg/promclient/labelfilter_test.go
@@ -408,3 +408,278 @@ func TestLabelFilterOnSyncError(t *testing.T) {
 		}
 	})
 }
+
+// referenceFilterLabelMatchers is the naive (pre-optimization) implementation of
+// FilterLabelMatchers; it simply calls matcher.Matches() over every value in the
+// filter's value set. The optimized implementation must agree with this for
+// every input.
+func referenceFilterLabelMatchers(filter map[string]map[string]struct{}, matcher *labels.Matcher) bool {
+	for labelName, labelFilter := range filter {
+		if matcher.Name == labelName {
+			match := false
+			// Check that there is a match somewhere!
+			for v := range labelFilter {
+				if matcher.Matches(v) {
+					match = true
+					break
+				}
+			}
+			if !match {
+				return match
+			}
+		}
+	}
+
+	return true
+}
+
+func TestFilterLabelMatchers(t *testing.T) {
+	tests := []struct {
+		name    string
+		filter  map[string]map[string]struct{}
+		matcher *labels.Matcher
+		expect  bool
+	}{
+		{
+			name:    "nil filter",
+			filter:  nil,
+			matcher: labels.MustNewMatcher(labels.MatchEqual, "__name__", "a"),
+			expect:  true,
+		},
+		{
+			name:    "label absent from filter",
+			filter:  map[string]map[string]struct{}{"job": {"a": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchEqual, "__name__", "a"),
+			expect:  true,
+		},
+		{
+			name:    "label absent from filter, notequal",
+			filter:  map[string]map[string]struct{}{"job": {"a": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchNotEqual, "__name__", "a"),
+			expect:  true,
+		},
+		{
+			name:    "empty value set, equal",
+			filter:  map[string]map[string]struct{}{"__name__": {}},
+			matcher: labels.MustNewMatcher(labels.MatchEqual, "__name__", "a"),
+			expect:  false,
+		},
+		{
+			name:    "empty value set, notequal",
+			filter:  map[string]map[string]struct{}{"__name__": {}},
+			matcher: labels.MustNewMatcher(labels.MatchNotEqual, "__name__", "a"),
+			expect:  false,
+		},
+		{
+			name:    "empty value set, regexp matching everything",
+			filter:  map[string]map[string]struct{}{"__name__": {}},
+			matcher: labels.MustNewMatcher(labels.MatchRegexp, "__name__", ".*"),
+			expect:  false,
+		},
+		{
+			name:    "equal hit",
+			filter:  map[string]map[string]struct{}{"__name__": {"a": struct{}{}, "b": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchEqual, "__name__", "a"),
+			expect:  true,
+		},
+		{
+			name:    "equal miss",
+			filter:  map[string]map[string]struct{}{"__name__": {"a": struct{}{}, "b": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchEqual, "__name__", "z"),
+			expect:  false,
+		},
+		{
+			name:    "single element set, notequal that same value",
+			filter:  map[string]map[string]struct{}{"__name__": {"a": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchNotEqual, "__name__", "a"),
+			expect:  false,
+		},
+		{
+			name:    "single element set, notequal some other value",
+			filter:  map[string]map[string]struct{}{"__name__": {"a": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchNotEqual, "__name__", "z"),
+			expect:  true,
+		},
+		{
+			name:    "multi element set, notequal a member",
+			filter:  map[string]map[string]struct{}{"__name__": {"a": struct{}{}, "b": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchNotEqual, "__name__", "a"),
+			expect:  true,
+		},
+		{
+			name:    "empty string value, equal",
+			filter:  map[string]map[string]struct{}{"__name__": {"": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchEqual, "__name__", ""),
+			expect:  true,
+		},
+		{
+			name:    "empty string value, notequal empty string",
+			filter:  map[string]map[string]struct{}{"__name__": {"": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchNotEqual, "__name__", ""),
+			expect:  false,
+		},
+		{
+			name:    "empty string value, notequal something else",
+			filter:  map[string]map[string]struct{}{"__name__": {"": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchNotEqual, "__name__", "a"),
+			expect:  true,
+		},
+		{
+			name:    "regexp setmatches hit",
+			filter:  map[string]map[string]struct{}{"__name__": {"c": struct{}{}, "d": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchRegexp, "__name__", "a|b|c"),
+			expect:  true,
+		},
+		{
+			name:    "regexp setmatches miss",
+			filter:  map[string]map[string]struct{}{"__name__": {"x": struct{}{}, "y": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchRegexp, "__name__", "a|b|c"),
+			expect:  false,
+		},
+		{
+			name:    "regexp no match",
+			filter:  map[string]map[string]struct{}{"__name__": {"foo_a": struct{}{}, "foo_b": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchRegexp, "__name__", "bar_.+"),
+			expect:  false,
+		},
+		{
+			name:    "regexp match",
+			filter:  map[string]map[string]struct{}{"__name__": {"foo_a": struct{}{}, "foo_b": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchRegexp, "__name__", "foo_.+"),
+			expect:  true,
+		},
+		{
+			name:    "notregexp setmatches covering the whole set",
+			filter:  map[string]map[string]struct{}{"__name__": {"a": struct{}{}, "b": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchNotRegexp, "__name__", "a|b|c"),
+			expect:  false,
+		},
+		{
+			name:    "notregexp setmatches leaving something",
+			filter:  map[string]map[string]struct{}{"__name__": {"a": struct{}{}, "z": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchNotRegexp, "__name__", "a|b|c"),
+			expect:  true,
+		},
+		{
+			name:    "notregexp genuine regex",
+			filter:  map[string]map[string]struct{}{"__name__": {"foo_a": struct{}{}, "foo_b": struct{}{}}},
+			matcher: labels.MustNewMatcher(labels.MatchNotRegexp, "__name__", "foo_.+"),
+			expect:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := FilterLabelMatchers(test.filter, test.matcher); got != test.expect {
+				t.Fatalf("expected %v got %v", test.expect, got)
+			}
+			// And it must always agree with the naive implementation
+			if got, want := FilterLabelMatchers(test.filter, test.matcher), referenceFilterLabelMatchers(test.filter, test.matcher); got != want {
+				t.Fatalf("disagrees with reference implementation: got %v want %v", got, want)
+			}
+		})
+	}
+}
+
+// TestFilterLabelMatchersMatchesReference exhaustively compares the optimized
+// implementation against the naive one across a cross-product of filters and
+// matchers of all four matcher types.
+func TestFilterLabelMatchersMatchesReference(t *testing.T) {
+	newSet := func(vals ...string) map[string]struct{} {
+		s := make(map[string]struct{}, len(vals))
+		for _, v := range vals {
+			s[v] = struct{}{}
+		}
+		return s
+	}
+
+	filters := map[string]map[string]map[string]struct{}{
+		"nil":                nil,
+		"empty":              {},
+		"other label only":   {"job": newSet("a", "b")},
+		"empty set":          {"__name__": newSet()},
+		"single a":           {"__name__": newSet("a")},
+		"single empty":       {"__name__": newSet("")},
+		"single z":           {"__name__": newSet("z")},
+		"multi abc":          {"__name__": newSet("a", "b", "c")},
+		"multi with empty":   {"__name__": newSet("", "a")},
+		"multi foo":          {"__name__": newSet("foo_a", "foo_b")},
+		"multi mixed":        {"__name__": newSet("a", "foo_a", "")},
+		"multi plus other":   {"__name__": newSet("a", "b"), "job": newSet("x")},
+		"disjoint from case": {"__name__": newSet("x", "y", "z")},
+	}
+
+	values := []string{"", "a", "b", "z", "foo_a", "a|b"}
+	regexes := []string{"", ".*", ".+", "a", "z", "a|b|c", "(a|z)", "[ab]", "foo_.+", "bar_.+", "a.*", "^$"}
+
+	for filterName, filter := range filters {
+		for _, v := range values {
+			for _, mt := range []labels.MatchType{labels.MatchEqual, labels.MatchNotEqual} {
+				matcher := labels.MustNewMatcher(mt, "__name__", v)
+				t.Run(fmt.Sprintf("%s/%s", filterName, matcher.String()), func(t *testing.T) {
+					got := FilterLabelMatchers(filter, matcher)
+					want := referenceFilterLabelMatchers(filter, matcher)
+					if got != want {
+						t.Fatalf("got %v want %v", got, want)
+					}
+				})
+			}
+		}
+		for _, re := range regexes {
+			for _, mt := range []labels.MatchType{labels.MatchRegexp, labels.MatchNotRegexp} {
+				matcher, err := labels.NewMatcher(mt, "__name__", re)
+				if err != nil {
+					t.Fatalf("error building matcher for %q: %v", re, err)
+				}
+				t.Run(fmt.Sprintf("%s/%s", filterName, matcher.String()), func(t *testing.T) {
+					got := FilterLabelMatchers(filter, matcher)
+					want := referenceFilterLabelMatchers(filter, matcher)
+					if got != want {
+						t.Fatalf("got %v want %v", got, want)
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkFilterLabelMatchers(b *testing.B) {
+	for _, size := range []int{1000, 10000, 100000} {
+		names := make(map[string]struct{}, size)
+		for i := 0; i < size; i++ {
+			names["metric_"+strconv.Itoa(i)] = struct{}{}
+		}
+		filter := map[string]map[string]struct{}{labels.MetricName: names}
+
+		// The last name added; a value which is definitely in the filter
+		present := "metric_" + strconv.Itoa(size-1)
+
+		matchers := []*labels.Matcher{
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, present),
+			labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "absent_metric"),
+			labels.MustNewMatcher(labels.MatchNotEqual, labels.MetricName, present),
+			labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "absent_a|absent_b|absent_c"),
+			labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "absent_a|absent_b|"+present),
+			labels.MustNewMatcher(labels.MatchNotRegexp, labels.MetricName, "absent_a|absent_b|absent_c"),
+			labels.MustNewMatcher(labels.MatchRegexp, labels.MetricName, "absent_.+"),
+		}
+		caseNames := []string{
+			"equal_hit",
+			"equal_miss",
+			"notequal_hit",
+			"regexp_set_miss",
+			"regexp_set_hit",
+			"notregexp_set_hit",
+			"regexp_scan_miss",
+		}
+
+		for i, matcher := range matchers {
+			b.Run(fmt.Sprintf("size=%d/%s", size, caseNames[i]), func(b *testing.B) {
+				b.ReportAllocs()
+				for n := 0; n < b.N; n++ {
+					FilterLabelMatchers(filter, matcher)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
The filter is `map[labelName]map[labelValue]struct{}` — already indexed both ways. `FilterLabelMatchers` ignored that twice: it ranged the outer map to find one key, then ranged every value calling `matcher.Matches(v)`, even for an equality matcher that could be a single map hit.

```go
for labelName, labelFilter := range filter {   // filter[matcher.Name] is right there
    if matcher.Name == labelName {
        for v := range labelFilter {           // full scan; regex eval per value
            if matcher.Matches(v) { ... }
```

Cost per matcher, per target, per query — all before any I/O — against a `__name__` filter of 100k names:

| case | before | after |
|---|---|---|
| equal, hit | 405.6 µs | 13.5 ns |
| equal, miss | 561.0 µs | 10.8 ns |
| regexp (SetMatches), miss | 888.7 µs | 53.3 ns |
| regexp (genuine), miss | 907 µs | unchanged |

The miss rows are the case `label_filter` exists to serve — deciding *not* to send a query for a metric this group doesn't have. Three matchers across ten targets was ~17 ms of CPU to make that decision.

### The change

- Index the outer map; a label absent from the filter still returns `true`.
- `MatchEqual` is one map lookup.
- `MatchNotEqual` / `MatchNotRegexp` reduce to counting how much of the set is excluded.
- Regexps try `SetMatches()` first — upstream populates it only for the case-sensitive literal-alternatives path, where `Matches(s)` is exactly `slices.Contains(setMatches, s)`, so this is semantics-preserving.
- Genuine regexps still scan and are unchanged; the benchmark keeps that case so the remaining worst path stays visible.

The value maps are shared across goroutines through the atomic, so all of this is strictly read-only — `countPresent` in particular never mutates.

### Testing

`TestFilterLabelMatchersMatchesReference` cross-checks against a reference implementation that just calls `matcher.Matches` over the whole set — 468 cases across 13 filters × all four matcher types — so the fast paths can't drift from the semantics they replace. Plus 21 named cases for the edges: nil filter, label absent, empty value set, single-element set with `MatchNotEqual` for that same value, empty-string values.

`go test -race -mod=vendor -tags netgo,builtinassets ./pkg/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
