### PR TITLE
fix(promapi): reject a vector entry with no value or histogram

### DIFF
--- a/pkg/promapi/decode.go
+++ b/pkg/promapi/decode.go
@@ -248,6 +248,12 @@ func decodeVector(iter *jsoniter.Iterator) []storage.Series {
 				iter.Skip()
 			}
 		}
+		// A nil sample would only fail once the series is iterated -- far from
+		// the response that produced it -- so reject the body here instead.
+		if sample == nil {
+			iter.ReportError("decodeVector", `result entry has neither a "value" nor a "histogram"`)
+			return nil
+		}
 		b.Sort()
 		out = append(out, NewSeries(b.Labels(), []chunks.Sample{sample}))
 	}

--- a/pkg/promapi/decode_test.go
+++ b/pkg/promapi/decode_test.go
@@ -254,3 +254,74 @@ func BenchmarkDecodeModelValueStdlib(b *testing.B) {
 		}
 	}
 }
+
+// TestDecodeVectorMissingSample covers vector entries carrying neither a
+// "value" nor a "histogram". Such an entry must surface as a decode error: the
+// series it would otherwise produce holds a nil chunks.Sample, which panics the
+// moment anything iterates it.
+func TestDecodeVectorMissingSample(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "only_metric",
+			body: `{"status":"success","data":{"resultType":"vector","result":[` +
+				`{"metric":{"__name__":"foo"}}]}}`,
+		},
+		{
+			name: "null_entry",
+			body: `{"status":"success","data":{"resultType":"vector","result":[null]}}`,
+		},
+		{
+			name: "matrix_shaped_entry",
+			body: `{"status":"success","data":{"resultType":"vector","result":[` +
+				`{"metric":{"__name__":"foo"},"values":[[100.000,"1"]]}]}}`,
+		},
+		{
+			// The whole response is rejected rather than silently truncated to
+			// the entries that happened to be well-formed.
+			name: "one_bad_entry_among_good",
+			body: `{"status":"success","data":{"resultType":"vector","result":[` +
+				`{"metric":{"__name__":"up","job":"a"},"value":[100.000,"1"]},` +
+				`{"metric":{"__name__":"up","job":"b"}}]}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := DecodeSeriesSet([]byte(tc.body))
+			n, samples := 0, 0
+			for ss.Next() {
+				n++
+				// Iterating is what panics on a nil sample.
+				it := ss.At().Iterator(nil)
+				for it.Next() != chunkenc.ValNone {
+					samples++
+				}
+			}
+			if n != 0 || samples != 0 {
+				t.Errorf("expected no series from a malformed response, got %d series / %d samples", n, samples)
+			}
+			if ss.Err() == nil {
+				t.Fatal("expected a decode error, got nil")
+			}
+			if !strings.Contains(ss.Err().Error(), `neither a "value" nor a "histogram"`) {
+				t.Fatalf("error does not name the missing fields: %v", ss.Err())
+			}
+		})
+	}
+}
+
+// TestDecodeMatrixMissingSamples pins the matrix counterpart: an entry with
+// neither "values" nor "histograms" yields a sample-less series rather than an
+// error. No nil sample is ever built there, and a caller can tell an empty
+// series from real data -- which is also what prometheus/common's
+// model.SampleStream decoding produces for the same body.
+func TestDecodeMatrixMissingSamples(t *testing.T) {
+	body := `{"status":"success","data":{"resultType":"matrix","result":[` +
+		`{"metric":{"__name__":"foo"}}]}}`
+	got := dumpSeriesSet(t, DecodeSeriesSet([]byte(body)))
+	if len(got) != 1 || got[`{__name__="foo"}`] != "" {
+		t.Fatalf("expected one sample-less series, got %v", got)
+	}
+}


### PR DESCRIPTION
> **Stacks on #816** (`fix/promapi-timestamp-precision`) — it rewrites `decodeVector` in the same function, so this is based on that branch and should merge after it. The diff below is this PR's commit only.

## The bug

`decodeVector` builds each vector entry's sample from either the `value` or the `histogram` key. A result object that carries neither leaves `sample` nil, and `[]chunks.Sample{nil}` is appended anyway:

```go
var sample chunks.Sample
for k := iter.ReadObject(); k != ""; k = iter.ReadObject() { ... }
b.Sort()
out = append(out, NewSeries(b.Labels(), []chunks.Sample{sample}))
```

Nothing fails at decode time. `DecodeSeriesSet` hands back a `SeriesSet` with a nil `Err()` and one series whose only sample is nil; the nil dereference fires later, in `storage.(*listSeriesIterator).Next`, when the PromQL engine iterates it. The engine's `recover` converts that into an opaque `unexpected error: ...` 500 plus a full stack-trace log — not a crash, but not a decode error naming the bad field either.

A `null` array entry (`"result":[null]`) reaches the same place: jsoniter's `ReadObject` consumes the null and returns `""` immediately, so no key is ever seen.

## The fix

Report through `iter.ReportError` — the pattern the other decode failures in this file already use — and return no series, so a nil sample cannot escape the decoder even if a future caller ignores `iter.Error`.

**Error, not skip.** A vector truncated to its well-formed entries is indistinguishable from a genuinely smaller result, and promxy would merge that partial answer with other server groups' data. A body that violates the schema should surface as an error, not as quietly-wrong data.

## Upstream parity

`prometheus/common`'s `model.Sample.UnmarshalJSON` accepts the same body and produces a sample of **value 0 at timestamp 0** (verified: `[{"metric":{"__name__":"foo"}}]` → `err=<nil>, foo => 0 @[0]`). It neither errors nor skips — it fabricates a data point. This PR deliberately diverges: for a body no conformant API (Prometheus, VictoriaMetrics, Mimir, Thanos) should ever send, a surfaced error beats invented data. The divergence is only in the malformed case; every well-formed body decodes identically.

## Other decode paths

- **`decodeMatrix`** — not affected. An entry with neither `values` nor `histograms` yields a sample-less series; no nil ever enters the slice, iterating it is safe, and a caller can tell it from real data. This matches what `model.SampleStream` decoding gives for the same body, so it is left as-is and pinned by a test.
- **`scalar`** — not affected. It always constructs a `floatSample`, and malformed input (`result:[]`, `result:{}`) already surfaces through the iterator's error.
- **`decodeHistogramPair`** returning a nil `*FloatHistogram` also reports through the iterator, so those series are already discarded by `DecodeSeriesSet`.

## Verification

New `TestDecodeVectorMissingSample` (4 cases: entry with only `metric`, `null` entry, a matrix-shaped entry inside a vector, and one bad entry among good ones) iterates every returned series' samples — the step that panics on a nil sample — and asserts zero series plus an error naming the missing fields. `TestDecodeMatrixMissingSamples` pins the matrix behavior.

Negative control, with the fix reverted:

```
--- FAIL: TestDecodeVectorMissingSample/only_metric
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 ...]
  github.com/prometheus/prometheus/storage.(*listSeriesIterator).Next
    vendor/github.com/prometheus/prometheus/storage/series.go:146
  github.com/jacksontj/promxy/pkg/promapi.TestDecodeVectorMissingSample.func1
    pkg/promapi/decode_test.go:298
```

Fix restored, full gate green: `make fmt` / `make imports` clean (`gofmt -l -s`, `goimports -l` both empty), `make static-check` clean, `make test` (`-race`, all packages) passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
