### PR TITLE
test(promclient): pin the HA quorum that ErrorWrap's missing Key() provides

### DIFF
--- a/pkg/promclient/error_wrap.go
+++ b/pkg/promclient/error_wrap.go
@@ -18,6 +18,18 @@ func (e *ErrorWrap) wrap(err error) error {
 	return nil
 }
 
+// ErrorWrap annotates every error from the wrapped API with Msg.
+//
+// It deliberately does not implement APILabels, and must not be given a Key()
+// that forwards to A. A server group wraps each of its targets in one of these
+// before handing them to NewMultiAPI, so swallowing Key() is what collapses the
+// targets into a single fingerprint bucket. MultiAPI applies requiredCount per
+// bucket, and a server group passes requiredCount=1, so one bucket means "any
+// one replica answering is enough" -- the HA property the whole server group
+// exists to provide. Forwarding Key() would split targets whose discovered
+// labels differ into a bucket each, and requiring one success per bucket means
+// requiring all of them, so a single down replica would fail every query.
+// TestMultiAPIToleratesDownReplica pins this.
 type ErrorWrap struct {
 	A   API
 	Msg string

--- a/pkg/promclient/multi_api_quorum_test.go
+++ b/pkg/promclient/multi_api_quorum_test.go
@@ -1,0 +1,132 @@
+package promclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+var errReplicaDown = errors.New("replica down")
+
+// quorumAPI is a target that either answers or fails. keyed controls whether it
+// exposes a Key(), which is what decides the fingerprint bucket MultiAPI puts
+// it in.
+type quorumAPI struct {
+	API
+
+	key  model.LabelSet
+	down bool
+}
+
+func (q *quorumAPI) LabelValues(ctx context.Context, label string, matchers []string, startTime, endTime time.Time) (model.LabelValues, v1.Warnings, error) {
+	if q.down {
+		return nil, nil, errReplicaDown
+	}
+	return model.LabelValues{"v"}, nil, nil
+}
+
+// keyedAPI exposes a Key(); quorumAPI on its own does not, which is how a
+// target reaches NewMultiAPI in practice (ErrorWrap does not forward Key()).
+type keyedAPI struct{ *quorumAPI }
+
+func (k *keyedAPI) Key() model.LabelSet { return k.key }
+
+// TestMultiAPIToleratesDownReplica pins the HA property a server group exists
+// to provide: with requiredCount=1, one replica answering is enough.
+//
+// The mechanism is easy to break by accident. MultiAPI enforces requiredCount
+// per fingerprint bucket, and a target's bucket comes from Key(). Targets reach
+// NewMultiAPI wrapped in ErrorWrap, which does not implement APILabels, so they
+// all share the zero fingerprint and land in one bucket. Give ErrorWrap a Key()
+// that forwards to the wrapped client and targets with differing discovered
+// labels split into a bucket each -- at which point requiredCount=1 per bucket
+// means every replica must answer.
+func TestMultiAPIToleratesDownReplica(t *testing.T) {
+	newAPIs := func(keyed bool, keys ...model.LabelSet) []API {
+		apis := make([]API, 0, len(keys))
+		for i, k := range keys {
+			q := &quorumAPI{key: k, down: i == 0}
+			if keyed {
+				apis = append(apis, &keyedAPI{q})
+			} else {
+				apis = append(apis, q)
+			}
+		}
+		return apis
+	}
+
+	call := func(t *testing.T, apis []API) error {
+		t.Helper()
+		m, err := NewMultiAPI(apis, model.TimeFromUnix(0), false, nil, 1, false)
+		if err != nil {
+			t.Fatalf("NewMultiAPI: %v", err)
+		}
+		_, _, err = m.LabelValues(context.Background(), "l", nil, time.Now(), time.Now())
+		return err
+	}
+
+	// How targets actually reach MultiAPI today: no Key(), so one bucket.
+	t.Run("no Key on the targets", func(t *testing.T) {
+		err := call(t, newAPIs(false,
+			model.LabelSet{"instance": "a"},
+			model.LabelSet{"instance": "b"},
+		))
+		if err != nil {
+			t.Fatalf("a down replica failed the query: %v", err)
+		}
+	})
+
+	// The arrangement a server group actually builds: each target carries its
+	// own discovered labels and is wrapped in ErrorWrap before reaching
+	// NewMultiAPI. This is the subtest that fails if ErrorWrap ever forwards
+	// Key().
+	t.Run("targets behind ErrorWrap, as a server group builds them", func(t *testing.T) {
+		var apis []API
+		for i, k := range []model.LabelSet{{"instance": "a"}, {"instance": "b"}} {
+			target := &keyedAPI{&quorumAPI{key: k, down: i == 0}}
+			apis = append(apis, &ErrorWrap{A: target, Msg: "error in target"})
+		}
+		if err := call(t, apis); err != nil {
+			t.Fatalf("a down replica failed the query: %v", err)
+		}
+	})
+
+	// Same, when the targets do share a key.
+	t.Run("identical keys", func(t *testing.T) {
+		err := call(t, newAPIs(true,
+			model.LabelSet{"job": "sg"},
+			model.LabelSet{"job": "sg"},
+		))
+		if err != nil {
+			t.Fatalf("a down replica failed the query: %v", err)
+		}
+	})
+
+	// The failure mode the ErrorWrap comment warns about: distinct keys put
+	// each replica in its own bucket, and requiredCount is applied per bucket.
+	// This is asserted so that anyone who "fixes" ErrorWrap to forward Key()
+	// sees the consequence spelled out rather than a mysterious HA regression.
+	t.Run("distinct keys remove all fault tolerance", func(t *testing.T) {
+		err := call(t, newAPIs(true,
+			model.LabelSet{"instance": "a"},
+			model.LabelSet{"instance": "b"},
+		))
+		if !errors.Is(err, errReplicaDown) {
+			t.Fatalf("expected the down replica to fail the whole query, got %v", err)
+		}
+	})
+}
+
+// TestErrorWrapDoesNotExposeKey guards the specific edit that would break
+// TestMultiAPIToleratesDownReplica: giving ErrorWrap a Key(). See the type's
+// doc comment for why it must not have one.
+func TestErrorWrapDoesNotExposeKey(t *testing.T) {
+	var api API = &ErrorWrap{A: &quorumAPI{key: model.LabelSet{"instance": "a"}}, Msg: "target"}
+	if _, ok := api.(APILabels); ok {
+		t.Fatal("ErrorWrap implements APILabels; this collapses server group HA -- see the ErrorWrap doc comment")
+	}
+}


### PR DESCRIPTION
**This started as a bug report and ended as a regression guard. No behavior changes.**

While reviewing #830 I noticed `ErrorWrap` does not implement `APILabels`, and since it is the outermost per-target wrapper a server group builds, `NewMultiAPI`'s type assertion always fails — so MultiAPI's per-key fingerprint grouping is inert in production. I flagged that as something to fix.

It is not a bug. It is what makes HA work, and "fixing" it would break every server group with more than one replica.

## Why

`MultiAPI` enforces `requiredCount` **per fingerprint bucket**:

```go
// Verify that we hit the requiredCount for all of the buckets
for k := range outstandingRequests {
    if successMap[k] < m.requiredCount {
        return nil, warnings.Warnings(), errors.Wrap(lastError, "Unable to fetch from downstream servers")
    }
```

A target's bucket comes from `Key()`. A server group wraps each target in `ErrorWrap` and calls `NewMultiAPI(..., requiredCount=1)`. `ErrorWrap` has no `Key()`, so every target gets the zero fingerprint and they share one bucket — "any one replica answering is enough".

Forward `Key()` and targets split by their discovered labels. `AddLabelClient`'s key is the target's non-reserved labels merged with the group's (`modelLabelSet.Merge(cfg.Labels)`), so it differs per target whenever SD or relabeling attaches anything beyond the reserved `__`-prefixed set. One bucket per target × `requiredCount=1` per bucket = **every replica must answer**, and a single down replica fails every query.

Measured rather than reasoned. With the forwarding added, the new ErrorWrap subtest fails:

```
--- FAIL: TestMultiAPIToleratesDownReplica/targets_behind_ErrorWrap,_as_a_server_group_builds_them
    a down replica failed the query: error in target: replica down
--- FAIL: TestErrorWrapDoesNotExposeKey
    ErrorWrap implements APILabels; this collapses server group HA -- see the ErrorWrap doc comment
```

## What this PR does

Documents the invariant on `ErrorWrap` and adds two guards, so the next person who spots the inertness learns why before shipping the change:

- **`TestMultiAPIToleratesDownReplica`** — the "targets behind ErrorWrap" case builds the arrangement a server group actually builds and asserts a down replica is survivable. A sibling case asserts the distinct-key arrangement removes fault tolerance, so the consequence is stated outright rather than left implicit.
- **`TestErrorWrapDoesNotExposeKey`** — fails on the exact edit, with a message pointing at the doc comment.

## Worth knowing separately

`Key()` appears to be universally nil in promxy's own wiring: `ServerGroup` does not implement it either, so the top-level `NewMultiAPI(apis, ..., requiredCount=len(apis))` in proxystorage also collapses to one bucket — which is again the intent there (every server group holds distinct data, so all must answer). The `APILabels` machinery is therefore dead weight in practice, but it is load-bearing dead weight in the sense above, and removing it is a much larger change than I want to bundle here. Flagging rather than touching it.

## Testing

`make fmt`, `make imports`, `make static-check`, and `make test` (`-race -mod=vendor -tags netgo,builtinassets ./...`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
