### PR TITLE
refactor(promhttputil)!: drop the dead MergeValues merge path

### DIFF
--- a/pkg/promclient/merge_seriesset_test.go
+++ b/pkg/promclient/merge_seriesset_test.go
@@ -3,6 +3,7 @@ package promclient
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -78,11 +79,36 @@ func stream(name string, pts ...float64) *model.SampleStream {
 	return ss
 }
 
-// TestMergeSeriesSetsMatchesMergeValues asserts the SeriesSet adapter produces
-// the same merged result as the existing model.Value MergeValues, across the
-// anti-affinity behaviours (overlap, holes, base-by-point-count, preferMax,
-// disjoint series).
-func TestMergeSeriesSetsMatchesMergeValues(t *testing.T) {
+// mergeMatrix is the model.Matrix-side reference merge: group streams by
+// fingerprint and hand each collision to promhttputil.MergeSampleStream --
+// the same primitive MergeSeriesSets folds with, reached without any of the
+// SeriesSet plumbing.
+func mergeMatrix(antiAffinity model.Time, dynamic bool, a, b model.Matrix, preferMax bool) model.Matrix {
+	merged := make(model.Matrix, 0, len(a)+len(b))
+	index := make(map[model.Fingerprint]int, len(a)+len(b))
+
+	for _, stream := range slices.Concat(a, b) {
+		finger := stream.Metric.Fingerprint()
+		if i, ok := index[finger]; ok {
+			// The only error MergeSampleStream returns is a fingerprint
+			// mismatch, which the index makes impossible here.
+			merged[i], _ = promhttputil.MergeSampleStream(antiAffinity, dynamic, merged[i], stream, preferMax)
+			continue
+		}
+		merged = append(merged, stream)
+		index[finger] = len(merged) - 1
+	}
+
+	return merged
+}
+
+// TestMergeSeriesSetsMatchesMatrixMerge asserts the SeriesSet adapter produces
+// the same merged result as folding the equivalent model.Matrix through
+// MergeSampleStream directly, across the anti-affinity behaviours (overlap,
+// holes, base-by-point-count, preferMax, disjoint series). What it pins is the
+// SeriesSet plumbing -- conversion, grouping, iteration -- since both sides
+// share the merge primitive itself.
+func TestMergeSeriesSetsMatchesMatrixMerge(t *testing.T) {
 	cases := []struct {
 		name         string
 		antiAffinity model.Time
@@ -118,11 +144,7 @@ func TestMergeSeriesSetsMatchesMergeValues(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			want, err := promhttputil.MergeValues(tc.antiAffinity, false, tc.a, tc.b, tc.preferMax)
-			if err != nil {
-				t.Fatalf("MergeValues: %v", err)
-			}
-			wantDump := dumpMatrix(want.(model.Matrix))
+			wantDump := dumpMatrix(mergeMatrix(tc.antiAffinity, false, tc.a, tc.b, tc.preferMax))
 
 			got := MergeSeriesSets(tc.antiAffinity, false, tc.preferMax, matrixToSeriesSet(tc.a), matrixToSeriesSet(tc.b))
 			gotDump := dumpSS(t, got)
@@ -230,8 +252,8 @@ func TestMaterializeSeriesSetDecouplesFromSource(t *testing.T) {
 // TestMergeSeriesSetsDynamic_FixesMixedScrapeIntervals proves the dynamic
 // anti-affinity flag (#734) actually takes effect through the live SeriesSet
 // merge path — MergeSeriesSets -> mergeAntiAffinity -> MergeSampleStream — and
-// not just the legacy model.Value MergeValues path the promhttputil tests
-// cover. Mirrors promhttputil.TestMergeValues_FixesMixedScrapeIntervals.
+// not just the model.Matrix fold the promhttputil tests cover. Mirrors
+// promhttputil.TestMergeMatrix_FixesMixedScrapeIntervals.
 func TestMergeSeriesSetsDynamic_FixesMixedScrapeIntervals(t *testing.T) {
 	// Two 60s-scrape sides of the same series; b is offset so its samples
 	// land inside a's 60s gaps but outside a tight static buffer — exactly

--- a/pkg/promhttputil/merge.go
+++ b/pkg/promhttputil/merge.go
@@ -3,7 +3,6 @@ package promhttputil
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -105,122 +104,6 @@ func ValueAddLabelSet(a model.Value, l model.LabelSet) error {
 
 	return nil
 
-}
-
-// MergeValues merges values `a` and `b` with the given antiAffinityBuffer.
-// When dynamic is true, each merged SampleStream infers its own anti-
-// affinity from the inter-sample spacing of the longer series and uses
-// antiAffinityBuffer only as a fallback when there isn't enough data to
-// estimate. See #734.
-func MergeValues(antiAffinityBuffer model.Time, dynamic bool, a, b model.Value, preferMax bool) (model.Value, error) {
-	if a == nil {
-		return b, nil
-	}
-	if b == nil {
-		return a, nil
-	}
-	if a.Type() != b.Type() {
-		return nil, fmt.Errorf("mismatch type %v!=%v", a.Type(), b.Type())
-	}
-
-	switch aTyped := a.(type) {
-	// TODO: more logic? for now we assume both are correct if they exist
-	// In the case where it is a single datapoint, we're going to assume that
-	// either is valid, we just need one
-	case *model.Scalar:
-		bTyped := b.(*model.Scalar)
-
-		if preferMax && bTyped.Value > aTyped.Value && bTyped.Timestamp != 0 {
-			return bTyped, nil
-		}
-
-		if aTyped.Value != 0 && aTyped.Timestamp != 0 {
-			return aTyped, nil
-		}
-		return bTyped, nil
-
-	// In the case where it is a single datapoint, we're going to assume that
-	// either is valid, we just need one
-	case *model.String:
-		bTyped := b.(*model.String)
-
-		if aTyped.Value != "" && aTyped.Timestamp != 0 {
-			return aTyped, nil
-		}
-		return bTyped, nil
-
-	// List of *model.Sample -- only 1 value (guaranteed same timestamp)
-	case model.Vector:
-		bTyped := b.(model.Vector)
-
-		newValue := make(model.Vector, 0, len(aTyped)+len(bTyped))
-		fingerPrintMap := make(map[model.Fingerprint]int)
-
-		addItem := func(item *model.Sample) {
-			finger := item.Metric.Fingerprint()
-
-			// If we've seen this fingerPrint before, lets make sure that a value exists
-			if index, ok := fingerPrintMap[finger]; ok {
-				existing := newValue[index]
-				// If either side carries a histogram (Value/Histogram are
-				// mutually exclusive on a Sample), keep the first non-empty
-				// observation. preferMax only applies to float-vs-float.
-				if existing.Histogram != nil || item.Histogram != nil {
-					if existing.Histogram == nil && existing.Value == 0 && item.Histogram != nil {
-						newValue[index] = item
-					}
-					return
-				}
-				// Only replace if we have no value (which seems reasonable)
-				// Or we prefer max value and there is a bigger value
-				if existing.Value == model.SampleValue(0) || preferMax && existing.Value < item.Value {
-					newValue[index].Value = item.Value
-				}
-			} else {
-				newValue = append(newValue, item)
-				fingerPrintMap[finger] = len(newValue) - 1
-			}
-		}
-
-		for _, item := range aTyped {
-			addItem(item)
-		}
-
-		for _, item := range bTyped {
-			addItem(item)
-		}
-		return newValue, nil
-
-	case model.Matrix:
-		bTyped := b.(model.Matrix)
-
-		newValue := make(model.Matrix, 0, len(aTyped)+len(bTyped))
-		fingerPrintMap := make(map[model.Fingerprint]int)
-
-		addStream := func(stream *model.SampleStream) {
-			finger := stream.Metric.Fingerprint()
-
-			// If we've seen this fingerPrint before, lets make sure that a value exists
-			if index, ok := fingerPrintMap[finger]; ok {
-				// TODO: check this error? For now the only one is sig collision, which we check
-				newValue[index], _ = MergeSampleStream(antiAffinityBuffer, dynamic, newValue[index], stream, preferMax)
-			} else {
-				newValue = append(newValue, stream)
-				fingerPrintMap[finger] = len(newValue) - 1
-			}
-		}
-
-		for _, item := range aTyped {
-			addStream(item)
-		}
-
-		for _, item := range bTyped {
-			addStream(item)
-		}
-		return newValue, nil
-	}
-
-	return nil, fmt.Errorf("unknown type! %v", reflect.TypeOf(a))
 }
 
 // MergeSampleStream merges SampleStreams `a` and `b` with the given

--- a/pkg/promhttputil/merge_dynamic_test.go
+++ b/pkg/promhttputil/merge_dynamic_test.go
@@ -69,13 +69,13 @@ func TestDynamicAntiAffinity(t *testing.T) {
 	}
 }
 
-// TestMergeValues_FixesMixedScrapeIntervals reproduces the case in
+// TestMergeMatrix_FixesMixedScrapeIntervals reproduces the case in
 // jacksontj/promxy#734: with a single static anti-affinity, low-frequency
 // series get gap-filled with samples from the other downstream because their
 // natural gap exceeds 2×buffer. count_over_time on the merged result then
 // reports too many samples. With dynamic mode on, each series picks its own
 // buffer and no gap-fill happens.
-func TestMergeValues_FixesMixedScrapeIntervals(t *testing.T) {
+func TestMergeMatrix_FixesMixedScrapeIntervals(t *testing.T) {
 	// 60s-scrape series: a has samples at 0, 60s, 120s. b has 60s-scrape
 	// samples too, offset enough that they fall OUTSIDE the static
 	// buffer of a's samples but INSIDE the gap between consecutive a
@@ -109,11 +109,7 @@ func TestMergeValues_FixesMixedScrapeIntervals(t *testing.T) {
 	// each gap gets filled with the corresponding b sample. Result: a's
 	// samples plus b's samples interleaved. count_over_time over this
 	// would double. This is the bug from #734.
-	staticRes, err := MergeValues(staticBuffer, false, a, b, false)
-	if err != nil {
-		t.Fatalf("static MergeValues: %v", err)
-	}
-	staticMatrix := staticRes.(model.Matrix)
+	staticMatrix := mergeMatrix(staticBuffer, false, a, b, false)
 	if got := len(staticMatrix[0].Values); got != 6 {
 		t.Fatalf("static merge sanity check: expected 6 samples (the bug), got %d", got)
 	}
@@ -122,11 +118,7 @@ func TestMergeValues_FixesMixedScrapeIntervals(t *testing.T) {
 	// is the gap-fill threshold. The 60s gaps no longer trigger fill
 	// (they're at the threshold, not above it). Result: a's 3 samples,
 	// no spurious fills.
-	dynamicRes, err := MergeValues(staticBuffer, true, a, b, false)
-	if err != nil {
-		t.Fatalf("dynamic MergeValues: %v", err)
-	}
-	dynamicMatrix := dynamicRes.(model.Matrix)
+	dynamicMatrix := mergeMatrix(staticBuffer, true, a, b, false)
 	gotTimes := make([]int64, 0, len(dynamicMatrix[0].Values))
 	for _, p := range dynamicMatrix[0].Values {
 		gotTimes = append(gotTimes, int64(p.Timestamp))
@@ -137,10 +129,10 @@ func TestMergeValues_FixesMixedScrapeIntervals(t *testing.T) {
 	}
 }
 
-// TestMergeValues_FallbackWithFewSamples covers the safety net: when
+// TestMergeMatrix_FallbackWithFewSamples covers the safety net: when
 // a series has too few samples to estimate, the configured static buffer is
 // used unchanged, so existing behavior is preserved for short queries.
-func TestMergeValues_FallbackWithFewSamples(t *testing.T) {
+func TestMergeMatrix_FallbackWithFewSamples(t *testing.T) {
 	a := model.Matrix{
 		{
 			Metric: model.Metric{model.MetricNameLabel: "x"},
@@ -164,23 +156,19 @@ func TestMergeValues_FallbackWithFewSamples(t *testing.T) {
 	}
 
 	for _, dyn := range []bool{false, true} {
-		got, err := MergeValues(model.Time(15_000), dyn, a, b, false)
-		if err != nil {
-			t.Fatalf("dyn=%v: MergeValues: %v", dyn, err)
-		}
-		mat := got.(model.Matrix)
+		mat := mergeMatrix(model.Time(15_000), dyn, a, b, false)
 		if n := len(mat[0].Values); n != 2 {
 			t.Fatalf("dyn=%v: want 2 samples, got %d", dyn, n)
 		}
 	}
 }
 
-// TestMergeValues_PerSeriesBuffer makes sure two series in one
+// TestMergeMatrix_PerSeriesBuffer makes sure two series in one
 // matrix with different scrape intervals each get their own dynamically-
 // inferred buffer. A 60s-scrape series and a 10s-scrape series share the
 // same merge call, and we want neither to be touched by the other's
 // buffer choice.
-func TestMergeValues_PerSeriesBuffer(t *testing.T) {
+func TestMergeMatrix_PerSeriesBuffer(t *testing.T) {
 	slow := model.Metric{model.MetricNameLabel: "slow"}
 	fast := model.Metric{model.MetricNameLabel: "fast"}
 
@@ -209,11 +197,7 @@ func TestMergeValues_PerSeriesBuffer(t *testing.T) {
 
 	staticBuffer := model.Time(15_000) // 15s — wrong for both, illustrative
 
-	got, err := MergeValues(staticBuffer, true, a, b, false)
-	if err != nil {
-		t.Fatalf("MergeValues: %v", err)
-	}
-	matrix := got.(model.Matrix)
+	matrix := mergeMatrix(staticBuffer, true, a, b, false)
 	if len(matrix) != 2 {
 		t.Fatalf("want 2 series, got %d", len(matrix))
 	}
@@ -241,12 +225,12 @@ func TestMergeValues_PerSeriesBuffer(t *testing.T) {
 	}
 }
 
-// TestMergeValues_NarrowerThanStatic exercises the direction the
+// TestMergeMatrix_NarrowerThanStatic exercises the direction the
 // other tests don't: a fast (10s) scrape with a wide configured buffer.
 // The static buffer's gap-fill threshold is wide enough to suppress a
 // genuine missed-scrape fill from b; the dynamic estimate is tight
 // enough to splice it in.
-func TestMergeValues_NarrowerThanStatic(t *testing.T) {
+func TestMergeMatrix_NarrowerThanStatic(t *testing.T) {
 	// 10s scrape on a, with a single missed scrape between t=20 and
 	// t=40 (gap = 20s instead of 10s).
 	a := model.Matrix{
@@ -275,33 +259,27 @@ func TestMergeValues_NarrowerThanStatic(t *testing.T) {
 	// well under that, so b's filler never triggers — count_over_time
 	// undercounts.
 	staticBuffer := model.Time(30_000)
-	sv, err := MergeValues(staticBuffer, false, a, b, false)
-	if err != nil {
-		t.Fatalf("static MergeValues: %v", err)
-	}
-	if got := len(sv.(model.Matrix)[0].Values); got != 5 {
+	sv := mergeMatrix(staticBuffer, false, a, b, false)
+	if got := len(sv[0].Values); got != 5 {
 		t.Fatalf("static sanity: expected 5 (no fill), got %d", got)
 	}
 
 	// Dynamic: median gap 10s → buffer 5s. Gap-fill threshold 10s; a's
 	// 20s gap exceeds it, so b's filler at t=30 splices in.
-	dv, err := MergeValues(staticBuffer, true, a, b, false)
-	if err != nil {
-		t.Fatalf("dynamic MergeValues: %v", err)
-	}
-	if got := len(dv.(model.Matrix)[0].Values); got != 6 {
+	dv := mergeMatrix(staticBuffer, true, a, b, false)
+	if got := len(dv[0].Values); got != 6 {
 		t.Fatalf("dynamic should have spliced b's filler, got %d (want 6)", got)
 	}
 }
 
-// TestMergeValues_PreferMax confirms preferMax merge logic and
+// TestMergeMatrix_PreferMax confirms preferMax merge logic and
 // dynamic buffer inference are independent — turning dynamic on with
 // preferMax=true should still pick the larger value when a/b overlap.
 //
 // Note: the merge code unconditionally appends a's first sample without
 // running the preferMax check (line "if len(newValues) == 0"), so we only
 // assert the property on samples 2..N.
-func TestMergeValues_PreferMax(t *testing.T) {
+func TestMergeMatrix_PreferMax(t *testing.T) {
 	a := model.Matrix{{
 		Metric: model.Metric{model.MetricNameLabel: "x"},
 		Values: []model.SamplePair{
@@ -316,11 +294,7 @@ func TestMergeValues_PreferMax(t *testing.T) {
 		},
 	}}
 
-	got, err := MergeValues(model.Time(15_000), true, a, b, true)
-	if err != nil {
-		t.Fatalf("MergeValues: %v", err)
-	}
-	mat := got.(model.Matrix)
+	mat := mergeMatrix(model.Time(15_000), true, a, b, true)
 	if len(mat[0].Values) != 3 {
 		t.Fatalf("want 3 samples, got %d", len(mat[0].Values))
 	}
@@ -331,11 +305,11 @@ func TestMergeValues_PreferMax(t *testing.T) {
 	}
 }
 
-// TestMergeValues_MismatchedScrapeIntervals: a is scraped at 60s,
+// TestMergeMatrix_MismatchedScrapeIntervals: a is scraped at 60s,
 // b at 30s. The estimator anchors on the longer side (b, since after
 // the swap-for-longer-base it becomes a) and should pick b's interval.
 // Behavior we want: no spurious gap-fill, no double-counting.
-func TestMergeValues_MismatchedScrapeIntervals(t *testing.T) {
+func TestMergeMatrix_MismatchedScrapeIntervals(t *testing.T) {
 	a := model.Matrix{{
 		Metric: model.Metric{model.MetricNameLabel: "x"},
 		Values: []model.SamplePair{
@@ -350,11 +324,7 @@ func TestMergeValues_MismatchedScrapeIntervals(t *testing.T) {
 		},
 	}}
 
-	got, err := MergeValues(model.Time(15_000), true, a, b, false)
-	if err != nil {
-		t.Fatalf("MergeValues: %v", err)
-	}
-	mat := got.(model.Matrix)
+	mat := mergeMatrix(model.Time(15_000), true, a, b, false)
 	// b is the longer side → becomes the base. Median gap is 30s,
 	// buffer = 15s. a's samples fall within b's buffer so they all
 	// dedupe; result is just b's 5 samples.
@@ -363,11 +333,11 @@ func TestMergeValues_MismatchedScrapeIntervals(t *testing.T) {
 	}
 }
 
-// TestMergeValues_Histograms confirms the same dynamic estimate
+// TestMergeMatrix_Histograms confirms the same dynamic estimate
 // is applied to histogram merges, not just floats. Without this the
 // histogram-only series would still hit the original bug under mixed
 // scrape intervals.
-func TestMergeValues_Histograms(t *testing.T) {
+func TestMergeMatrix_Histograms(t *testing.T) {
 	mkH := func(ts model.Time, v float64) model.SampleHistogramPair {
 		return model.SampleHistogramPair{
 			Timestamp: ts,
@@ -391,14 +361,14 @@ func TestMergeValues_Histograms(t *testing.T) {
 	staticBuffer := model.Time(15_000) // wrong for 60s scrape
 
 	// Static: buggy fill, ends up with 6 histograms.
-	staticRes, _ := MergeValues(staticBuffer, false, a, b, false)
-	if got := len(staticRes.(model.Matrix)[0].Histograms); got != 6 {
+	staticRes := mergeMatrix(staticBuffer, false, a, b, false)
+	if got := len(staticRes[0].Histograms); got != 6 {
 		t.Fatalf("static sanity: expected 6 histograms (the bug), got %d", got)
 	}
 
 	// Dynamic: estimate from histogram timestamps directly, no fill.
-	dynRes, _ := MergeValues(staticBuffer, true, a, b, false)
-	if got := len(dynRes.(model.Matrix)[0].Histograms); got != 3 {
+	dynRes := mergeMatrix(staticBuffer, true, a, b, false)
+	if got := len(dynRes[0].Histograms); got != 3 {
 		t.Fatalf("dynamic histograms: want 3, got %d", got)
 	}
 }

--- a/pkg/promhttputil/merge_test.go
+++ b/pkg/promhttputil/merge_test.go
@@ -2,217 +2,43 @@ package promhttputil
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/prometheus/common/model"
 )
 
-/*
-   ValNone ValueType = iota
-   ValScalar
-   ValVector
-   ValMatrix
-   ValString
+// mergeMatrix folds two matrices into one the way the HA merge does: group
+// the streams by fingerprint and hand each collision to MergeSampleStream.
+// Streams that appear on only one side are carried through untouched.
+func mergeMatrix(antiAffinityBuffer model.Time, dynamic bool, a, b model.Matrix, preferMax bool) model.Matrix {
+	merged := make(model.Matrix, 0, len(a)+len(b))
+	index := make(map[model.Fingerprint]int, len(a)+len(b))
 
-*/
-// Merge 2 values and
-func TestMergeValues(t *testing.T) {
+	for _, stream := range slices.Concat(a, b) {
+		finger := stream.Metric.Fingerprint()
+		if i, ok := index[finger]; ok {
+			// The only error MergeSampleStream returns is a fingerprint
+			// mismatch, which the index makes impossible here.
+			merged[i], _ = MergeSampleStream(antiAffinityBuffer, dynamic, merged[i], stream, preferMax)
+			continue
+		}
+		merged = append(merged, stream)
+		index[finger] = len(merged) - 1
+	}
+
+	return merged
+}
+
+func TestMergeMatrix(t *testing.T) {
 	tests := []struct {
 		name         string
-		a            model.Value
-		b            model.Value
-		r            model.Value
+		a            model.Matrix
+		b            model.Matrix
+		r            model.Matrix
 		antiAffinity model.Time
 		preferMax    bool
-		err          error
 	}{
-		//
-		// edge-cases
-		{
-			name: "nils",
-			a:    nil,
-			b:    nil,
-			r:    nil,
-		},
-
-		{
-			name: "bnil",
-			a:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-			b:    nil,
-			r:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-		},
-
-		{
-			name: "anil",
-			a:    nil,
-			b:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-			r:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-		},
-
-		//
-		// Scalar tests
-		{
-			name: "scalar dedupe",
-			a:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-			b:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-			r:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-		},
-
-		// Fill missing
-		{
-			name: "scalar fill missing",
-			a:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-			b:    &model.Scalar{},
-			r:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-		},
-
-		// Fill missing
-		{
-			name: "scalar fill missing",
-			a:    &model.Scalar{},
-			b:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-			r:    &model.Scalar{model.SampleValue(10), model.Time(100)},
-		},
-
-		//
-		// String tests
-		{
-			name: "String dedupe",
-			a:    &model.String{"a", model.Time(100)},
-			b:    &model.String{"a", model.Time(100)},
-			r:    &model.String{"a", model.Time(100)},
-		},
-
-		// Fill missing
-		{
-			name: "string fill missing",
-			a:    &model.String{"a", model.Time(100)},
-			b:    &model.String{"", model.Time(100)},
-			r:    &model.String{"a", model.Time(100)},
-		},
-
-		// Fill missing
-		{
-			name: "string fill missing",
-			a:    &model.String{"", model.Time(100)},
-			b:    &model.String{"a", model.Time(100)},
-			r:    &model.String{"a", model.Time(100)},
-		},
-
-		//
-		// Vector tests
-		{
-			name: "Vector dedupe",
-			a: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("hosta")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-			b: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("hosta")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-			r: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("hosta")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-		},
-
-		{
-			name: "Vector dedupe multiseries",
-			a: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("metrica")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("metricb")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-			b: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("metrica")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-			r: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("metrica")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("metricb")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-		},
-
-		// Fill missing
-		{
-			name: "Vector fill missing1",
-			a: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("hosta")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-			b: model.Vector([]*model.Sample{}),
-			r: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("hosta")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-		},
-
-		// Fill missing
-		{
-			name: "Vector fill missing2",
-			a:    model.Vector([]*model.Sample{}),
-			b: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("hosta")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-			r: model.Vector([]*model.Sample{
-				{
-					model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("hosta")}),
-					model.SampleValue(10),
-					model.Time(100),
-					nil,
-				},
-			}),
-		},
-
 		//
 		// Matrix tests
 		{
@@ -1136,10 +962,7 @@ func TestMergeValues(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := MergeValues(test.antiAffinity, false, test.a, test.b, test.preferMax)
-			if err != test.err {
-				t.Fatalf("mismatch err in %s expected=%v actual=%v", test.name, test.err, err)
-			}
+			result := mergeMatrix(test.antiAffinity, false, test.a, test.b, test.preferMax)
 			if !reflect.DeepEqual(result, test.r) {
 				t.Fatalf("mismatch in %s \nexpected=%v\nactual=%v", test.name, test.r, result)
 			}
@@ -1162,7 +985,7 @@ func hist(t int64, tag float64) model.SampleHistogramPair {
 	}
 }
 
-func TestMergeValuesHistograms(t *testing.T) {
+func TestMergeMatrixHistograms(t *testing.T) {
 	metric := model.Metric(model.LabelSet{model.MetricNameLabel: model.LabelValue("hosta")})
 
 	tests := []struct {
@@ -1242,10 +1065,7 @@ func TestMergeValuesHistograms(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := MergeValues(test.antiAffinity, false, test.a, test.b, false)
-			if err != nil {
-				t.Fatalf("unexpected err: %v", err)
-			}
+			result := mergeMatrix(test.antiAffinity, false, test.a, test.b, false)
 			if !reflect.DeepEqual(result, test.r) {
 				t.Fatalf("mismatch in %s\nexpected=%v\nactual=%v", test.name, test.r, result)
 			}


### PR DESCRIPTION
`promhttputil.MergeValues` has had no non-test caller since the `storage.SeriesSet` refactor. Instant and range results are converted with `ModelValueToSeriesSet` and merged by `promclient.MergeSeriesSets`, which folds through `MergeSampleStream` directly. `MergeValues` was reached only from tests, so it was carrying its own dead scalar/string/vector merge policy — plus a latent aliasing bug: the `model.Vector` branch stored the caller's `*model.Sample` into the result and then mutated its `Value` in place, which would corrupt the input matrix of whichever downstream happened to be merged second. Deleting the function removes the bug with it.

`MergeSampleStream` — the part that is still live — is untouched and keeps all of its coverage.

## What happened to the tests

The two suites that drove `MergeSampleStream` *through* `MergeValues` now drive it through a small local `mergeMatrix` helper: group streams by fingerprint, fold collisions through `MergeSampleStream`. That is exactly what the deleted `Matrix` branch did.

- `pkg/promhttputil`: `TestMergeValues` → `TestMergeMatrix`, `TestMergeValuesHistograms` → `TestMergeMatrixHistograms`, `TestMergeValues_*` → `TestMergeMatrix_*`. Every Matrix case is preserved verbatim.
- `pkg/promclient`: the differential oracle `TestMergeSeriesSetsMatchesMergeValues` → `TestMergeSeriesSetsMatchesMatrixMerge`, same table, same assertions. It is unchanged in substance: both sides of that comparison always shared `MergeSampleStream` (`MergeValues`' Matrix branch called it, and so does `MergeSeriesSets`), so what the oracle actually pins is the SeriesSet plumbing — conversion, grouping, iteration — not the merge primitive. Swapping the reference side from `MergeValues` to the equivalent fold keeps that check intact.

## Coverage that is deliberately retired

The table cases for the nil / scalar / string / vector branches of `MergeValues` (~165 lines). Those exercised merge policy promxy no longer has anywhere: nothing merges `model.Value` any more, and instant-vector results now go through `ModelValueToSeriesSet` and are merged as single-sample series by the SeriesSet path. Keeping them would have meant keeping the dead branches alive in a `_test.go` file purely to have something to test.

## Breaking change

Marked `!`: `promhttputil.MergeValues` is exported, so this breaks anyone importing promxy as a library and calling it. The replacement for a `model.Matrix` merge is a fingerprint-keyed fold over `promhttputil.MergeSampleStream`, or `promclient.MergeSeriesSets` on the SeriesSet side.

## Verification

Full CI gate, all clean: `make fmt` + `git diff --exit-code`, `make imports` + `git diff --exit-code`, `make static-check`, `make test` (`-race`, `netgo,builtinassets`, `./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4