### PR TITLE
fix(federate): stop writing into a dead connection, and stop calling it a failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/prometheus/sigv4 v0.2.0
 	github.com/sirupsen/logrus v1.9.3
 	go.uber.org/atomic v1.11.0
+	golang.org/x/net v0.55.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
@@ -204,7 +205,6 @@ require (
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/pkg/expfmt/encode.go
+++ b/pkg/expfmt/encode.go
@@ -203,13 +203,36 @@ func MetricFamilyToText(out io.Writer, mf *dto.MetricFamily) error {
 // default (UnderscoreEscaping) and legacy-valid names this is allocation-free.
 type Encoder struct {
 	w        *bufio.Writer
+	ew       *errWriter
 	scheme   model.EscapingScheme
 	lastName string
 	started  bool
 }
 
 func NewEncoder(w io.Writer, scheme model.EscapingScheme) *Encoder {
-	return &Encoder{w: bufio.NewWriter(w), scheme: scheme}
+	ew := &errWriter{w: w}
+	return &Encoder{w: bufio.NewWriter(ew), ew: ew, scheme: scheme}
+}
+
+// errWriter latches the first error returned by the underlying writer, so the
+// Encoder can report it without every write in the hot path having to be
+// checked. bufio.Writer already stops accepting data after its first error
+// ("all subsequent writes, and Flush, will return the error"), so once this
+// fires the remaining encoding work is pure waste -- see Encoder.Err.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) Write(p []byte) (int, error) {
+	if ew.err != nil {
+		return 0, ew.err
+	}
+	n, err := ew.w.Write(p)
+	if err != nil {
+		ew.err = err
+	}
+	return n, err
 }
 
 // WriteFloatSample writes one untyped sample.
@@ -288,3 +311,11 @@ func (e *Encoder) WriteFloatSample(name string, lbls labels.Labels, external []l
 
 // Flush flushes any buffered output to the underlying writer.
 func (e *Encoder) Flush() error { return e.w.Flush() }
+
+// Err returns the first error the underlying writer returned, or nil. Writes
+// are buffered, so it only becomes non-nil once a buffer flush has actually hit
+// the underlying writer -- i.e. it reports "the destination is dead", not
+// "sample N failed". Callers streaming many samples should check it in the loop
+// (it is a single field read) and stop encoding once it is set, since after the
+// first error nothing more can reach the destination.
+func (e *Encoder) Err() error { return e.ew.err }

--- a/pkg/federate/federate.go
+++ b/pkg/federate/federate.go
@@ -15,11 +15,16 @@
 package federate
 
 import (
+	"context"
+	"errors"
+	"io"
+	"net"
 	"net/http"
 	"slices"
 	"sort"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	commonexpfmt "github.com/prometheus/common/expfmt"
@@ -31,6 +36,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/net/http2"
 
 	promexpfmt "github.com/jacksontj/promxy/pkg/expfmt"
 )
@@ -169,12 +175,73 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	external := *h.extLabels.Load()
 	w.Header().Set("Content-Type", string(format))
-	enc := promexpfmt.NewEncoder(w, format.ToEscapingScheme())
+	if written, err := writeSamples(w, vec, external, format.ToEscapingScheme()); err != nil {
+		logWriteError(err, written, len(vec))
+	}
+}
+
+// writeSamples encodes vec to w and returns the number of samples encoded. It
+// stops at the first write error rather than formatting the rest of the payload
+// into a socket that can no longer accept it -- a client that hangs up mid-body
+// (scrape timeout, cancellation) otherwise costs a full render of the result
+// set. The returned count is samples handed to the encoder; because writes are
+// buffered, the tail of it may not have reached w.
+func writeSamples(w io.Writer, vec []floatSample, external []labels.Label, scheme model.EscapingScheme) (int, error) {
+	enc := promexpfmt.NewEncoder(w, scheme)
+	written := 0
 	for i := range vec {
 		s := &vec[i]
 		enc.WriteFloatSample(s.metric.Get(labels.MetricName), s.metric, external, s.f, s.t)
+		if err := enc.Err(); err != nil {
+			return written, err
+		}
+		written++
 	}
-	if err := enc.Flush(); err != nil {
-		logrus.WithError(err).Error("federation failed")
+	return written, enc.Flush()
+}
+
+// logWriteError reports a federation response that could not be fully written.
+// A client that went away mid-scrape is normal operation (scrape_timeout,
+// cancelled scrape, connection reset) and is logged at debug; anything else is
+// a real failure and stays at error. Both carry how far through the payload we
+// got, so an aborted scrape can be told apart from an empty/failed one.
+func logWriteError(err error, written, total int) {
+	e := logrus.WithError(err).WithFields(logrus.Fields{
+		"samples_written": written,
+		"samples_total":   total,
+	})
+	if isClientDisconnect(err) {
+		e.Debug("federation aborted: client went away")
+		return
 	}
+	e.Error("federation failed")
+}
+
+// isClientDisconnect reports whether err means the scraping client went away
+// (cancelled/timed-out scrape, closed connection or http2 stream) rather than a
+// genuine failure to serve the response.
+func isClientDisconnect(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	// golang.org/x/net/http2 surfaces peer resets as typed errors.
+	var streamErr http2.StreamError
+	if errors.As(err, &streamErr) {
+		return true
+	}
+	var connErr http2.ConnectionError
+	if errors.As(err, &connErr) {
+		return true
+	}
+	// net/http's bundled http2 server has its own (unexported) copies of those
+	// sentinels -- "http2: stream closed" and "client disconnected" -- which are
+	// only reachable by message. This is the shape seen in issue #781.
+	msg := err.Error()
+	return strings.Contains(msg, "http2: stream closed") || strings.Contains(msg, "client disconnected")
 }

--- a/pkg/federate/federate_write_test.go
+++ b/pkg/federate/federate_write_test.go
@@ -1,0 +1,270 @@
+package federate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/http2"
+)
+
+// failingWriter is an http.ResponseWriter that accepts failAfter bytes and then
+// fails every write with err. It records how many Write calls it saw, so a test
+// can tell "stopped early" from "formatted the whole payload".
+type failingWriter struct {
+	failAfter int
+	err       error
+
+	hdr      http.Header
+	accepted int
+	writes   int
+	status   int
+}
+
+func (f *failingWriter) Header() http.Header {
+	if f.hdr == nil {
+		f.hdr = http.Header{}
+	}
+	return f.hdr
+}
+
+func (f *failingWriter) WriteHeader(status int) { f.status = status }
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	f.writes++
+	room := f.failAfter - f.accepted
+	if room <= 0 {
+		return 0, f.err
+	}
+	if room >= len(p) {
+		f.accepted += len(p)
+		return len(p), nil
+	}
+	f.accepted += room
+	return room, f.err
+}
+
+// bigLoad builds a promqltest load block with n distinct series of one metric,
+// large enough that the encoder's buffered writer flushes several times.
+func bigLoad(n int) string {
+	var b strings.Builder
+	b.WriteString("load 1m\n")
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "  fed_metric{instance=\"instance-%04d\",job=\"federation-test\"} 1 2 3\n", i)
+	}
+	return b.String()
+}
+
+// captureLogs redirects the standard logrus logger into a buffer of JSON lines
+// for the duration of the test.
+func captureLogs(t *testing.T, level logrus.Level) *bytes.Buffer {
+	t.Helper()
+	std := logrus.StandardLogger()
+	out, formatter, lvl := std.Out, std.Formatter, std.GetLevel()
+	var buf bytes.Buffer
+	std.SetOutput(&buf)
+	std.SetFormatter(&logrus.JSONFormatter{})
+	std.SetLevel(level)
+	t.Cleanup(func() {
+		std.SetOutput(out)
+		std.SetFormatter(formatter)
+		std.SetLevel(lvl)
+	})
+	return &buf
+}
+
+func lastLogLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) == 0 || lines[0] == "" {
+		t.Fatal("no log output captured")
+	}
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &entry); err != nil {
+		t.Fatalf("parsing log line %q: %v", lines[len(lines)-1], err)
+	}
+	return entry
+}
+
+// TestWriteSamplesStopsAtFirstError asserts the sample loop aborts as soon as a
+// write fails, instead of formatting the rest of the payload into a dead
+// socket.
+func TestWriteSamplesStopsAtFirstError(t *testing.T) {
+	const total = 2000
+	vec := make([]floatSample, 0, total)
+	for i := 0; i < total; i++ {
+		vec = append(vec, floatSample{
+			metric: labels.FromStrings(labels.MetricName, "fed_metric", "instance", fmt.Sprintf("instance-%04d", i)),
+			t:      120000,
+			f:      float64(i),
+		})
+	}
+
+	boom := errors.New("boom")
+	fw := &failingWriter{failAfter: 0, err: boom}
+
+	written, err := writeSamples(fw, vec, []labels.Label{{Name: model.InstanceLabel, Value: ""}}, model.UnderscoreEscaping)
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected the write error back, got %v", err)
+	}
+	if written == 0 || written >= total {
+		t.Fatalf("expected to stop partway through the payload, wrote %d of %d", written, total)
+	}
+	// The whole payload is many buffer-flushes worth of data; stopping early
+	// means the writer sees only the first failed flush (plus at most the
+	// final Flush).
+	if fw.writes > 2 {
+		t.Fatalf("expected to stop after the first failed write, saw %d writes", fw.writes)
+	}
+}
+
+// TestWriteSamplesWritesEverySample asserts the early-exit plumbing does not
+// truncate a successful federation: every sample is written and the bytes match
+// the vendored handler exactly for a multi-flush payload.
+func TestWriteSamplesWritesEverySample(t *testing.T) {
+	const series = 300
+	st := promqltest.LoadedStorage(t, bigLoad(series))
+	t.Cleanup(func() { st.Close() })
+
+	now := timestamp.Time(120000)
+	lookback := 5 * time.Minute
+	target := "/federate?match%5B%5D=" + url.QueryEscape("fed_metric")
+
+	h := New(st, lookback, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("unexpected fallback to vendored handler for text/plain request")
+	}))
+	h.now = func() time.Time { return now }
+	h.SetExternalLabels(labels.EmptyLabels())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+
+	want, err := referenceFederate(st, lookback, now, labels.EmptyLabels(), httptest.NewRequest(http.MethodGet, target, nil))
+	if err != nil {
+		t.Fatalf("reference: %v", err)
+	}
+	got := rec.Body.Bytes()
+	if !bytes.Equal(got, want) {
+		t.Fatalf("output mismatch (%d vs %d bytes)", len(got), len(want))
+	}
+	if n := bytes.Count(got, []byte("fed_metric{")); n != series {
+		t.Fatalf("expected %d sample lines, got %d", series, n)
+	}
+	if len(got) < 4096 {
+		t.Fatalf("payload too small (%d bytes) to exercise a multi-flush write", len(got))
+	}
+}
+
+// TestFederateWriteErrorLogging asserts a response body that could not be fully
+// written is logged with how far it got, and that a client-side disconnect is
+// not logged as an error.
+func TestFederateWriteErrorLogging(t *testing.T) {
+	st := promqltest.LoadedStorage(t, bigLoad(300))
+	t.Cleanup(func() { st.Close() })
+
+	for _, tc := range []struct {
+		name    string
+		err     error
+		level   string
+		message string
+	}{
+		{
+			name:    "genuine_failure",
+			err:     errors.New("kaboom"),
+			level:   "error",
+			message: "federation failed",
+		},
+		{
+			name:    "client_disconnect",
+			err:     fmt.Errorf("write tcp 10.0.0.1:9090->10.0.0.2:53124: %w", syscall.EPIPE),
+			level:   "debug",
+			message: "federation aborted: client went away",
+		},
+		{
+			name:    "http2_stream_closed",
+			err:     errors.New("http2: stream closed"),
+			level:   "debug",
+			message: "federation aborted: client went away",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureLogs(t, logrus.DebugLevel)
+
+			h := New(st, 5*time.Minute, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatal("unexpected fallback to vendored handler for text/plain request")
+			}))
+			h.now = func() time.Time { return timestamp.Time(120000) }
+
+			fw := &failingWriter{failAfter: 100, err: tc.err}
+			target := "/federate?match%5B%5D=" + url.QueryEscape("fed_metric")
+			h.ServeHTTP(fw, httptest.NewRequest(http.MethodGet, target, nil))
+
+			entry := lastLogLine(t, logs)
+			if entry["level"] != tc.level {
+				t.Fatalf("level = %v, want %v (entry: %v)", entry["level"], tc.level, entry)
+			}
+			if entry["msg"] != tc.message {
+				t.Fatalf("msg = %v, want %v", entry["msg"], tc.message)
+			}
+			written, _ := entry["samples_written"].(float64)
+			total, _ := entry["samples_total"].(float64)
+			if total != 300 {
+				t.Fatalf("samples_total = %v, want 300", entry["samples_total"])
+			}
+			if written <= 0 || written >= total {
+				t.Fatalf("samples_written = %v, want a partial count of %v", written, total)
+			}
+			if fw.writes > 2 {
+				t.Fatalf("expected to stop after the first failed write, saw %d writes", fw.writes)
+			}
+		})
+	}
+}
+
+// TestIsClientDisconnect covers the classification that decides between a debug
+// line (the scrape's client went away) and an error line (a real failure).
+func TestIsClientDisconnect(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context_canceled", context.Canceled, true},
+		{"wrapped_context_canceled", fmt.Errorf("writing response: %w", context.Canceled), true},
+		{"epipe", syscall.EPIPE, true},
+		{"wrapped_epipe", fmt.Errorf("write tcp: %w", syscall.EPIPE), true},
+		{"econnreset", fmt.Errorf("write tcp: %w", syscall.ECONNRESET), true},
+		{"net_err_closed", fmt.Errorf("write: %w", net.ErrClosed), true},
+		{"http2_stream_error", http2.StreamError{StreamID: 3, Code: http2.ErrCodeCancel}, true},
+		{"wrapped_http2_stream_error", fmt.Errorf("federate: %w", http2.StreamError{StreamID: 3, Code: http2.ErrCodeCancel}), true},
+		{"http2_connection_error", http2.ConnectionError(http2.ErrCodeCancel), true},
+		{"bundled_http2_stream_closed", errors.New("http2: stream closed"), true},
+		{"bundled_client_disconnected", errors.New("client disconnected"), true},
+		{"deadline_exceeded", context.DeadlineExceeded, false},
+		{"short_write", io.ErrShortWrite, false},
+		{"arbitrary", errors.New("something else went wrong"), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isClientDisconnect(tc.err); got != tc.want {
+				t.Fatalf("isClientDisconnect(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`ServeHTTP` discarded every `WriteFloatSample` return and only checked the final `Flush`:

```go
for i := range vec {
    s := &vec[i]
    enc.WriteFloatSample(s.metric.Get(labels.MetricName), s.metric, external, s.f, s.t)
}
if err := enc.Flush(); err != nil {
    logrus.WithError(err).Error("federation failed")
}
```

When a scraping client hangs up mid-body — scrape_timeout, cancellation — the writes start failing immediately but promxy keeps formatting and attempting to write the entire remaining result set, noticing only at the end. On a large federation payload that's a lot of wasted CPU per aborted scrape, and the log line says nothing about how far it got.

### Sticky error rather than a per-call return

`WriteFloatSample` performs ~15 individual `bufio` writes per sample, so an error return would mean either checking each (branchy, slow) or probing at the end — and probing at the end *is* what `Encoder.Err()` is, only reusable. It also keeps the hot loop's allocation-free structure intact: `BenchmarkEncoderLean` is still 3 allocs/op for 5000 samples. Cost in the loop is one deref and nil check per sample.

### Classifying the failure

A scrape cancelled by its client is normal operation, not a promxy failure. `context.Canceled`, `EPIPE`, `ECONNRESET`, `net.ErrClosed` and http2 stream/connection errors now log at debug with a `samples_written`/`samples_total` count; genuine encoding failures stay at error.

**Relevant to #781.** The `federation failed: http2: stream closed` noise comes from this path — specifically from net/http's *bundled* h2 server, whose sentinels are unexported and reachable only by message, hence the string check alongside the typed ones. This does not fix whatever is cancelling those scrapes; it stops promxy reporting the client's disconnect as its own error, and gives the sample counts needed to tell a disconnect from a real failure.

`golang.org/x/net` moves from indirect to direct in `go.mod` — it was already vendored and marked explicit, so `vendor/` is unchanged.

### Testing

`TestWriteSamplesStopsAtFirstError` sends 2000 samples into a writer that fails immediately and asserts the writer saw ≤2 `Write` calls (the full payload would be ~30 flushes). `TestWriteSamplesWritesEverySample` checks a successful multi-flush federation is still byte-equal to the vendored handler. `TestIsClientDisconnect` covers 15 cases including wrapped errnos, typed h2 errors, both bundled-h2 message forms, and negatives.

`go test -race -mod=vendor -tags netgo,builtinassets ./pkg/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
