### PR TITLE
refactor(servergroup)!: publish config and client atomically

### DIFF
--- a/pkg/proxystorage/histogram_routing.go
+++ b/pkg/proxystorage/histogram_routing.go
@@ -120,11 +120,12 @@ func (p *ProxyStorage) strictMissingRemoteRead() []int {
 	}
 	var ords []int
 	for _, sg := range state.sgs {
-		if sg.Cfg == nil {
+		cfg := sg.Config()
+		if cfg == nil {
 			continue
 		}
-		if !sg.Cfg.RemoteRead && !sg.Cfg.NativeHistogram.AllowLossy {
-			ords = append(ords, sg.Cfg.Ordinal)
+		if !cfg.RemoteRead && !cfg.NativeHistogram.AllowLossy {
+			ords = append(ords, cfg.Ordinal)
 		}
 	}
 	return ords
@@ -145,7 +146,7 @@ func (p *ProxyStorage) histogramNamePredicate() func(string) bool {
 	}
 	var enabled bool
 	for _, sg := range state.sgs {
-		if sg.Cfg != nil && sg.Cfg.NativeHistogram.MetadataRefresh > 0 {
+		if cfg := sg.Config(); cfg != nil && cfg.NativeHistogram.MetadataRefresh > 0 {
 			enabled = true
 			break
 		}

--- a/pkg/proxystorage/histogram_routing_test.go
+++ b/pkg/proxystorage/histogram_routing_test.go
@@ -90,6 +90,22 @@ func TestIsHistogramExpr(t *testing.T) {
 	}
 }
 
+// sgWithConfig builds a ServerGroup carrying only the given configuration.
+// ServerGroup.Config is published atomically by ApplyConfig, so tests go
+// through the real constructor + ApplyConfig rather than setting a field.
+func sgWithConfig(t *testing.T, cfg *servergroup.Config) *servergroup.ServerGroup {
+	t.Helper()
+	sg, err := servergroup.NewServerGroup()
+	if err != nil {
+		t.Fatalf("NewServerGroup: %v", err)
+	}
+	t.Cleanup(sg.Cancel)
+	if err := sg.ApplyConfig(cfg); err != nil {
+		t.Fatalf("ApplyConfig: %v", err)
+	}
+	return sg
+}
+
 func TestStrictMissingRemoteRead(t *testing.T) {
 	cases := []struct {
 		name string
@@ -99,39 +115,39 @@ func TestStrictMissingRemoteRead(t *testing.T) {
 		{
 			name: "all remote_read configured",
 			sgs: []*servergroup.ServerGroup{
-				{Cfg: &servergroup.Config{Ordinal: 0, RemoteRead: true}},
-				{Cfg: &servergroup.Config{Ordinal: 1, RemoteRead: true}},
+				sgWithConfig(t, &servergroup.Config{Ordinal: 0, RemoteRead: true}),
+				sgWithConfig(t, &servergroup.Config{Ordinal: 1, RemoteRead: true}),
 			},
 			want: nil,
 		},
 		{
 			name: "remote_read missing, allow_lossy off — strict",
 			sgs: []*servergroup.ServerGroup{
-				{Cfg: &servergroup.Config{Ordinal: 0, RemoteRead: false}},
+				sgWithConfig(t, &servergroup.Config{Ordinal: 0, RemoteRead: false}),
 			},
 			want: []int{0},
 		},
 		{
 			name: "remote_read missing, allow_lossy on — not strict",
 			sgs: []*servergroup.ServerGroup{
-				{Cfg: &servergroup.Config{
+				sgWithConfig(t, &servergroup.Config{
 					Ordinal:         0,
 					RemoteRead:      false,
 					NativeHistogram: servergroup.NativeHistogramConfig{AllowLossy: true},
-				}},
+				}),
 			},
 			want: nil,
 		},
 		{
 			name: "mixed — only the strict one shows up",
 			sgs: []*servergroup.ServerGroup{
-				{Cfg: &servergroup.Config{Ordinal: 0, RemoteRead: true}},
-				{Cfg: &servergroup.Config{Ordinal: 1, RemoteRead: false}}, // strict
-				{Cfg: &servergroup.Config{
+				sgWithConfig(t, &servergroup.Config{Ordinal: 0, RemoteRead: true}),
+				sgWithConfig(t, &servergroup.Config{Ordinal: 1, RemoteRead: false}), // strict
+				sgWithConfig(t, &servergroup.Config{
 					Ordinal:         2,
 					RemoteRead:      false,
 					NativeHistogram: servergroup.NativeHistogramConfig{AllowLossy: true},
-				}},
+				}),
 			},
 			want: []int{1},
 		},

--- a/pkg/servergroup/concurrency_test.go
+++ b/pkg/servergroup/concurrency_test.go
@@ -1,0 +1,167 @@
+package servergroup
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+// TestConfigAccessorLifecycle covers the contract of the Config() accessor:
+// nil before the first ApplyConfig (callers such as groupIdentifier and the
+// proxystorage histogram routing rely on that), and the applied config after.
+func TestConfigAccessorLifecycle(t *testing.T) {
+	sg, err := NewServerGroup()
+	if err != nil {
+		t.Fatalf("NewServerGroup: %v", err)
+	}
+	defer sg.Cancel()
+
+	if got := sg.Config(); got != nil {
+		t.Fatalf("Config() before ApplyConfig = %v, want nil", got)
+	}
+	// The nil config must not panic anything that reads it.
+	if got := sg.groupIdentifier(); got != "unknown" {
+		t.Fatalf("groupIdentifier() before ApplyConfig = %q, want %q", got, "unknown")
+	}
+
+	cfg := &Config{Ordinal: 7, Name: "accessor-test", Scheme: "http"}
+	if err := sg.ApplyConfig(cfg); err != nil {
+		t.Fatalf("ApplyConfig: %v", err)
+	}
+
+	if got := sg.Config(); got != cfg {
+		t.Fatalf("Config() after ApplyConfig = %v, want %v", got, cfg)
+	}
+	if got := sg.groupIdentifier(); got != "ord=7 name=accessor-test" {
+		t.Fatalf("groupIdentifier() after ApplyConfig = %q", got)
+	}
+	if sg.httpClient() == nil {
+		t.Fatal("httpClient() after ApplyConfig = nil, want a client")
+	}
+}
+
+// TestApplyConfigConcurrentWithReaders exercises the three concurrent users of
+// the ServerGroup config/client: ApplyConfig publishing new ones, RoundTrip
+// reading both on every downstream request, and the Sync goroutine reading the
+// config while it rebuilds target clients. Run under -race this fails if either
+// field is published without synchronization.
+func TestApplyConfigConcurrentWithReaders(t *testing.T) {
+	// Make service discovery churn quickly so the Sync goroutine actually
+	// reloads targets (and thus reads the config) during the test.
+	oldInterval := DiscoveryUpdateInterval
+	DiscoveryUpdateInterval = 10 * time.Millisecond
+	defer func() { DiscoveryUpdateInterval = oldInterval }()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	// Two configs that differ in every field the concurrent readers touch: the
+	// custom headers (RoundTrip), and the labels/targets (Sync).
+	configs := make([]*Config, 2)
+	for i := range configs {
+		raw := fmt.Sprintf(`
+scheme: http
+http_client:
+  dial_timeout: 200ms
+http_headers:
+  X-Promxy-Test: variant-%d
+labels:
+  variant: "%d"
+static_configs:
+  - targets: [%q, %q]
+`, i, i, host, fmt.Sprintf("127.0.0.%d:9090", i+2))
+		cfg := &Config{}
+		if err := yaml.Unmarshal([]byte(raw), cfg); err != nil {
+			t.Fatalf("unmarshal config %d: %v", i, err)
+		}
+		cfg.Ordinal = i
+		configs[i] = cfg
+	}
+
+	sg, err := NewServerGroup()
+	if err != nil {
+		t.Fatalf("NewServerGroup: %v", err)
+	}
+	defer sg.Cancel()
+
+	if err := sg.ApplyConfig(configs[0]); err != nil {
+		t.Fatalf("ApplyConfig: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Readers: hammer the transport-level read path (config headers + client).
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+				if err != nil {
+					t.Errorf("NewRequest: %v", err)
+					return
+				}
+				resp, err := sg.RoundTrip(req)
+				if err != nil {
+					t.Errorf("RoundTrip: %v", err)
+					return
+				}
+				resp.Body.Close()
+			}
+		}()
+	}
+
+	// Writer: reconfigure the live server group. This also re-drives service
+	// discovery, so the Sync goroutine reloads targets (reading the config)
+	// while these writes are happening.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(stop)
+		for i := 0; i < 200; i++ {
+			if err := sg.ApplyConfig(configs[i%len(configs)]); err != nil {
+				t.Errorf("ApplyConfig: %v", err)
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+
+	// Sanity check that the sync path really ran (i.e. the config reads in
+	// loadTargetGroupMap were genuinely exercised, not skipped).
+	select {
+	case <-sg.Ready:
+	case <-time.After(10 * time.Second):
+		t.Fatal("server group never became ready; target sync never ran")
+	}
+
+	// Discovery churn means an update can transiently carry zero targets, so
+	// wait for the post-churn state to settle rather than sampling once.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if state := sg.State(); state != nil && len(state.Targets) > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("expected discovered targets after sync, got none")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -113,9 +113,13 @@ type ServerGroup struct {
 	loaded bool
 	Ready  chan struct{}
 
-	// TODO: lock/atomics on cfg and client
-	Cfg           *Config
-	client        *http.Client
+	// cfg and client are published by ApplyConfig and read concurrently by
+	// RoundTrip and by the Sync goroutine (which is started before the first
+	// ApplyConfig ever runs), so both are held as atomic pointers. Readers must
+	// take a single snapshot per operation (via Config()/httpClient()) rather
+	// than re-loading per field, or they can straddle two configurations.
+	cfg           atomic.Pointer[Config]
+	client        atomic.Pointer[http.Client]
 	targetManager *discovery.Manager
 
 	OriginalURLs []string
@@ -123,9 +127,9 @@ type ServerGroup struct {
 	state atomic.Value
 
 	// histogramCache backs IsHistogramMetric. The background refresh loop is
-	// only started when Cfg.HistogramMetadataRefresh > 0; when zero, the
-	// cache stays empty and IsHistogramMetric always returns false (AST-only
-	// routing). See pkg/servergroup/histogram_cache.go.
+	// only started when the config's native_histogram metadata refresh interval
+	// is > 0; when zero, the cache stays empty and IsHistogramMetric always
+	// returns false (AST-only routing). See pkg/servergroup/histogram_cache.go.
 	histogramCache histogramMetadataCache
 }
 
@@ -141,32 +145,52 @@ func (s *ServerGroup) IsHistogramMetric(name string) bool {
 	return s.histogramCache.Contains(name)
 }
 
-// groupIdentifier returns a human-readable identifier for this server group for
-// use in logs. The ordinal is always included (it is guaranteed unique); the
-// optional, non-unique name is appended when set.
-func (s *ServerGroup) groupIdentifier() string {
-	if s.Cfg == nil {
-		return "unknown"
-	}
-	if s.Cfg.Name != "" {
-		return fmt.Sprintf("ord=%d name=%s", s.Cfg.Ordinal, s.Cfg.Name)
-	}
-	return fmt.Sprintf("ord=%d", s.Cfg.Ordinal)
+// Config returns the configuration most recently published by ApplyConfig. It
+// returns nil if ApplyConfig has not (successfully) run yet, so callers must
+// nil-check the result. The returned *Config must be treated as read-only; take
+// a single snapshot per operation instead of calling this repeatedly.
+func (s *ServerGroup) Config() *Config {
+	return s.cfg.Load()
 }
 
-func (s *ServerGroup) logTargetTransition(oldCount, newCount int, initial bool) {
+// httpClient returns the *http.Client most recently published by ApplyConfig,
+// or nil if ApplyConfig has not (successfully) run yet.
+func (s *ServerGroup) httpClient() *http.Client {
+	return s.client.Load()
+}
+
+// groupIdentifier returns a human-readable identifier for this server group for
+// use in logs.
+func (s *ServerGroup) groupIdentifier() string {
+	return configIdentifier(s.Config())
+}
+
+// configIdentifier returns a human-readable identifier for the given server
+// group config for use in logs. The ordinal is always included (it is
+// guaranteed unique); the optional, non-unique name is appended when set.
+func configIdentifier(cfg *Config) string {
+	if cfg == nil {
+		return "unknown"
+	}
+	if cfg.Name != "" {
+		return fmt.Sprintf("ord=%d name=%s", cfg.Ordinal, cfg.Name)
+	}
+	return fmt.Sprintf("ord=%d", cfg.Ordinal)
+}
+
+func (s *ServerGroup) logTargetTransition(cfg *Config, oldCount, newCount int, initial bool) {
 	fields := logrus.Fields{
 		"old_targets": oldCount,
 		"new_targets": newCount,
 	}
-	if s.Cfg != nil {
-		fields["ordinal"] = s.Cfg.Ordinal
-		if s.Cfg.Name != "" {
-			fields["name"] = s.Cfg.Name
+	if cfg != nil {
+		fields["ordinal"] = cfg.Ordinal
+		if cfg.Name != "" {
+			fields["name"] = cfg.Name
 		}
 	}
 
-	ident := s.groupIdentifier()
+	ident := configIdentifier(cfg)
 	switch {
 	case initial && newCount == 0:
 		logrus.WithFields(fields).Warnf("ServerGroup %s started with zero targets; check service discovery configuration and relabel rules", ident)
@@ -182,19 +206,29 @@ func (s *ServerGroup) Cancel() {
 
 // RoundTrip allows us to intercept and mutate downstream HTTP requests at the transport level
 func (s *ServerGroup) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Snapshot the config and client once for this request; ApplyConfig may
+	// swap either one concurrently.
+	cfg := s.Config()
+	client := s.httpClient()
+	if client == nil {
+		return nil, fmt.Errorf("servergroup %s has no client; no configuration applied yet", configIdentifier(cfg))
+	}
+
 	for k, v := range middleware.GetHeaders(r.Context()) {
 		r.Header.Set(k, v)
 	}
-	for k, v := range s.Cfg.HTTPClientHeaders {
-		r.Header.Set(k, v)
-		logrus.Tracef("Set ServerGroup custom header %s: %s", k, v)
+	if cfg != nil {
+		for k, v := range cfg.HTTPClientHeaders {
+			r.Header.Set(k, v)
+			logrus.Tracef("Set ServerGroup custom header %s: %s", k, v)
+		}
 	}
 	// Ensure Body is non-nil so downstream transports (e.g. SigV4) that
 	// unconditionally read the body don't panic on GET requests.
 	if r.Body == nil {
 		r.Body = http.NoBody
 	}
-	return s.client.Transport.RoundTrip(r)
+	return client.Transport.RoundTrip(r)
 }
 
 // Sync updates the targets from our discovery manager
@@ -224,6 +258,13 @@ func (s *ServerGroup) Sync() {
 }
 
 func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgroup.Group) (err error) {
+	// Snapshot the config once for the whole load; ApplyConfig may publish a
+	// new one while we're building clients and we must not straddle two.
+	cfg := s.Config()
+	if cfg == nil {
+		return fmt.Errorf("no configuration applied to servergroup yet")
+	}
+
 	targets := make([]string, 0)
 	apiClients := make([]promclient.API, 0)
 
@@ -255,13 +296,13 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 					}
 				}
 
-				lbls = append(lbls, labels.Label{Name: model.SchemeLabel, Value: string(s.Cfg.Scheme)})
-				lbls = append(lbls, labels.Label{Name: PathPrefixLabel, Value: string(s.Cfg.PathPrefix)})
+				lbls = append(lbls, labels.Label{Name: model.SchemeLabel, Value: string(cfg.Scheme)})
+				lbls = append(lbls, labels.Label{Name: PathPrefixLabel, Value: string(cfg.PathPrefix)})
 
 				lset := labels.New(lbls...)
 
 				logrus.Tracef("Potential target pre-relabel: %v", lset)
-				lset, keep := relabel.Process(lset, s.Cfg.RelabelConfigs...)
+				lset, keep := relabel.Process(lset, cfg.RelabelConfigs...)
 				logrus.Tracef("Potential target post-relabel: %v", lset)
 				// Check if the target was dropped, if so we skip it
 				if !keep || lset.IsEmpty() {
@@ -286,8 +327,8 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 					return err
 				}
 
-				if len(s.Cfg.QueryParams) > 0 {
-					client = promclient.NewClientArgsWrap(client, s.Cfg.QueryParams)
+				if len(cfg.QueryParams) > 0 {
+					client = promclient.NewClientArgsWrap(client, cfg.QueryParams)
 				}
 
 				var apiClient promclient.API
@@ -300,12 +341,12 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 					apiClient = &promclient.DebugAPI{apiClient, u.String()}
 				}
 
-				if s.Cfg.RemoteRead {
-					u.Path = path.Join(u.Path, s.Cfg.RemoteReadPath)
+				if cfg.RemoteRead {
+					u.Path = path.Join(u.Path, cfg.RemoteReadPath)
 					cfg := &remote.ClientConfig{
 						URL:              &config_util.URL{u},
-						HTTPClientConfig: s.Cfg.HTTPConfig.HTTPConfig,
-						SigV4Config:      s.Cfg.HTTPConfig.SigV4Config,
+						HTTPClientConfig: cfg.HTTPConfig.HTTPConfig,
+						SigV4Config:      cfg.HTTPConfig.SigV4Config,
 						Timeout:          model.Duration(time.Minute * 2),
 						ChunkedReadLimit: prom_config.DefaultChunkedReadLimit,
 					}
@@ -318,28 +359,28 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 				}
 
 				// Optionally add time range layers
-				if s.Cfg.AbsoluteTimeRangeConfig != nil {
+				if cfg.AbsoluteTimeRangeConfig != nil {
 					apiClient = &promclient.AbsoluteTimeFilter{
 						API:      apiClient,
-						Start:    s.Cfg.AbsoluteTimeRangeConfig.Start,
-						End:      s.Cfg.AbsoluteTimeRangeConfig.End,
-						Truncate: s.Cfg.AbsoluteTimeRangeConfig.Truncate,
+						Start:    cfg.AbsoluteTimeRangeConfig.Start,
+						End:      cfg.AbsoluteTimeRangeConfig.End,
+						Truncate: cfg.AbsoluteTimeRangeConfig.Truncate,
 					}
 				}
 
-				if s.Cfg.RelativeTimeRangeConfig != nil {
+				if cfg.RelativeTimeRangeConfig != nil {
 					apiClient = &promclient.RelativeTimeFilter{
 						API:      apiClient,
-						Start:    s.Cfg.RelativeTimeRangeConfig.Start,
-						End:      s.Cfg.RelativeTimeRangeConfig.End,
-						Truncate: s.Cfg.RelativeTimeRangeConfig.Truncate,
+						Start:    cfg.RelativeTimeRangeConfig.Start,
+						End:      cfg.RelativeTimeRangeConfig.End,
+						Truncate: cfg.RelativeTimeRangeConfig.Truncate,
 					}
 				}
 
 				// Optionally re-stamp step-aligned query_range results back onto the
 				// requested step grid. Enabled per-server-group for backends (e.g.
 				// Mimir/Cortex) that snap query_range output to the epoch grid; see #787.
-				if s.Cfg.AlignQueryRangeWithStep {
+				if cfg.AlignQueryRangeWithStep {
 					apiClient = &promclient.StepAlignClient{API: apiClient}
 				}
 
@@ -355,7 +396,7 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 				// applied beneath the label-manipulation wrappers below so the matchers
 				// reach the downstream verbatim, without interacting with label_filter's
 				// query filtering or metrics_relabel's matcher reversal.
-				if injectMatchers, err := s.Cfg.GetInjectMatchers(); err != nil {
+				if injectMatchers, err := cfg.GetInjectMatchers(); err != nil {
 					return err
 				} else if len(injectMatchers) > 0 {
 					apiClient, err = promclient.NewInjectMatchersClient(apiClient, injectMatchers)
@@ -365,11 +406,11 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 				}
 
 				// Add labels
-				apiClient = &promclient.AddLabelClient{apiClient, modelLabelSet.Merge(s.Cfg.Labels)}
+				apiClient = &promclient.AddLabelClient{apiClient, modelLabelSet.Merge(cfg.Labels)}
 
 				// Add MetricRelabel if set
-				if len(s.Cfg.MetricsRelabelConfigs) > 0 {
-					tmp, err := promclient.NewMetricsRelabelClient(apiClient, s.Cfg.MetricsRelabelConfigs)
+				if len(cfg.MetricsRelabelConfigs) > 0 {
+					tmp, err := promclient.NewMetricsRelabelClient(apiClient, cfg.MetricsRelabelConfigs)
 					if err != nil {
 						return err
 					}
@@ -378,8 +419,8 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 				}
 
 				// Add LabelFilter if configured
-				if s.Cfg.LabelFilterConfig != nil {
-					apiClient, err = promclient.NewLabelFilterClient(ctx, apiClient, s.Cfg.LabelFilterConfig)
+				if cfg.LabelFilterConfig != nil {
+					apiClient, err = promclient.NewLabelFilterClient(ctx, apiClient, cfg.LabelFilterConfig)
 					if err != nil {
 						return err
 					}
@@ -396,7 +437,7 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 	}
 
 	logrus.Debugf("Updating targets from discovery manager: %v", targets)
-	apiClient, err := promclient.NewMultiAPI(apiClients, s.Cfg.GetAntiAffinity(), s.Cfg.AntiAffinityDynamic, apiClientMetricFunc, 1, s.Cfg.GetPreferMax())
+	apiClient, err := promclient.NewMultiAPI(apiClients, cfg.GetAntiAffinity(), cfg.AntiAffinityDynamic, apiClientMetricFunc, 1, cfg.GetPreferMax())
 	if err != nil {
 		return err
 	}
@@ -404,21 +445,21 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 	newState := &ServerGroupState{
 		Targets: targets,
 		// Add error wrap for this specific servergroup
-		apiClient: &promclient.ErrorWrap{apiClient, fmt.Sprintf("error in servergroup ord=%d", s.Cfg.Ordinal)},
+		apiClient: &promclient.ErrorWrap{apiClient, fmt.Sprintf("error in servergroup ord=%d", cfg.Ordinal)},
 		ctx:       ctx,
 		ctxCancel: ctxCancel,
 	}
 
-	if s.Cfg.IgnoreError {
+	if cfg.IgnoreError {
 		newState.apiClient = &promclient.IgnoreErrorAPI{newState.apiClient}
 	}
 
-	if s.Cfg.DowngradeError {
+	if cfg.DowngradeError {
 		newState.apiClient = &promclient.DowngradeErrorAPI{newState.apiClient}
 	}
 
-	s.logTargetTransition(oldCount, len(targets), !s.loaded)
-	serverGroupTargets.WithLabelValues(strconv.Itoa(s.Cfg.Ordinal), s.Cfg.Name).Set(float64(len(targets)))
+	s.logTargetTransition(cfg, oldCount, len(targets), !s.loaded)
+	serverGroupTargets.WithLabelValues(strconv.Itoa(cfg.Ordinal), cfg.Name).Set(float64(len(targets)))
 
 	s.state.Store(newState) // Store new state
 	if oldState != nil {
@@ -485,10 +526,7 @@ func newDownstreamTransport(cfg *Config) (*http.Transport, error) {
 }
 
 // ApplyConfig applies new configuration to the ServerGroup
-// TODO: move config + client into state object to be swapped with atomics
 func (s *ServerGroup) ApplyConfig(cfg *Config) error {
-	s.Cfg = cfg
-
 	transport, err := newDownstreamTransport(cfg)
 	if err != nil {
 		return err
@@ -526,7 +564,10 @@ func (s *ServerGroup) ApplyConfig(cfg *Config) error {
 		)
 	}
 
-	s.client = &http.Client{Transport: rt}
+	// Publish the client before the config so that any reader which sees the
+	// new config also sees the client that was built from it.
+	s.client.Store(&http.Client{Transport: rt})
+	s.cfg.Store(cfg)
 
 	if err := s.targetManager.ApplyConfig(map[string]discovery.Configs{"foo": cfg.ServiceDiscoveryConfigs}); err != nil {
 		return err

--- a/pkg/servergroup/servergroup_test.go
+++ b/pkg/servergroup/servergroup_test.go
@@ -90,7 +90,7 @@ func TestHTTPClientIntegration(t *testing.T) {
 			}
 
 			// Verify the HTTP client was created
-			if sg.client == nil {
+			if sg.httpClient() == nil {
 				t.Errorf("expected HTTP client to be created")
 				return
 			}
@@ -107,7 +107,7 @@ func TestHTTPClientIntegration(t *testing.T) {
 				// Make the request through the servergroup's RoundTrip method
 				// Note: We can't easily test the actual SigV4 signing without AWS credentials
 				// but we can verify the round tripper chain is set up correctly
-				if sg.client.Transport != nil {
+				if sg.httpClient().Transport != nil {
 					// Just verify the transport exists
 					t.Logf("Transport chain configured successfully")
 				}
@@ -192,12 +192,12 @@ func TestSigV4RoundTripperPresence(t *testing.T) {
 			}
 
 			// Verify the transport chain is configured
-			if sg.client == nil {
+			if sg.httpClient() == nil {
 				t.Errorf("expected HTTP client to be created")
 				return
 			}
 
-			if sg.client.Transport == nil {
+			if sg.httpClient().Transport == nil {
 				t.Errorf("expected HTTP client transport to be configured")
 				return
 			}
@@ -355,13 +355,13 @@ func TestHTTPClientBackwardCompatibility(t *testing.T) {
 			}
 
 			// Verify the HTTP client was created
-			if sg.client == nil {
+			if sg.httpClient() == nil {
 				t.Errorf("expected HTTP client to be created")
 				return
 			}
 
 			// Verify the transport exists
-			if sg.client.Transport == nil {
+			if sg.httpClient().Transport == nil {
 				t.Errorf("expected HTTP client transport to be configured")
 				return
 			}
@@ -437,12 +437,12 @@ func TestSigV4RoundTripperErrorHandling(t *testing.T) {
 			}
 
 			// Verify the transport chain is configured
-			if sg.client == nil {
+			if sg.httpClient() == nil {
 				t.Errorf("expected HTTP client to be created")
 				return
 			}
 
-			if sg.client.Transport == nil {
+			if sg.httpClient().Transport == nil {
 				t.Errorf("expected HTTP client transport to be configured")
 				return
 			}
@@ -564,9 +564,9 @@ static_configs:
 
 			// With no auth configured the base transport is the client's
 			// round-tripper directly -- no wrapping to unwrap.
-			transport, ok := sg.client.Transport.(*http.Transport)
+			transport, ok := sg.httpClient().Transport.(*http.Transport)
 			if !ok {
-				t.Fatalf("expected *http.Transport, got %T", sg.client.Transport)
+				t.Fatalf("expected *http.Transport, got %T", sg.httpClient().Transport)
 			}
 
 			if transport.ForceAttemptHTTP2 != tt.want {

--- a/pkg/servergroup/zero_targets_test.go
+++ b/pkg/servergroup/zero_targets_test.go
@@ -36,7 +36,8 @@ func TestGroupIdentifier(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sg := &ServerGroup{Cfg: tt.cfg}
+			sg := &ServerGroup{}
+			sg.cfg.Store(tt.cfg)
 			if got := sg.groupIdentifier(); got != tt.want {
 				t.Fatalf("groupIdentifier() = %q, want %q", got, tt.want)
 			}
@@ -80,7 +81,7 @@ func TestServerGroupTargetsMetric(t *testing.T) {
 				t.Fatalf("NewServerGroup: %v", err)
 			}
 			defer sg.Cancel()
-			sg.Cfg = &Config{Ordinal: tt.ordinal, Name: tt.groupName, Scheme: "http"}
+			sg.cfg.Store(&Config{Ordinal: tt.ordinal, Name: tt.groupName, Scheme: "http"})
 
 			if err := sg.loadTargetGroupMap(tt.targetGroup); err != nil {
 				t.Fatalf("loadTargetGroupMap: %v", err)


### PR DESCRIPTION
> **Stacked on #822** — base that first; this PR's diff is only the atomics change.

> [!WARNING]
> **Breaking:** the exported field `ServerGroup.Cfg` is replaced by the method `ServerGroup.Config()`. Readers must call `Config()` and nil-check the result; writers must go through `ApplyConfig`. Nothing else in the exported surface changes.

`ApplyConfig` assigned `s.Cfg` and `s.client` with no synchronization, while both were read by `RoundTrip` on every downstream request and by the `Sync` goroutine — which `NewServerGroup` starts *before* `ApplyConfig` ever runs. `loadTargetGroupMap` alone reads ~25 fields off `s.Cfg`. There's no happens-before edge between the write and those reads. The struct carried a `// TODO: lock/atomics on cfg and client` acknowledging it.

### This is latent, not a live race

I checked every `ApplyConfig` call site. `pkg/proxystorage/proxy.go` is the only non-test caller, and each reload builds a fresh `newState.sgs`, calls `NewServerGroup()` per group, then `ApplyConfig` exactly once on that brand-new group, cancelling the old ones. No in-use `ServerGroup` is ever reconfigured in place. Every other caller is a test doing one `ApplyConfig` right after construction.

So there's nothing to fix in today's behaviour — the problem is that nothing *enforces* the single-`ApplyConfig`-per-group invariant, and an exported mutable field invites breaking it. Happy to drop this if you'd rather keep the exported field and just leave the TODO.

### The change

Both fields become `atomic.Pointer`, read through accessors. Readers take a **single snapshot per operation** rather than re-loading per field — `loadTargetGroupMap` could otherwise straddle two configs mid-loop.

`ApplyConfig` publishes the client before the config, so a reader seeing the new config sees the client built from it. Side effect: a transport construction failure no longer leaves a group with a new config and a stale client. `RoundTrip` now returns an error instead of nil-panicking if called before any config is applied.

`httpClient()` stays unexported — nothing outside the package needs it, so the exported surface doesn't grow beyond `Config()`.

Three test files needed mechanical updates for the field removal (assertions unchanged): `zero_targets_test.go` constructs via `sg.cfg.Store`, `servergroup_test.go` uses `httpClient()`, and `histogram_routing_test.go` goes through a helper using the real `NewServerGroup()` + `ApplyConfig()`.

### Testing

`TestApplyConfigConcurrentWithReaders` runs 200 `ApplyConfig` calls against 4 goroutines hammering `RoundTrip` on a real httptest backend, plus the group's own `Sync` loop churning targets (discovery interval dropped to 10ms). Reverting the fields to plain struct members makes it fail under `-race` with two reports — one on the `RoundTrip` path, one on the `Sync`/`loadTargetGroupMap` path.

`go test -race -mod=vendor -tags netgo,builtinassets ./pkg/...` passes, and the concurrency test also passes at `-count=5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
