### PR TITLE
fix: honor the server group timeout on remote_read, and trim metadata deterministically

### DIFF
--- a/pkg/proxystorage/metadata_limit_test.go
+++ b/pkg/proxystorage/metadata_limit_test.go
@@ -1,0 +1,114 @@
+package proxystorage
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+func metadataFixture(names ...string) map[string][]v1.Metadata {
+	m := make(map[string][]v1.Metadata, len(names))
+	for _, n := range names {
+		m[n] = []v1.Metadata{{Type: v1.MetricTypeCounter, Help: n}}
+	}
+	return m
+}
+
+func sortedKeys(m map[string][]v1.Metadata) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestTrimMetadataToLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		limit int
+		want  []string
+	}{
+		{
+			name:  "under the limit is untouched",
+			input: []string{"b", "a"},
+			limit: 5,
+			want:  []string{"a", "b"},
+		},
+		{
+			name:  "exactly at the limit is untouched",
+			input: []string{"b", "a"},
+			limit: 2,
+			want:  []string{"a", "b"},
+		},
+		{
+			name:  "over the limit keeps the lowest names",
+			input: []string{"delta", "alpha", "charlie", "bravo"},
+			limit: 2,
+			want:  []string{"alpha", "bravo"},
+		},
+		{
+			name:  "zero drops everything",
+			input: []string{"a", "b"},
+			limit: 0,
+			want:  []string{},
+		},
+		{
+			name:  "negative is clamped to zero rather than panicking",
+			input: []string{"a", "b"},
+			limit: -1,
+			want:  []string{},
+		},
+		{
+			name:  "empty input is a no-op",
+			input: nil,
+			limit: 3,
+			want:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := metadataFixture(tt.input...)
+
+			trimMetadataToLimit(m, tt.limit)
+
+			if got := sortedKeys(m); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("kept %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTrimMetadataToLimitIsDeterministic is the point of the sort: Go
+// randomizes map iteration order, so a trim that ranged the map directly
+// returned a different subset on each call for the same input.
+func TestTrimMetadataToLimitIsDeterministic(t *testing.T) {
+	names := make([]string, 0, 128)
+	for i := 0; i < 128; i++ {
+		names = append(names, fmt.Sprintf("metric_%03d", i))
+	}
+
+	const limit = 8
+	var first []string
+	for i := 0; i < 100; i++ {
+		m := metadataFixture(names...)
+		trimMetadataToLimit(m, limit)
+
+		got := sortedKeys(m)
+		if len(got) != limit {
+			t.Fatalf("iteration %d: kept %d entries, want %d", i, len(got), limit)
+		}
+		if first == nil {
+			first = got
+			continue
+		}
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("iteration %d: kept %v, first run kept %v", i, got, first)
+		}
+	}
+}

--- a/pkg/proxystorage/proxy.go
+++ b/pkg/proxystorage/proxy.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -269,6 +270,30 @@ func (p *ProxyStorage) ConfigHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// trimMetadataToLimit drops entries from metadata until at most limit remain,
+// keeping the lowest metric names by byte order.
+//
+// The ordering matters: map iteration is randomized, so picking survivors as
+// they come out of the range would leave two identical requests against an
+// unchanged downstream returning different subsets. The API guarantees no
+// particular ordering, but it should at least be reproducible.
+func trimMetadataToLimit(metadata map[string][]v1.Metadata, limit int) {
+	if limit < 0 {
+		limit = 0
+	}
+	if len(metadata) <= limit {
+		return
+	}
+	names := make([]string, 0, len(metadata))
+	for name := range metadata {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names[limit:] {
+		delete(metadata, name)
+	}
+}
+
 // MetadataHandler is an implementation of the metadata handler within the prometheus API
 func (p *ProxyStorage) MetadataHandler(w http.ResponseWriter, r *http.Request) {
 	// Check that "limit" is valid
@@ -287,15 +312,8 @@ func (p *ProxyStorage) MetadataHandler(w http.ResponseWriter, r *http.Request) {
 	metadata, err := state.client.Metadata(r.Context(), r.FormValue("metric"), r.FormValue("limit"))
 
 	// Trim the results to the requested limit
-	if limit != nil && len(metadata) > *limit {
-		count := 0
-		for k := range metadata {
-			if count < *limit {
-				count++
-			} else {
-				delete(metadata, k)
-			}
-		}
+	if limit != nil {
+		trimMetadataToLimit(metadata, *limit)
 	}
 
 	var v map[string]interface{}

--- a/pkg/servergroup/remote_read_timeout_test.go
+++ b/pkg/servergroup/remote_read_timeout_test.go
@@ -1,0 +1,119 @@
+package servergroup
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"gopkg.in/yaml.v2"
+)
+
+func TestRemoteReadTimeoutFromConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{
+			name:    "unset falls back to the default",
+			timeout: 0,
+			want:    DefaultRemoteReadTimeout,
+		},
+		{
+			name:    "a configured timeout is honored",
+			timeout: 30 * time.Second,
+			want:    30 * time.Second,
+		},
+		{
+			name:    "a timeout longer than the default is honored too",
+			timeout: 10 * time.Minute,
+			want:    10 * time.Minute,
+		},
+		{
+			name:    "a negative timeout falls back rather than disabling the bound",
+			timeout: -1 * time.Second,
+			want:    DefaultRemoteReadTimeout,
+		},
+	}
+
+	u, err := url.Parse("http://localhost:9090/api/v1/read")
+	if err != nil {
+		t.Fatalf("parsing url: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Timeout: tt.timeout}
+
+			got := newRemoteReadConfig(cfg, u)
+
+			if time.Duration(got.Timeout) != tt.want {
+				t.Errorf("Timeout = %v, want %v", time.Duration(got.Timeout), tt.want)
+			}
+			if got.URL == nil || got.URL.URL != u {
+				t.Errorf("URL = %v, want %v", got.URL, u)
+			}
+			if got.ChunkedReadLimit == 0 {
+				t.Errorf("expected ChunkedReadLimit to be set")
+			}
+		})
+	}
+}
+
+// TestRemoteReadTimeoutFromYAML checks the server group's timeout reaches the
+// remote_read client config, rather than only the helper honoring it.
+func TestRemoteReadTimeoutFromYAML(t *testing.T) {
+	tests := []struct {
+		name       string
+		yamlConfig string
+		want       time.Duration
+	}{
+		{
+			name: "timeout applies to remote_read",
+			yamlConfig: `
+remote_read: true
+remote_read_path: /api/v1/read
+timeout: 15s
+static_configs:
+  - targets:
+      - localhost:9090
+`,
+			want: 15 * time.Second,
+		},
+		{
+			name: "no timeout keeps the default",
+			yamlConfig: `
+remote_read: true
+remote_read_path: /api/v1/read
+static_configs:
+  - targets:
+      - localhost:9090
+`,
+			want: DefaultRemoteReadTimeout,
+		},
+	}
+
+	u, err := url.Parse("http://localhost:9090/api/v1/read")
+	if err != nil {
+		t.Fatalf("parsing url: %v", err)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Config
+			if err := yaml.Unmarshal([]byte(tt.yamlConfig), &cfg); err != nil {
+				t.Fatalf("unmarshaling config: %v", err)
+			}
+			if !cfg.RemoteRead {
+				t.Fatalf("expected remote_read to be enabled")
+			}
+
+			got := newRemoteReadConfig(&cfg, u)
+
+			if model.Duration(tt.want) != got.Timeout {
+				t.Errorf("Timeout = %v, want %v", time.Duration(got.Timeout), tt.want)
+			}
+		})
+	}
+}

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -66,6 +66,31 @@ func init() {
 	prometheus.MustRegister(serverGroupTargets)
 }
 
+// DefaultRemoteReadTimeout bounds a remote_read request for a server group that
+// sets no explicit timeout.
+const DefaultRemoteReadTimeout = 2 * time.Minute
+
+// newRemoteReadConfig builds the remote_read client config for a server group.
+//
+// Note that remote.ClientConfig.Timeout becomes a deadline on the whole read,
+// while cfg.Timeout bounds only the response headers on the HTTP path (it is
+// wired to Transport.ResponseHeaderTimeout). Reusing the knob here is therefore
+// a stricter bound than it is there, which is deliberate: remote_read carries
+// the largest payloads, so it is the path where a stuck request costs the most.
+func newRemoteReadConfig(cfg *Config, u *url.URL) *remote.ClientConfig {
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = DefaultRemoteReadTimeout
+	}
+	return &remote.ClientConfig{
+		URL:              &config_util.URL{URL: u},
+		HTTPClientConfig: cfg.HTTPConfig.HTTPConfig,
+		SigV4Config:      cfg.HTTPConfig.SigV4Config,
+		Timeout:          model.Duration(timeout),
+		ChunkedReadLimit: prom_config.DefaultChunkedReadLimit,
+	}
+}
+
 // New creates a new servergroup
 func NewServerGroup() (*ServerGroup, error) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
@@ -343,14 +368,7 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 
 				if cfg.RemoteRead {
 					u.Path = path.Join(u.Path, cfg.RemoteReadPath)
-					cfg := &remote.ClientConfig{
-						URL:              &config_util.URL{u},
-						HTTPClientConfig: cfg.HTTPConfig.HTTPConfig,
-						SigV4Config:      cfg.HTTPConfig.SigV4Config,
-						Timeout:          model.Duration(time.Minute * 2),
-						ChunkedReadLimit: prom_config.DefaultChunkedReadLimit,
-					}
-					remoteStorageClient, err := remote.NewReadClient("foo", cfg)
+					remoteStorageClient, err := remote.NewReadClient("foo", newRemoteReadConfig(cfg, u))
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
Two independent fixes from the audit (E4 and M5), both to knobs that did not do what they said. They touch different packages and are easy to review separately.

## remote_read ignored the server group's `timeout`

`remote.ClientConfig` hardcoded a 2m deadline while the HTTP path used `cfg.Timeout`. A group tuned to fail fast on the JSON API would still hang for two minutes on remote_read — the path carrying the largest payloads, and so the one where a stuck request is most expensive.

**This is a behavior change if you already set both `remote_read` and a short `timeout`.** The two timeouts do not mean the same thing:

| | meaning | wired to |
|---|---|---|
| promxy `timeout` | wait for response *headers* | `Transport.ResponseHeaderTimeout` |
| `remote.ClientConfig.Timeout` | deadline over the *entire* read, body included | `context.WithTimeout` |

So reusing the knob is a strictly tighter bound on remote_read than it is on the HTTP path. I think that is clearly better than ignoring it — 2m was a leftover default, not a considered value — but a deployment with a short `timeout` and large remote_read payloads may need to raise it. Unset still means 2m, so the default is unchanged.

If you'd rather not conflate the two, the alternative is to leave remote_read on its own dial and give it a separate config key. Happy to switch.

## `MetadataHandler` trimmed to `limit` non-deterministically

It ranged the map and deleted past a counter. Go randomizes map iteration order, so two identical requests against an unchanged downstream returned different subsets:

```
iteration 0: kept [metric_024 metric_038 metric_041 metric_049 ...]
iteration 1: kept [metric_007 metric_046 metric_071 metric_091 ...]
```

The endpoint guarantees no particular ordering (Prometheus is non-deterministic here too), but it should at least be reproducible, so the survivors are now the lowest metric names by byte order. A negative `limit` previously deleted everything by accident; it is now clamped to zero, which does the same thing on purpose and without an out-of-range slice.

**This does not make the result fully deterministic**, and I did not try to. promxy also forwards the raw `limit` downstream, so each target truncates its own response arbitrarily before the union is trimmed here. Making the whole result well-defined would mean dropping the downstream limit and paying for full metadata dumps from every target — which, given how large those get on a fleet with many metric names, is a separate call and probably yours to make.

## Testing

Both fixes are extracted into helpers (`newRemoteReadConfig`, `trimMetadataToLimit`) so they can be tested without standing up a server group or an HTTP handler, following the `newDownstreamTransport` pattern from #822.

- `TestRemoteReadTimeoutFromConfig` — unset/positive/longer-than-default/negative
- `TestRemoteReadTimeoutFromYAML` — the value reaches the client config from real YAML, not just the helper
- `TestTrimMetadataToLimit` — under/at/over the limit, zero, negative, empty
- `TestTrimMetadataToLimitIsDeterministic` — 100 runs over the same 128-name input agree

Each was checked against a negative control: reverting the fix and confirming the tests fail for the stated reason (2m instead of the configured timeout; differing subsets between runs).

`make fmt`, `make imports`, `make static-check`, and `make test` (`-race -mod=vendor -tags netgo,builtinassets ./...`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
