### PR TITLE
feat(labelfilter): add sync_lookback to bound the dynamic label sync window

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -216,6 +216,23 @@ promxy:
           - job
         # (optional) this will define a re-sync interval for dynamic labels from the downstream
         sync_interval: 5m
+        # (optional) sync_lookback bounds how far back each dynamic label sync
+        # looks on the downstream (it asks for label values over
+        # `now-sync_lookback` to `now` instead of over all time).
+        # The default (unset) is unbounded: every sync asks the downstream for
+        # the values of each dynamic label from the epoch to now. That is correct
+        # regardless of the downstream's retention, but it is also the most
+        # expensive question you can ask -- the downstream has to consult every
+        # block on disk, for every dynamic label, for every target in the
+        # server_group, once per `sync_interval`. For the common `__name__` case
+        # that is the complete set of metric names the downstream has ever held.
+        # Setting this to something comfortably larger than your scrape/staleness
+        # window (e.g. 1h or 24h) bounds that work to the recent blocks.
+        # NOTE: a label value that exists downstream but has had no samples
+        # within the lookback window will be absent from the filter, and queries
+        # matching only that value will be filtered out (not sent downstream) --
+        # so keep this well above the age of data you expect to query here.
+        sync_lookback: 24h
         # This will statically define a filter of labels
         static_labels_include:
           instance:

--- a/pkg/promclient/labelfilter.go
+++ b/pkg/promclient/labelfilter.go
@@ -68,6 +68,25 @@ type LabelFilterConfig struct {
 	DynamicLabels []string `yaml:"dynamic_labels"`
 	// SyncInterval defines how frequenlty to update the dynamic label filter
 	SyncInterval time.Duration `yaml:"sync_interval"`
+	// SyncLookback bounds how far back each dynamic label sync looks on the
+	// downstream; the sync asks for label values over `now-sync_lookback` to
+	// `now` instead of over all time.
+	//
+	// The default (unset/0) is unbounded: every sync asks the downstream for the
+	// values of each dynamic label from the epoch to now. That is correct
+	// regardless of the downstream's retention, but it is also the most
+	// expensive question you can ask -- the downstream has to consult every
+	// block on disk, for every dynamic label, for every target in the
+	// servergroup, once per `sync_interval`. For the common `__name__` case that
+	// is the complete set of metric names the downstream has ever held. Setting
+	// this to something comfortably larger than your scrape/staleness window
+	// (e.g. 1h or 24h) bounds that work to the recent blocks.
+	//
+	// NOTE: a label value that exists downstream but has had no samples within
+	// the lookback window will be absent from the filter, and queries matching
+	// only that value will be filtered out (not sent downstream) -- so keep this
+	// well above the age of data you expect to query from this target.
+	SyncLookback time.Duration `yaml:"sync_lookback"`
 	// StaticLabelsInclude is a set of labels to always add to the downstream filter
 	// this allows you to define some metrics to be included statically if you want to
 	// avoid polling the downstream.
@@ -99,6 +118,14 @@ func (c *LabelFilterConfig) Validate() error {
 
 	if c.SyncInterval > 0 && len(c.DynamicLabels) == 0 {
 		return fmt.Errorf("sync_interval requires `dynamic_labels_include` to be set")
+	}
+
+	if c.SyncLookback < 0 {
+		return fmt.Errorf("sync_lookback must not be negative")
+	}
+
+	if c.SyncLookback > 0 && len(c.DynamicLabels) == 0 {
+		return fmt.Errorf("sync_lookback requires `dynamic_labels` to be set")
 	}
 
 	switch c.OnSyncError {
@@ -223,10 +250,18 @@ func (c *LabelFilterClient) LabelFilter() map[string]map[string]struct{} {
 func (c *LabelFilterClient) Sync(ctx context.Context) error {
 	filter := make(map[string]map[string]struct{})
 
+	end := model.Now().Time()
+	// An unset sync_lookback means "all of time"; the epoch is as far back as a
+	// model.Time can express, so it stands in for an unbounded start.
+	start := model.Time(0).Time()
+	if c.cfg.SyncLookback > 0 {
+		start = end.Add(-c.cfg.SyncLookback)
+	}
+
 	for _, label := range c.cfg.DynamicLabels {
 		labelFilter := make(map[string]struct{})
 		// TODO: warn?
-		vals, _, err := c.LabelValues(ctx, label, nil, model.Time(0).Time(), model.Now().Time())
+		vals, _, err := c.LabelValues(ctx, label, nil, start, end)
 		if err != nil {
 			return err
 		}

--- a/pkg/promclient/labelfilter_test.go
+++ b/pkg/promclient/labelfilter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
+	"gopkg.in/yaml.v2"
 )
 
 func newCountAPI(a API) *countAPI {
@@ -682,4 +684,124 @@ func BenchmarkFilterLabelMatchers(b *testing.B) {
 			})
 		}
 	}
+}
+
+// syncRangeAPI records the time range that the label_filter sync asks the
+// downstream for.
+type syncRangeAPI struct {
+	*stubAPI
+
+	mu     sync.Mutex
+	starts []time.Time
+	ends   []time.Time
+}
+
+func (s *syncRangeAPI) LabelValues(ctx context.Context, label string, matchers []string, startTime, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	s.mu.Lock()
+	s.starts = append(s.starts, startTime)
+	s.ends = append(s.ends, endTime)
+	s.mu.Unlock()
+	return model.LabelValues{"knownmetric"}, nil, nil
+}
+
+func (s *syncRangeAPI) lastRange(t *testing.T) (time.Time, time.Time) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.starts) == 0 {
+		t.Fatal("downstream LabelValues was never called")
+	}
+	return s.starts[len(s.starts)-1], s.ends[len(s.ends)-1]
+}
+
+func TestLabelFilterSyncLookback(t *testing.T) {
+	// Unset sync_lookback keeps the historical unbounded (epoch) start.
+	t.Run("unset", func(t *testing.T) {
+		api := &syncRangeAPI{stubAPI: &stubAPI{}}
+		cfg := &LabelFilterConfig{DynamicLabels: []string{"__name__"}}
+		if err := cfg.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewLabelFilterClient(context.Background(), api, cfg); err != nil {
+			t.Fatal(err)
+		}
+
+		start, _ := api.lastRange(t)
+		if want := model.Time(0).Time(); !start.Equal(want) {
+			t.Fatalf("expected unbounded (epoch) start with no sync_lookback, want=%v got=%v", want, start)
+		}
+	})
+
+	// A configured sync_lookback bounds the start to now-lookback.
+	t.Run("set", func(t *testing.T) {
+		const lookback = time.Hour
+
+		api := &syncRangeAPI{stubAPI: &stubAPI{}}
+		cfg := &LabelFilterConfig{DynamicLabels: []string{"__name__"}, SyncLookback: lookback}
+		if err := cfg.Validate(); err != nil {
+			t.Fatal(err)
+		}
+
+		before := time.Now()
+		if _, err := NewLabelFilterClient(context.Background(), api, cfg); err != nil {
+			t.Fatal(err)
+		}
+		after := time.Now()
+
+		start, end := api.lastRange(t)
+		// The sync uses model.Now(), which is millisecond-truncated, so give the
+		// bounds a millisecond of slack on either side.
+		slack := time.Millisecond
+		if start.Before(before.Add(-lookback - slack)) {
+			t.Fatalf("start=%v is further back than now-%v", start, lookback)
+		}
+		if start.After(after.Add(-lookback + slack)) {
+			t.Fatalf("start=%v is not as far back as now-%v", start, lookback)
+		}
+		if got := end.Sub(start); got < lookback-slack || got > lookback+slack {
+			t.Fatalf("expected a %v window, got %v (start=%v end=%v)", lookback, got, start, end)
+		}
+	})
+}
+
+func TestLabelFilterConfigSyncLookbackYAML(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		cfg := &LabelFilterConfig{}
+		in := "dynamic_labels:\n  - __name__\nsync_lookback: 24h\n"
+		if err := yaml.Unmarshal([]byte(in), cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.SyncLookback != 24*time.Hour {
+			t.Fatalf("expected sync_lookback=24h, got %v", cfg.SyncLookback)
+		}
+	})
+
+	t.Run("unset", func(t *testing.T) {
+		cfg := &LabelFilterConfig{}
+		if err := yaml.Unmarshal([]byte("dynamic_labels:\n  - __name__\n"), cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.SyncLookback != 0 {
+			t.Fatalf("expected sync_lookback to default to 0 (unbounded), got %v", cfg.SyncLookback)
+		}
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		cfg := &LabelFilterConfig{}
+		in := "dynamic_labels:\n  - __name__\nsync_lookback: -1h\n"
+		err := yaml.Unmarshal([]byte(in), cfg)
+		if err == nil {
+			t.Fatal("expected a negative sync_lookback to be rejected")
+		}
+		if !strings.Contains(err.Error(), "sync_lookback must not be negative") {
+			t.Fatalf("expected the validation error for a negative sync_lookback, got: %v", err)
+		}
+	})
+
+	t.Run("without_dynamic_labels", func(t *testing.T) {
+		cfg := &LabelFilterConfig{}
+		if err := yaml.Unmarshal([]byte("sync_lookback: 1h\n"), cfg); err == nil {
+			t.Fatal("expected sync_lookback without dynamic_labels to be rejected")
+		}
+	})
 }


### PR DESCRIPTION
## The problem

`(*LabelFilterClient).Sync` asks the downstream for the values of each dynamic label over the entire time domain:

```go
vals, _, err := c.LabelValues(ctx, label, nil, model.Time(0).Time(), model.Now().Time())
```

No matchers, epoch to now — once per dynamic label, per target, per `sync_interval`. An unbounded start forces the downstream to consult every block on disk. For the documented `__name__` case that is the complete set of metric names the downstream has ever held, re-enumerated forever. A servergroup with N targets and L dynamic labels on a 5m `sync_interval` asks that question `N*L` times every 5 minutes.

## The change

Adds a `sync_lookback` duration to `label_filter`. When set, the sync asks for `now-sync_lookback` → `now` instead of epoch → now, which scopes the work to the recent blocks.

```yaml
label_filter:
  dynamic_labels:
    - __name__
  sync_interval: 5m
  sync_lookback: 24h
```

Validation rejects a negative value, and (mirroring `sync_interval`) rejects the knob without `dynamic_labels`. Also hoists the `now` used by the sync out of the per-label loop so every label in one sync shares a single time range.

## Why the default is still unbounded

Unset/`0` means unbounded, which is exactly today's behavior. I deliberately did **not** pick a bounded default:

promxy cannot know the downstream's retention. If the window is narrower than the age of data a user queries, a label value whose samples all fall outside the window silently drops out of the filter — and the filter then makes promxy *skip* a servergroup that should have been queried. That is a silent wrong-results failure (missing series, no error), which is strictly worse than the sync cost it would save. The cost is at least visible in `promxy_label_filter_sync_duration_seconds` and on the downstream; the wrong answer is not.

So the tradeoff is documented on the config field and in `cmd/promxy/config.yaml`, and left as an operator decision.

## Tests

`TestLabelFilterSyncLookback` (unset ⇒ epoch start unchanged; set ⇒ start bounded to `now-lookback` with the expected window width) and `TestLabelFilterConfigSyncLookbackYAML` (round-trips `24h` through YAML; unset stays 0; negative and missing-`dynamic_labels` are rejected).

Negative control — reverting just the bounding in `Sync` and re-running:

```
=== RUN   TestLabelFilterSyncLookback/set
    labelfilter_test.go:756: start=1969-12-31 16:00:00 -0800 PST is further back than now-1h0m0s
--- FAIL: TestLabelFilterSyncLookback/set (0.00s)
```

Full gate run locally and green: `make fmt` + `git diff --exit-code`, `make imports` + `git diff --exit-code`, `make static-check`, `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
