### PR TITLE
perf(servergroup): refresh histogram metadata from one target per HA key

### DIFF
--- a/cmd/promxy/config.yaml
+++ b/cmd/promxy/config.yaml
@@ -87,6 +87,9 @@ promxy:
         # queries which touch histogram metrics WITHOUT invoking one of
         # the histogram-only functions (e.g. rate(my_hist[5m])) are also
         # routed via remote_read. When unset, detection is pure AST.
+        # Each refresh pulls a full metadata dump from *one* target of
+        # this group (not from every replica); that is still a large
+        # response in a big deployment, so keep the interval in minutes.
         metadata_refresh: 5m
         # allow_lossy controls behavior when a histogram-bearing query
         # hits this group with no remote_read configured. Default false:

--- a/pkg/promclient/multi_api.go
+++ b/pkg/promclient/multi_api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -119,6 +120,10 @@ type MultiAPI struct {
 	metricFunc          MultiAPIMetricFunc
 	requiredCount       int // number "per key" that we require to respond
 	preferMax           bool
+
+	// metadataRotation advances on every MetadataOnePerKey call so that
+	// consecutive calls start from a different member of each HA key.
+	metadataRotation atomic.Uint64
 }
 
 func (m *MultiAPI) recordMetric(i int, api, status string, took float64) {
@@ -700,4 +705,70 @@ func SortExemplars(exemplars []v1.Exemplar) {
 		}
 		return a.Labels.String() < b.Labels.String()
 	})
+}
+
+// MetadataOnePerKey returns metadata about metrics currently scraped, fetching
+// from a single API per HA key instead of fanning out to all of them.
+//
+// APIs sharing a Key() fingerprint are HA replicas of one another -- the same
+// grouping requiredCount is enforced over -- so any one of them can answer for
+// the whole group. Members of a group are tried in turn, starting at a rotating
+// offset so successive calls spread across replicas, until one answers; a group
+// with no reachable member fails the call. APIs that expose no Key() all share
+// the zero fingerprint and are therefore treated as a single group.
+//
+// Merging across groups is first-writer-wins per metric name, in group order,
+// matching Metadata.
+func (m *MultiAPI) MetadataOnePerKey(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	// Group API indexes by HA key, keeping first-seen order so the merge below
+	// is deterministic in the API ordering.
+	keyOrder := make([]model.Fingerprint, 0, len(m.apis))
+	groups := make(map[model.Fingerprint][]int, len(m.apis))
+	for i, fp := range m.apiFingerprints {
+		if _, ok := groups[fp]; !ok {
+			keyOrder = append(keyOrder, fp)
+		}
+		groups[fp] = append(groups[fp], i)
+	}
+
+	rotation := int(m.metadataRotation.Add(1) - 1)
+
+	var result map[string][]v1.Metadata
+	for _, fp := range keyOrder {
+		members := groups[fp]
+		var (
+			md       map[string][]v1.Metadata
+			lastErr  error
+			answered bool
+		)
+		for n := 0; n < len(members); n++ {
+			i := members[(rotation+n)%len(members)]
+			start := time.Now()
+			v, err := m.apis[i].Metadata(ctx, metric, limit)
+			took := time.Since(start)
+			if err != nil {
+				m.recordMetric(i, "metadata", "error", took.Seconds())
+				lastErr = NormalizePromError(err)
+				continue
+			}
+			m.recordMetric(i, "metadata", "success", took.Seconds())
+			md, answered = v, true
+			break
+		}
+		if !answered {
+			return nil, errors.Wrap(lastErr, "Unable to fetch metadata from downstream servers")
+		}
+
+		if result == nil {
+			result = md
+		} else {
+			for k, vv := range md {
+				if _, ok := result[k]; !ok {
+					result[k] = vv
+				}
+			}
+		}
+	}
+
+	return result, nil
 }

--- a/pkg/promclient/multi_api_metadata_test.go
+++ b/pkg/promclient/multi_api_metadata_test.go
@@ -1,0 +1,157 @@
+package promclient
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// metadataCountAPI records how many Metadata calls it served, so tests can pin
+// how many downstreams a fetch actually touches. Metadata is the only method
+// implemented; the embedded (nil) API satisfies the rest of the interface.
+type metadataCountAPI struct {
+	API
+
+	name  string // metric name this "target" reports metadata for
+	err   error  // when set, every Metadata call fails with it
+	calls atomic.Int64
+}
+
+func (a *metadataCountAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	a.calls.Add(1)
+	if a.err != nil {
+		return nil, a.err
+	}
+	return map[string][]v1.Metadata{
+		a.name: {{Type: v1.MetricTypeHistogram, Help: "help"}},
+	}, nil
+}
+
+// newMetadataTargets builds n targets sharing a single HA key. AddLabelClient
+// is what exposes Key(), so it has to be the outermost wrapper for the targets
+// to be grouped by anything other than the zero fingerprint.
+func newMetadataTargets(n int, key model.LabelSet) ([]*metadataCountAPI, []API) {
+	stubs := make([]*metadataCountAPI, n)
+	apis := make([]API, n)
+	for i := 0; i < n; i++ {
+		stubs[i] = &metadataCountAPI{name: fmt.Sprintf("metric_%d", i)}
+		apis[i] = &AddLabelClient{stubs[i], key}
+	}
+	return stubs, apis
+}
+
+func totalCalls(stubs ...[]*metadataCountAPI) int64 {
+	var total int64
+	for _, group := range stubs {
+		for _, s := range group {
+			total += s.calls.Load()
+		}
+	}
+	return total
+}
+
+func TestMultiAPIMetadataOnePerKey(t *testing.T) {
+	t.Run("one target per HA key", func(t *testing.T) {
+		stubs, apis := newMetadataTargets(5, model.LabelSet{"a": "1"})
+		m := NewMustMultiAPI(apis, model.Time(0), false, nil, 1, false)
+
+		md, err := m.MetadataOnePerKey(context.Background(), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := totalCalls(stubs); got != 1 {
+			t.Fatalf("expected exactly 1 downstream metadata call, got %d", got)
+		}
+		if len(md) != 1 {
+			t.Fatalf("expected metadata from a single target, got %v", md)
+		}
+
+		// For comparison: the fan-out variant hits every target.
+		if _, err := m.Metadata(context.Background(), "", ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := totalCalls(stubs); got != 1+int64(len(stubs)) {
+			t.Fatalf("expected Metadata to fan out to all %d targets, total calls %d", len(stubs), got)
+		}
+	})
+
+	t.Run("rotates across replicas", func(t *testing.T) {
+		stubs, apis := newMetadataTargets(3, model.LabelSet{"a": "1"})
+		m := NewMustMultiAPI(apis, model.Time(0), false, nil, 1, false)
+
+		for i := 0; i < len(stubs); i++ {
+			if _, err := m.MetadataOnePerKey(context.Background(), "", ""); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		}
+		for i, s := range stubs {
+			if got := s.calls.Load(); got != 1 {
+				t.Fatalf("target %d served %d calls; expected each of the 3 replicas to serve exactly 1", i, got)
+			}
+		}
+	})
+
+	t.Run("fails over to another replica", func(t *testing.T) {
+		stubs, apis := newMetadataTargets(3, model.LabelSet{"a": "1"})
+		// The first call starts at index 0, so break that one.
+		stubs[0].err = fmt.Errorf("target is down")
+		m := NewMustMultiAPI(apis, model.Time(0), false, nil, 1, false)
+
+		md, err := m.MetadataOnePerKey(context.Background(), "", "")
+		if err != nil {
+			t.Fatalf("expected failover to a healthy replica, got error: %v", err)
+		}
+		if _, ok := md["metric_1"]; !ok {
+			t.Fatalf("expected metadata from the second replica, got %v", md)
+		}
+		if got := totalCalls(stubs); got != 2 {
+			t.Fatalf("expected 1 failed + 1 successful call, got %d", got)
+		}
+	})
+
+	t.Run("errors when the whole key is down", func(t *testing.T) {
+		stubs, apis := newMetadataTargets(2, model.LabelSet{"a": "1"})
+		for _, s := range stubs {
+			s.err = fmt.Errorf("target is down")
+		}
+		m := NewMustMultiAPI(apis, model.Time(0), false, nil, 1, false)
+
+		if _, err := m.MetadataOnePerKey(context.Background(), "", ""); err == nil {
+			t.Fatal("expected an error when no replica of a key answers")
+		}
+		if got := totalCalls(stubs); got != 2 {
+			t.Fatalf("expected every replica of the key to be tried, got %d calls", got)
+		}
+	})
+
+	t.Run("queries every distinct key and merges", func(t *testing.T) {
+		stubsA, apisA := newMetadataTargets(2, model.LabelSet{"a": "1"})
+		stubsB, apisB := newMetadataTargets(2, model.LabelSet{"a": "2"})
+		// Distinguish the second key's metric names from the first key's.
+		for i, s := range stubsB {
+			s.name = fmt.Sprintf("other_metric_%d", i)
+		}
+		m := NewMustMultiAPI(append(apisA, apisB...), model.Time(0), false, nil, 1, false)
+
+		md, err := m.MetadataOnePerKey(context.Background(), "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := totalCalls(stubsA, stubsB); got != 2 {
+			t.Fatalf("expected 1 call per key (2 total), got %d", got)
+		}
+		if len(md) != 2 {
+			t.Fatalf("expected the two keys' metadata merged, got %v", md)
+		}
+		if _, ok := md["metric_0"]; !ok {
+			t.Fatalf("missing first key's metadata: %v", md)
+		}
+		if _, ok := md["other_metric_0"]; !ok {
+			t.Fatalf("missing second key's metadata: %v", md)
+		}
+	})
+}

--- a/pkg/servergroup/config.go
+++ b/pkg/servergroup/config.go
@@ -520,6 +520,12 @@ type NativeHistogramConfig struct {
 	// of all groups' caches when classifying queries. The cache is
 	// name-keyed (typically <2% of the total metric-name space) so
 	// memory is bounded by histogram-name count, not series cardinality.
+	//
+	// Cost: each refresh pulls a full /api/v1/metadata body (every
+	// metric name, help string and unit) from one target of the group,
+	// not from every replica — but that body can still be tens of MB in
+	// a large deployment, so pick the interval accordingly. Metric
+	// names change on deploys, not on scrapes; minutes, not seconds.
 	MetadataRefresh time.Duration `yaml:"metadata_refresh,omitempty"`
 
 	// AllowLossy controls what happens when a histogram-bearing query

--- a/pkg/servergroup/histogram_cache.go
+++ b/pkg/servergroup/histogram_cache.go
@@ -8,15 +8,24 @@ import (
 
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/sirupsen/logrus"
-
-	"github.com/jacksontj/promxy/pkg/promclient"
 )
+
+// metadataSource is the slice of the server group's client that the cache
+// needs: a metadata fetch that talks to one target per HA key rather than
+// fanning out to every replica. Implemented by *promclient.MultiAPI.
+type metadataSource interface {
+	MetadataOnePerKey(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error)
+}
 
 // histogramMetadataCache holds the set of metric names whose upstream type
 // is HISTOGRAM, refreshed periodically from /api/v1/metadata. It exists so
 // that promxy can route any query referencing a histogram metric via
 // remote_read even when the query doesn't use one of the histogram-only
 // PromQL functions (which the AST walker can detect on its own).
+//
+// Each refresh reads the metadata of a single target per HA key rather than
+// every target: within a key the targets are replicas of each other, so their
+// metadata is the same set of names, and /api/v1/metadata bodies are large.
 //
 // The cache is name-keyed, not series-keyed: a deployment with millions of
 // active series typically has only thousands of distinct metric names, and
@@ -53,7 +62,7 @@ func (c *histogramMetadataCache) Contains(name string) bool {
 // Subsequent calls are no-ops. getAPI is called on each tick to fetch the
 // current API client (which can change as service discovery updates the
 // server group's target set).
-func (c *histogramMetadataCache) start(ctx context.Context, getAPI func() promclient.API, refresh time.Duration, logger *logrus.Entry) {
+func (c *histogramMetadataCache) start(ctx context.Context, getAPI func() metadataSource, refresh time.Duration, logger *logrus.Entry) {
 	if c == nil || refresh <= 0 {
 		return
 	}
@@ -62,7 +71,7 @@ func (c *histogramMetadataCache) start(ctx context.Context, getAPI func() promcl
 	})
 }
 
-func (c *histogramMetadataCache) run(ctx context.Context, getAPI func() promclient.API, refresh time.Duration, logger *logrus.Entry) {
+func (c *histogramMetadataCache) run(ctx context.Context, getAPI func() metadataSource, refresh time.Duration, logger *logrus.Entry) {
 	// One immediate refresh so the first query after startup can already
 	// benefit; the ticker takes over after that.
 	c.refresh(ctx, getAPI(), logger)
@@ -78,7 +87,7 @@ func (c *histogramMetadataCache) run(ctx context.Context, getAPI func() promclie
 	}
 }
 
-func (c *histogramMetadataCache) refresh(ctx context.Context, api promclient.API, logger *logrus.Entry) {
+func (c *histogramMetadataCache) refresh(ctx context.Context, api metadataSource, logger *logrus.Entry) {
 	if api == nil {
 		// Service discovery hasn't populated targets yet. Skip silently;
 		// the next tick will retry. Keep the previous snapshot in place.
@@ -86,7 +95,7 @@ func (c *histogramMetadataCache) refresh(ctx context.Context, api promclient.API
 	}
 	fctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	md, err := api.Metadata(fctx, "", "")
+	md, err := api.MetadataOnePerKey(fctx, "", "")
 	if err != nil {
 		logger.WithError(err).Warn("histogram metadata cache refresh failed; keeping previous snapshot")
 		return

--- a/pkg/servergroup/histogram_cache_refresh_test.go
+++ b/pkg/servergroup/histogram_cache_refresh_test.go
@@ -1,0 +1,223 @@
+package servergroup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/sirupsen/logrus"
+
+	"github.com/jacksontj/promxy/pkg/promclient"
+)
+
+// metadataTarget stands in for one downstream prometheus. It serves a fixed
+// metadata dump and records how many calls (and how many bytes of response) it
+// served, so tests can pin the fan-out of a metadata refresh.
+type metadataTarget struct {
+	md        map[string][]v1.Metadata
+	mdSize    int64 // marshaled size of md, i.e. bytes on the wire per call
+	err       error
+	calls     atomic.Int64
+	bytesSent atomic.Int64
+}
+
+func (t *metadataTarget) Metadata(ctx context.Context, metric, limit string) (map[string][]v1.Metadata, error) {
+	t.calls.Add(1)
+	if t.err != nil {
+		return nil, t.err
+	}
+	t.bytesSent.Add(t.mdSize)
+	return t.md, nil
+}
+
+func (t *metadataTarget) LabelNames(context.Context, []string, time.Time, time.Time) ([]string, v1.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (t *metadataTarget) LabelValues(context.Context, string, []string, time.Time, time.Time) (model.LabelValues, v1.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (t *metadataTarget) Query(context.Context, string, time.Time) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+
+func (t *metadataTarget) QueryRange(context.Context, string, v1.Range) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+
+func (t *metadataTarget) Series(context.Context, []string, time.Time, time.Time) ([]model.LabelSet, v1.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (t *metadataTarget) GetValue(context.Context, time.Time, time.Time, []*labels.Matcher) storage.SeriesSet {
+	return storage.EmptySeriesSet()
+}
+
+func (t *metadataTarget) QueryExemplars(context.Context, string, time.Time, time.Time) ([]v1.ExemplarQueryResult, error) {
+	return nil, nil
+}
+
+// buildMetadata produces a metadata dump of the size a real deployment returns:
+// histograms plus a much larger tail of other types, each with a help string.
+func buildMetadata(names int) map[string][]v1.Metadata {
+	md := make(map[string][]v1.Metadata, names)
+	for i := 0; i < names; i++ {
+		t := v1.MetricTypeCounter
+		if i%50 == 0 {
+			t = v1.MetricTypeHistogram
+		}
+		name := fmt.Sprintf("some_service_subsystem_metric_name_%d", i)
+		md[name] = []v1.Metadata{{
+			Type: t,
+			Help: "Help text for " + name + ", which is typically a full sentence describing the metric.",
+			Unit: "",
+		}}
+	}
+	return md
+}
+
+// newServerGroupMultiAPI wraps targets the way loadTargetGroupMap does: label
+// addition then a per-target error wrap, all behind a MultiAPI.
+func newServerGroupMultiAPI(t *testing.T, targets []*metadataTarget) *promclient.MultiAPI {
+	t.Helper()
+	apis := make([]promclient.API, len(targets))
+	for i, target := range targets {
+		var api promclient.API = &promclient.AddLabelClient{API: target, Labels: model.LabelSet{"sg": "0"}}
+		apis[i] = &promclient.ErrorWrap{A: api, Msg: fmt.Sprintf("error in target=%d", i)}
+	}
+	m, err := promclient.NewMultiAPI(apis, model.Time(0), false, nil, 1, false)
+	if err != nil {
+		t.Fatalf("error building multi api: %v", err)
+	}
+	return m
+}
+
+func newMetadataTargetSet(t *testing.T, count, names int) []*metadataTarget {
+	t.Helper()
+	md := buildMetadata(names)
+	b, err := json.Marshal(md)
+	if err != nil {
+		t.Fatalf("error marshaling metadata: %v", err)
+	}
+	targets := make([]*metadataTarget, count)
+	for i := range targets {
+		// Each replica gets its own copy: MultiAPI's fan-out merge writes into
+		// the first response it gets, so a shared map would be a data race.
+		own := make(map[string][]v1.Metadata, len(md))
+		for k, v := range md {
+			own[k] = v
+		}
+		targets[i] = &metadataTarget{md: own, mdSize: int64(len(b))}
+	}
+	return targets
+}
+
+func testLogger() *logrus.Entry {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return logrus.NewEntry(l)
+}
+
+func totalTargetCalls(targets []*metadataTarget) int64 {
+	var n int64
+	for _, target := range targets {
+		n += target.calls.Load()
+	}
+	return n
+}
+
+func totalTargetBytes(targets []*metadataTarget) int64 {
+	var n int64
+	for _, target := range targets {
+		n += target.bytesSent.Load()
+	}
+	return n
+}
+
+func TestHistogramMetadataCacheRefreshQueriesOneTarget(t *testing.T) {
+	const (
+		targetCount = 20
+		nameCount   = 5000
+	)
+
+	targets := newMetadataTargetSet(t, targetCount, nameCount)
+	api := newServerGroupMultiAPI(t, targets)
+
+	var c histogramMetadataCache
+	c.refresh(context.Background(), api, testLogger())
+
+	if got := totalTargetCalls(targets); got != 1 {
+		t.Fatalf("expected the refresh to query exactly 1 of %d targets, got %d calls", targetCount, got)
+	}
+	if !c.Contains("some_service_subsystem_metric_name_0") {
+		t.Fatal("expected the refresh to populate the histogram name set")
+	}
+	if c.Contains("some_service_subsystem_metric_name_1") {
+		t.Fatal("non-histogram metric leaked into the histogram name set")
+	}
+
+	refreshBytes := totalTargetBytes(targets)
+
+	// Fan-out cost for the same snapshot, for comparison.
+	fanoutTargets := newMetadataTargetSet(t, targetCount, nameCount)
+	fanoutAPI := newServerGroupMultiAPI(t, fanoutTargets)
+	if _, err := fanoutAPI.Metadata(context.Background(), "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fanoutBytes := totalTargetBytes(fanoutTargets)
+
+	t.Logf("metadata bytes per refresh: %d (one target) vs %d (all %d targets)", refreshBytes, fanoutBytes, targetCount)
+	if refreshBytes*int64(targetCount) != fanoutBytes {
+		t.Fatalf("expected the refresh to transfer 1/%d of the fan-out bytes: %d vs %d", targetCount, refreshBytes, fanoutBytes)
+	}
+}
+
+func TestHistogramMetadataCacheRefreshFailsOver(t *testing.T) {
+	t.Run("falls back to a healthy target", func(t *testing.T) {
+		targets := newMetadataTargetSet(t, 3, 100)
+		targets[0].err = fmt.Errorf("connection refused")
+		api := newServerGroupMultiAPI(t, targets)
+
+		var c histogramMetadataCache
+		c.refresh(context.Background(), api, testLogger())
+
+		if !c.Contains("some_service_subsystem_metric_name_0") {
+			t.Fatal("expected the refresh to fail over to a healthy target and populate the cache")
+		}
+		if got := totalTargetCalls(targets); got != 2 {
+			t.Fatalf("expected 1 failed + 1 successful call, got %d", got)
+		}
+	})
+
+	t.Run("keeps the previous snapshot when every target is down", func(t *testing.T) {
+		targets := newMetadataTargetSet(t, 3, 100)
+		api := newServerGroupMultiAPI(t, targets)
+
+		var c histogramMetadataCache
+		c.refresh(context.Background(), api, testLogger())
+		if !c.Contains("some_service_subsystem_metric_name_0") {
+			t.Fatal("expected the first refresh to populate the cache")
+		}
+
+		for _, target := range targets {
+			target.err = fmt.Errorf("connection refused")
+		}
+		c.refresh(context.Background(), api, testLogger())
+
+		if !c.Contains("some_service_subsystem_metric_name_0") {
+			t.Fatal("expected a failed refresh to keep the previous snapshot")
+		}
+		if got := totalTargetCalls(targets); got != 1+3 {
+			t.Fatalf("expected every target to be tried before giving up, got %d calls", got)
+		}
+	})
+}

--- a/pkg/servergroup/servergroup.go
+++ b/pkg/servergroup/servergroup.go
@@ -126,6 +126,11 @@ type ServerGroupState struct {
 	Targets   []string
 	apiClient promclient.API
 
+	// multiAPI is the fan-out client that apiClient is built on top of, kept
+	// unwrapped for the callers that need its per-target view (the histogram
+	// metadata cache, which fetches from one target per HA key).
+	multiAPI *promclient.MultiAPI
+
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 }
@@ -464,6 +469,7 @@ func (s *ServerGroup) loadTargetGroupMap(targetGroupMap map[string][]*targetgrou
 		Targets: targets,
 		// Add error wrap for this specific servergroup
 		apiClient: &promclient.ErrorWrap{apiClient, fmt.Sprintf("error in servergroup ord=%d", cfg.Ordinal)},
+		multiAPI:  apiClient,
 		ctx:       ctx,
 		ctxCancel: ctxCancel,
 	}
@@ -596,12 +602,14 @@ func (s *ServerGroup) ApplyConfig(cfg *Config) error {
 	// spawn duplicate goroutines.
 	s.histogramCache.start(
 		s.ctx,
-		func() promclient.API {
+		func() metadataSource {
 			st := s.State()
-			if st == nil {
+			// Returned explicitly as nil rather than as a typed nil pointer
+			// wrapped in the interface, which the cache can't detect.
+			if st == nil || st.multiAPI == nil {
 				return nil
 			}
-			return st.apiClient
+			return st.multiAPI
 		},
 		cfg.NativeHistogram.MetadataRefresh,
 		logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
## The problem

The native-histogram metadata cache (`native_histogram.metadata_refresh`) refreshed itself with `api.Metadata(ctx, "", "")` on the server group's merged client. That fans out through `MultiAPI` to **every** target: each refresh pulled a complete `/api/v1/metadata` body — every metric name, help string and unit — from every replica, on the refresh interval, just to keep the histogram-typed names. A fleet with 50k metric names and 20 targets moves tens of MB per refresh to build a set of a few thousand strings.

It is opt-in, so nobody pays for it by default — but the price for turning it on was N× larger than it needed to be.

## The change

A promxy server group is a set of HA replicas of each other (the assumption anti-affinity merging is already built on), so one replica's metadata answers for the whole group.

- `MultiAPI.MetadataOnePerKey` queries a **single API per `Key()` fingerprint** — the same grouping `requiredCount` is enforced over — instead of fanning out. The starting member rotates between calls so consecutive refreshes spread across replicas.
- **Failover**: if the chosen member errors, the remaining members of that group are tried in turn. Only when no member of a group answers does the call fail, and the cache then logs and keeps the previous snapshot (unchanged, and still the right behavior for a name-keyed cache whose contents change on deploys, not on scrapes).
- The cache is wired to the unwrapped `*MultiAPI` via a new `multiAPI` field on `ServerGroupState`; the merged `apiClient` is untouched, so query paths are unaffected.
- Config docs (`NativeHistogramConfig.MetadataRefresh` and `cmd/promxy/config.yaml`) now state the per-refresh cost so the interval is chosen with it in mind.

Note: `ErrorWrap`, the outermost per-target wrapper a server group builds, does not forward `Key()`, so in practice every target of a group lands in one fingerprint bucket and a refresh is exactly one request. The per-key grouping keeps the method correct for callers whose members are not all interchangeable.

Not done, deliberately: `/api/v1/metadata` can't filter by type, and `limit` truncates the name space arbitrarily — it would silently drop histogram names from the cache. `MultiAPI.Metadata` has no dedup to lean on; it fans out and merges first-writer-wins.

Behavior change worth flagging: the new path records downstream latency under `call="metadata"` in `server_group_request_duration_seconds`, rather than the `"query"` label the existing (copy-pasted) fan-out path uses.

## Verification

New tests pin the behavior:

- `TestMultiAPIMetadataOnePerKey` — one call per HA key (vs. all targets for `Metadata`), rotation across replicas, failover to a healthy replica, error when a whole key is down, one call per distinct key with merged results.
- `TestHistogramMetadataCacheRefreshQueriesOneTarget` — a refresh through the production wrapper shape (20 targets, 5k metric names) issues exactly 1 downstream call, extracts only histogram names, and transfers 1/20 of the fan-out bytes.
- `TestHistogramMetadataCacheRefreshFailsOver` — falls back to a healthy target, and keeps the previous snapshot when every target is down.

Measured by the test: **973KB per refresh, down from 19.5MB** (5k names, 20 targets).

Negative control (`MetadataOnePerKey` temporarily delegating to the old fan-out `Metadata`):

```
--- FAIL: TestMultiAPIMetadataOnePerKey/one_target_per_HA_key
        expected exactly 1 downstream metadata call, got 5
--- FAIL: TestMultiAPIMetadataOnePerKey/rotates_across_replicas
        target 0 served 3 calls; expected each of the 3 replicas to serve exactly 1
--- FAIL: TestMultiAPIMetadataOnePerKey/fails_over_to_another_replica
        expected 1 failed + 1 successful call, got 3
--- FAIL: TestMultiAPIMetadataOnePerKey/queries_every_distinct_key_and_merges
        expected 1 call per key (2 total), got 4
--- FAIL: TestHistogramMetadataCacheRefreshQueriesOneTarget
        expected the refresh to query exactly 1 of 20 targets, got 20 calls
--- FAIL: TestHistogramMetadataCacheRefreshFailsOver/falls_back_to_a_healthy_target
        expected 1 failed + 1 successful call, got 3
--- FAIL: TestHistogramMetadataCacheRefreshFailsOver/keeps_the_previous_snapshot_when_every_target_is_down
        expected every target to be tried before giving up, got 6 calls
```

`make fmt`, `make imports`, `make static-check` and `make test` (`-race`) all pass.

## Risk

If a server group is *not* actually homogeneous — targets in one group scraping different metrics — the cache now sees only one target's metric names instead of the union. The consequence is bounded: a histogram name known only to an unqueried target is not in the set, so those queries fall back to AST-only detection, which is the pre-cache behavior. Promxy already assumes HA-replica homogeneity within a server group for anti-affinity merging, so this is the same assumption applied to one more place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
