### PR TITLE
refactor(promhttputil)!: drop the dead ValueAddLabelSet

### DIFF
--- a/pkg/promhttputil/merge.go
+++ b/pkg/promhttputil/merge.go
@@ -80,32 +80,6 @@ func (s WarningSet) Warnings() v1.Warnings {
 	return w
 }
 
-// ValueAddLabelSet adds the labelset `l` to the value `a`
-func ValueAddLabelSet(a model.Value, l model.LabelSet) error {
-	switch aTyped := a.(type) {
-	case model.Vector:
-		for _, item := range aTyped {
-			for k, v := range l {
-				item.Metric[k] = v
-			}
-		}
-
-	case model.Matrix:
-		for _, item := range aTyped {
-			// If the current metric has no labels, set them
-			if item.Metric == nil {
-				item.Metric = model.Metric(model.LabelSet(make(map[model.LabelName]model.LabelValue)))
-			}
-			for k, v := range l {
-				item.Metric[k] = v
-			}
-		}
-	}
-
-	return nil
-
-}
-
 // MergeSampleStream merges SampleStreams `a` and `b` with the given
 // antiAffinityBuffer. When combining series from 2 different prometheus
 // hosts we can run into clock-skew / scrape-skew issues (the timestamp


### PR DESCRIPTION
Follow-up to #828, which removed `MergeValues`. `ValueAddLabelSet` is the same `model.Value`-era helper, dead for the same reason: nothing has called it since labels moved onto the per-target `AddLabelClient` wrapper, which builds a new `labels.Labels` rather than mutating a decoded value in place.

Unlike `MergeValues` there is nothing to preserve — it has **no callers at all, not even tests**, so there is no oracle to keep and no coverage to relocate.

I swept the rest of the package for the same shape while I was here; it is the only dead exported non-test function left in `promhttputil`:

```
1  ValueAddLabelSet
6  WarningsConvert
7  MergeSampleStream
11 MatcherToString
```

(counts are non-vendor, non-test references excluding the definition itself)

## Why it is worth removing rather than leaving

It carried the same aliasing hazard `MergeValues` did, and would have been a live bug had anything called it again — the `model.Vector` branch writes straight into `item.Metric`, and a `Vector`'s elements are `*model.Sample`, so it mutates the caller's samples. It also returned an `error` that was unconditionally `nil`.

## Breaking

Removes an exported symbol, hence `!`, matching #828 and `e20e69d1`.

## Testing

`make fmt`, `make imports`, `make static-check`, and `make test` (`-race -mod=vendor -tags netgo,builtinassets ./...`) all pass. No test needed to be changed or deleted, since nothing referenced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
