### PR TITLE
fix(proxyquerier): honor sortSeries in Select

### DIFF
--- a/pkg/promclient/merge_seriesset.go
+++ b/pkg/promclient/merge_seriesset.go
@@ -152,10 +152,13 @@ func mergeAntiAffinity(antiAffinity model.Time, dynamic bool, preferMax bool) st
 	}
 }
 
-// sortedSeriesSet materializes ss and returns it sorted by labels, which
-// storage.NewMergeSeriesSet requires of its inputs. Warnings and errors are
-// preserved.
-func sortedSeriesSet(ss storage.SeriesSet) storage.SeriesSet {
+// SortSeriesSet materializes ss and returns it sorted by labels, which is what
+// storage.NewMergeSeriesSet requires of its inputs and what a
+// Querier.Select(sortSeries=true) must return. Only the series handles are
+// collected -- samples stay behind their iterators -- so the cost is a slice of
+// pointers plus the sort. Warnings and errors are preserved; both are read
+// after draining, when they are final.
+func SortSeriesSet(ss storage.SeriesSet) storage.SeriesSet {
 	var series []storage.Series
 	for ss.Next() {
 		series = append(series, ss.At())
@@ -179,7 +182,7 @@ func MergeSeriesSets(antiAffinity model.Time, dynamic bool, preferMax bool, sets
 	}
 	sorted := make([]storage.SeriesSet, len(sets))
 	for i, s := range sets {
-		sorted[i] = sortedSeriesSet(s)
+		sorted[i] = SortSeriesSet(s)
 	}
 	// limit 0 = unlimited; the merge func applies anti-affinity to same-labeled
 	// series across the sets.

--- a/pkg/proxyquerier/chunk_querier.go
+++ b/pkg/proxyquerier/chunk_querier.go
@@ -2,7 +2,6 @@ package proxyquerier
 
 import (
 	"context"
-	"sort"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
@@ -25,21 +24,7 @@ type ProxyChunkQuerier struct {
 
 // Select fetches the matching series as samples and re-encodes them as chunks.
 // The remote-read streaming API requires series to be sorted by label set, so
-// the result is always sorted here (ProxyQuerier.Select does not guarantee an
-// order); the sortSeries hint is therefore honored unconditionally.
-func (h *ProxyChunkQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
-	ss := h.ProxyQuerier.Select(ctx, sortSeries, hints, matchers...)
-
-	// ProxyQuerier already materializes the full result, so collecting and
-	// sorting here adds no extra round-trips.
-	var series []storage.Series
-	for ss.Next() {
-		series = append(series, ss.At())
-	}
-	sort.Slice(series, func(i, j int) bool {
-		return labels.Compare(series[i].Labels(), series[j].Labels()) < 0
-	})
-
-	// ss.Err()/ss.Warnings() are only final once iteration is drained above.
-	return storage.NewSeriesSetToChunkSet(NewSeriesSet(series, ss.Warnings(), ss.Err()))
+// the sort is requested unconditionally regardless of the caller's hint.
+func (h *ProxyChunkQuerier) Select(ctx context.Context, _ bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.ChunkSeriesSet {
+	return storage.NewSeriesSetToChunkSet(h.ProxyQuerier.Select(ctx, true, hints, matchers...))
 }

--- a/pkg/proxyquerier/querier.go
+++ b/pkg/proxyquerier/querier.go
@@ -2,6 +2,7 @@ package proxyquerier
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -25,8 +26,17 @@ type ProxyQuerier struct {
 }
 
 // Select returns a set of series that matches the given label matchers.
-// TODO: switch based on sortSeries bool(first arg)
-func (h *ProxyQuerier) Select(ctx context.Context, _ bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+//
+// When sortSeries is set the result is ordered by labels.Compare, as the
+// storage.Querier contract requires: callers such as the /federate and
+// /api/v1/series handlers feed several Select results into
+// storage.NewMergeSeriesSet, whose k-way merge silently emits duplicate series
+// if an input is out of order. Nothing below guarantees that order on its own
+// -- the downstream's ordering is only meaningful in terms of the labels it
+// sent, and promxy rewrites those (server-group labels, metric_relabel_configs)
+// after the fact. When sortSeries is unset (the promql engine's path) the
+// result is passed through untouched.
+func (h *ProxyQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	start := time.Now()
 	defer func() {
 		logrus.WithFields(logrus.Fields{
@@ -61,12 +71,21 @@ func (h *ProxyQuerier) Select(ctx context.Context, _ bool, hints *storage.Select
 			lb.Sort()
 			series[j] = storage.NewListSeries(lb.Labels(), nil)
 		}
+		if sortSeries {
+			sort.Slice(series, func(i, j int) bool {
+				return labels.Compare(series[i].Labels(), series[j].Labels()) < 0
+			})
+		}
 		return NewSeriesSet(series, warnings, nil)
 	}
 
 	// Data path: the client already returns a storage.SeriesSet, decoded
 	// straight from the downstream response (no model.Value round-trip).
-	return h.Client.GetValue(ctx, timestamp.Time(hints.Start), timestamp.Time(hints.End), matchers)
+	ss := h.Client.GetValue(ctx, timestamp.Time(hints.Start), timestamp.Time(hints.End), matchers)
+	if sortSeries {
+		ss = promclient.SortSeriesSet(ss)
+	}
+	return ss
 }
 
 // LabelValues returns all potential values for a label name.

--- a/pkg/proxyquerier/querier_test.go
+++ b/pkg/proxyquerier/querier_test.go
@@ -1,0 +1,237 @@
+package proxyquerier
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+
+	proxyconfig "github.com/jacksontj/promxy/pkg/config"
+	"github.com/jacksontj/promxy/pkg/promclient"
+)
+
+func mustSelector(t *testing.T, s string) []*labels.Matcher {
+	t.Helper()
+	m, err := parser.ParseMetricSelector(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return m
+}
+
+func drainSeries(t *testing.T, ss storage.SeriesSet) []labels.Labels {
+	t.Helper()
+	var out []labels.Labels
+	for ss.Next() {
+		out = append(out, ss.At().Labels())
+	}
+	if err := ss.Err(); err != nil {
+		t.Fatalf("series set error: %v", err)
+	}
+	return out
+}
+
+func drainLabels(t *testing.T, ss storage.SeriesSet) []string {
+	t.Helper()
+	var out []string
+	for _, l := range drainSeries(t, ss) {
+		out = append(out, l.String())
+	}
+	return out
+}
+
+// newTestQuerier stands up a real downstream Prometheus API server over the
+// given promql test data and wraps it in the same client stack a single-target
+// server group builds: AddLabelClient (server-group labels) over a MultiAPI.
+func newTestQuerier(t *testing.T, data string, sgLabels model.LabelSet) *ProxyQuerier {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "data.test")
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatalf("write test data: %v", err)
+	}
+	api, closeFn, err := promclient.CreateTestServer(t, path)
+	if closeFn != nil {
+		t.Cleanup(closeFn)
+	}
+	if err != nil {
+		t.Fatalf("create test server: %v", err)
+	}
+
+	multi, err := promclient.NewMultiAPI(
+		[]promclient.API{&promclient.AddLabelClient{API: api, Labels: sgLabels}},
+		0, false, nil, 1, false,
+	)
+	if err != nil {
+		t.Fatalf("new multi api: %v", err)
+	}
+
+	return &ProxyQuerier{
+		Start:  timestamp.Time(selectStart).UTC(),
+		End:    timestamp.Time(selectEnd).UTC(),
+		Client: multi,
+		Cfg:    &proxyconfig.PromxyConfig{},
+	}
+}
+
+const (
+	selectStart = int64(60000)
+	selectEnd   = int64(120000)
+)
+
+// A single-target server group whose labels collide with a downstream label
+// reorders the downstream's (correctly sorted) result: overwriting job="a"/
+// job="b" with job="sg" turns `up{job="a",pod="x"} < up{job="b"}` into
+// `up{job="sg",pod="x"} > up{job="sg"}`. Nothing below Select re-sorts in that
+// configuration -- MergeSeriesSets passes a lone set straight through -- so
+// Select is the only place the sortSeries contract can be honored.
+const collidingLabelData = `load 1m
+  up{job="a",pod="x"} 1 1 1
+  up{job="b"} 2 2 2
+`
+
+// TestSelectHonorsSortSeries asserts Select(sortSeries=true) returns series in
+// labels.Compare order even when the client stack has reordered the
+// downstream's result, and that Select(sortSeries=false) passes the result
+// through untouched.
+func TestSelectHonorsSortSeries(t *testing.T) {
+	q := newTestQuerier(t, collidingLabelData, model.LabelSet{"job": "sg"})
+	hints := &storage.SelectHints{Start: selectStart, End: selectEnd}
+	sel := mustSelector(t, `{__name__="up"}`)
+
+	unsorted := drainLabels(t, q.Select(context.Background(), false, hints, sel...))
+	want := []string{`{__name__="up", job="sg", pod="x"}`, `{__name__="up", job="sg"}`}
+	if len(unsorted) != len(want) || unsorted[0] != want[0] || unsorted[1] != want[1] {
+		t.Fatalf("sortSeries=false should pass the client's order through\n got: %v\nwant: %v", unsorted, want)
+	}
+
+	sorted := drainSeries(t, q.Select(context.Background(), true, hints, sel...))
+	for i := 1; i < len(sorted); i++ {
+		if labels.Compare(sorted[i-1], sorted[i]) >= 0 {
+			t.Fatalf("sortSeries=true returned unsorted series: %v", sorted)
+		}
+	}
+	if len(sorted) != len(unsorted) {
+		t.Fatalf("sorting changed the series count: got %v want %v", sorted, unsorted)
+	}
+}
+
+// TestSelectSortedFeedsMergeSeriesSet drives the pattern the /federate and
+// /api/v1/series handlers use -- one Select per match[], all fed to
+// storage.NewMergeSeriesSet -- and asserts no series is emitted twice. That
+// k-way merge assumes each input is sorted and silently duplicates series when
+// one is not.
+func TestSelectSortedFeedsMergeSeriesSet(t *testing.T) {
+	q := newTestQuerier(t, collidingLabelData, model.LabelSet{"job": "sg"})
+	hints := &storage.SelectHints{Start: selectStart, End: selectEnd}
+
+	// The second selector matches only the lexically-smaller of the two series,
+	// so the merge's cursor advances past the first set's out-of-order head.
+	sets := []storage.SeriesSet{
+		q.Select(context.Background(), true, hints, mustSelector(t, `{__name__="up"}`)...),
+		q.Select(context.Background(), true, hints, mustSelector(t, `{__name__="up",pod=""}`)...),
+	}
+
+	got := drainLabels(t, storage.NewMergeSeriesSet(sets, 0, storage.ChainedSeriesMerge))
+	seen := make(map[string]int, len(got))
+	for _, l := range got {
+		seen[l]++
+	}
+	for l, n := range seen {
+		if n > 1 {
+			t.Fatalf("series %s emitted %d times by the merge: %v", l, n, got)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 distinct series, got %v", got)
+	}
+}
+
+// countingSeriesSet reports how many times it was advanced, so a test can tell
+// whether a wrapper drained it.
+type countingSeriesSet struct {
+	series []storage.Series
+	idx    int
+	nexts  int
+}
+
+func (s *countingSeriesSet) Next() bool {
+	s.nexts++
+	if s.idx >= len(s.series) {
+		return false
+	}
+	s.idx++
+	return true
+}
+func (s *countingSeriesSet) At() storage.Series                { return s.series[s.idx-1] }
+func (s *countingSeriesSet) Err() error                        { return nil }
+func (s *countingSeriesSet) Warnings() annotations.Annotations { return nil }
+
+// stubAPI serves a fixed SeriesSet from GetValue. The embedded nil API panics
+// on any other call, which is what we want: nothing else should be reached.
+type stubAPI struct {
+	promclient.API
+	ss        storage.SeriesSet
+	labelsets []model.LabelSet
+}
+
+func (s *stubAPI) GetValue(_ context.Context, _, _ time.Time, _ []*labels.Matcher) storage.SeriesSet {
+	return s.ss
+}
+
+func (s *stubAPI) Series(_ context.Context, _ []string, _, _ time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	return s.labelsets, nil, nil
+}
+
+// TestSelectSeriesMetadataHonorsSortSeries covers the metadata branch of Select
+// (hints.Func == "series"), which builds series from Client.Series. MultiAPI
+// concatenates the per-target label sets, so the result arrives in target order.
+func TestSelectSeriesMetadataHonorsSortSeries(t *testing.T) {
+	q := &ProxyQuerier{
+		Client: &stubAPI{labelsets: []model.LabelSet{
+			{"__name__": "up", "pod": "x"},
+			{"__name__": "up"},
+		}},
+		Cfg: &proxyconfig.PromxyConfig{},
+	}
+	hints := &storage.SelectHints{Func: "series"}
+	sel := mustSelector(t, `{__name__="up"}`)
+
+	got := drainLabels(t, q.Select(context.Background(), true, hints, sel...))
+	want := []string{`{__name__="up"}`, `{__name__="up", pod="x"}`}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("sortSeries=true on the metadata path\n got: %v\nwant: %v", got, want)
+	}
+
+	if got := drainLabels(t, q.Select(context.Background(), false, hints, sel...)); got[0] != want[1] {
+		t.Fatalf("sortSeries=false should pass the client's order through: %v", got)
+	}
+}
+
+// TestSelectUnsortedDoesNotDrain pins the promql engine's hot path: it calls
+// Select with sortSeries=false and the result must be handed back without being
+// materialized, so a streaming client stays streaming.
+func TestSelectUnsortedDoesNotDrain(t *testing.T) {
+	src := &countingSeriesSet{series: []storage.Series{
+		storage.NewListSeries(labels.FromStrings("__name__", "up", "pod", "x"), nil),
+		storage.NewListSeries(labels.FromStrings("__name__", "up"), nil),
+	}}
+	q := &ProxyQuerier{Client: &stubAPI{ss: src}, Cfg: &proxyconfig.PromxyConfig{}}
+
+	ss := q.Select(context.Background(), false, &storage.SelectHints{Start: selectStart, End: selectEnd})
+	if src.nexts != 0 {
+		t.Fatalf("Select(sortSeries=false) advanced the source %d times; it must not materialize", src.nexts)
+	}
+	if got := drainLabels(t, ss); len(got) != 2 || got[0] != `{__name__="up", pod="x"}` {
+		t.Fatalf("Select(sortSeries=false) altered the result: %v", got)
+	}
+}


### PR DESCRIPTION
`ProxyQuerier.Select` ignored its `sortSeries` argument (there was a `// TODO: switch based on sortSeries bool(first arg)` where the handling should have been) and returned whatever order the fan-out produced.

Callers that pass `sortSeries=true` feed several `Select` results into `storage.NewMergeSeriesSet` — `/federate` and the vendored `/api/v1/series` handler both do, one `Select` per `match[]` — and that k-way merge assumes each input is ordered by `labels.Compare`. Given an out-of-order input it doesn't error; it emits **duplicate series**.

## Why the order wasn't already there

`MergeSeriesSets` sorts its inputs, but only when it has more than one set to merge; a single server group with a single target returns the set straight from the JSON decode.

And the downstream's ordering is only meaningful in terms of the labels the *downstream* sent — promxy rewrites those afterwards. `AddLabelClient` applies server-group labels with `labels.Builder.Set`, which overwrites, so a server group whose labels collide with a downstream label reorders a perfectly sorted result:

```
server group labels: {job: sg}

downstream (correctly sorted):   up{job="a",pod="x"}   up{job="b"}
after AddLabelClient:            up{job="sg",pod="x"}  up{job="sg"}   <- now reversed
```

`metric_relabel_configs` gets there by a second route, since `relabel.Process` can rename labels arbitrarily.

## Reproduction

End-to-end against a real Prometheus API server (the promqltest-backed `promclient.CreateTestServer`), through `AddLabelClient` → `MultiAPI` → `ProxyQuerier` → the federate handler with two `match[]` selectors. Before the fix:

```
# TYPE up untyped
up{job="sg",instance=""} 2 120000
up{job="sg",pod="x",instance=""} 1 120000
up{job="sg",instance=""} 2 120000      <- duplicate
```

A Prometheus scraping that endpoint rejects the payload as a duplicate sample for the timestamp.

## The fix

`Select` sorts when the caller asks, and passes the set through untouched when it doesn't.

- The promql engine's path (`Select(ctx, false, ...)`, `promql/engine.go:1025`) is unchanged and still streams. A test pins it: `Select` must not advance the underlying set when `sortSeries` is unset.
- `MergeSeriesSets` keeps its `len(sets) == 1` fast path for the same reason — sorting there would add a full materialization to every hot-path query.
- The metadata branch (`hints.Func == "series"`) is sorted too; `MultiAPI.Series` concatenates the per-target label sets, so it arrives in target order.
- `promclient.sortedSeriesSet` is exported as `SortSeriesSet` for reuse, and `ProxyChunkQuerier.Select` drops its own copy of the same sort in favor of asking `ProxyQuerier` for one.

## Tests

New `pkg/proxyquerier/querier_test.go`:

| test | asserts |
| --- | --- |
| `TestSelectHonorsSortSeries` | real stack; `sortSeries=true` returns `labels.Compare` order, `false` passes the client's order through |
| `TestSelectSortedFeedsMergeSeriesSet` | the `/federate` + `/api/v1/series` pattern emits no series twice |
| `TestSelectSeriesMetadataHonorsSortSeries` | same contract on the `hints.Func == "series"` branch |
| `TestSelectUnsortedDoesNotDrain` | `Select(ctx, false, …)` gains no sort and no materialization |

Negative control — with the data-path sort removed:

```
--- FAIL: TestSelectHonorsSortSeries
    sortSeries=true returned unsorted series: [{__name__="up", job="sg", pod="x"} {__name__="up", job="sg"}]
--- FAIL: TestSelectSortedFeedsMergeSeriesSet
    series {__name__="up", job="sg"} emitted 2 times by the merge:
      [{__name__="up", job="sg"} {__name__="up", job="sg", pod="x"} {__name__="up", job="sg"}]
--- PASS: TestSelectUnsortedDoesNotDrain
```

and with the metadata-path sort removed:

```
--- FAIL: TestSelectSeriesMetadataHonorsSortSeries
     got: [{__name__="up", pod="x"} {__name__="up"}]
    want: [{__name__="up"} {__name__="up", pod="x"}]
```

`make fmt`, `make imports`, `make static-check` and `make test` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
