### PR TITLE
fix(promapi): reject a vector entry with no value or histogram

### DIFF
--- a/pkg/promapi/decode.go
+++ b/pkg/promapi/decode.go
@@ -245,6 +245,12 @@ func decodeVector(iter *jsoniter.Iterator) []storage.Series {
 				iter.Skip()
 			}
 		}
+		// A nil sample would only fail once the series is iterated -- far from
+		// the response that produced it -- so reject the body here instead.
+		if sample == nil {
+			iter.ReportError("decodeVector", `result entry has neither a "value" nor a "histogram"`)
+			return nil
+		}
 		b.Sort()
 		out = append(out, NewSeries(b.Labels(), []chunks.Sample{sample}))
 	}

--- a/pkg/promapi/decode_test.go
+++ b/pkg/promapi/decode_test.go
@@ -254,3 +254,74 @@ func BenchmarkDecodeModelValueStdlib(b *testing.B) {
 		}
 	}
 }
+
+// TestDecodeVectorMissingSample covers vector entries carrying neither a
+// "value" nor a "histogram". Such an entry must surface as a decode error: the
+// series it would otherwise produce holds a nil chunks.Sample, which panics the
+// moment anything iterates it.
+func TestDecodeVectorMissingSample(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "only_metric",
+			body: `{"status":"success","data":{"resultType":"vector","result":[` +
+				`{"metric":{"__name__":"foo"}}]}}`,
+		},
+		{
+			name: "null_entry",
+			body: `{"status":"success","data":{"resultType":"vector","result":[null]}}`,
+		},
+		{
+			name: "matrix_shaped_entry",
+			body: `{"status":"success","data":{"resultType":"vector","result":[` +
+				`{"metric":{"__name__":"foo"},"values":[[100.000,"1"]]}]}}`,
+		},
+		{
+			// The whole response is rejected rather than silently truncated to
+			// the entries that happened to be well-formed.
+			name: "one_bad_entry_among_good",
+			body: `{"status":"success","data":{"resultType":"vector","result":[` +
+				`{"metric":{"__name__":"up","job":"a"},"value":[100.000,"1"]},` +
+				`{"metric":{"__name__":"up","job":"b"}}]}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ss := DecodeSeriesSet([]byte(tc.body))
+			n, samples := 0, 0
+			for ss.Next() {
+				n++
+				// Iterating is what panics on a nil sample.
+				it := ss.At().Iterator(nil)
+				for it.Next() != chunkenc.ValNone {
+					samples++
+				}
+			}
+			if n != 0 || samples != 0 {
+				t.Errorf("expected no series from a malformed response, got %d series / %d samples", n, samples)
+			}
+			if ss.Err() == nil {
+				t.Fatal("expected a decode error, got nil")
+			}
+			if !strings.Contains(ss.Err().Error(), `neither a "value" nor a "histogram"`) {
+				t.Fatalf("error does not name the missing fields: %v", ss.Err())
+			}
+		})
+	}
+}
+
+// TestDecodeMatrixMissingSamples pins the matrix counterpart: an entry with
+// neither "values" nor "histograms" yields a sample-less series rather than an
+// error. No nil sample is ever built there, and a caller can tell an empty
+// series from real data -- which is also what prometheus/common's
+// model.SampleStream decoding produces for the same body.
+func TestDecodeMatrixMissingSamples(t *testing.T) {
+	body := `{"status":"success","data":{"resultType":"matrix","result":[` +
+		`{"metric":{"__name__":"foo"}}]}}`
+	got := dumpSeriesSet(t, DecodeSeriesSet([]byte(body)))
+	if len(got) != 1 || got[`{__name__="foo"}`] != "" {
+		t.Fatalf("expected one sample-less series, got %v", got)
+	}
+}


### PR DESCRIPTION
Re-targets #827 at master. That PR merged into #816's branch, and #816 was then closed, so this fix never reached master — it has been sitting unmerged on a dead branch. Same commit, cherry-picked; it applies cleanly and does not depend on anything from #816.

## The bug

`decodeVector` left `sample` nil when a result entry carried neither a `"value"` nor a `"histogram"` key, and appended `[]chunks.Sample{nil}` anyway. Nothing failed at decode time — `DecodeSeriesSet` returned a SeriesSet with a nil `Err()` and a series whose single sample was nil. The dereference only fired later, when something iterated it, inside the PromQL engine and several layers from the response that caused it.

`"result":[null]` hits the same path: jsoniter's `ReadObject` consumes the null and returns `""` immediately, so no key is ever seen.

Blast radius is contained but opaque: the engine's `recover()` catches the `runtime.Error` and turns it into an `unexpected error` 500 plus a stack-trace log, rather than a decode error naming the bad field. `recoverAPI` would not help — it is test-only, and the panic is lazy, firing on iteration rather than on the client call.

## The fix

Report through `iter.ReportError`, as the other decode failures in this file do, and return no series so a nil sample cannot escape the decoder even if a future caller ignores `iter.Error`.

Rejecting the whole response rather than skipping the bad entry is deliberate: a truncated vector is indistinguishable from a genuinely smaller result, and promxy merges that partial answer with other server groups' data — silent truncation would produce quietly wrong query results.

## Divergence from upstream, on purpose

`prometheus/common`'s `model.Sample.UnmarshalJSON` accepts the same body and yields a **fabricated** sample of value 0 at timestamp 0. It neither errors nor skips. Verified empirically against the vendored copy.

Given promxy also fronts VictoriaMetrics/Mimir/Thanos, divergence from the reference decoder deserves a deliberate call, and this is one: invented data is a worse outcome than a surfaced error for a body no conformant API should send. Well-formed bodies decode identically.

## Not affected, and pinned by tests

- `decodeMatrix` — an entry with neither `"values"` nor `"histograms"` produces a sample-less series, never a nil sample, matching what `model.SampleStream` decoding gives for that body.
- The `scalar` path — always constructs a `floatSample`, and already reports malformed input through the iterator.

## Testing

Negative control re-run **on this base** (not just on #816's), since the original was written against that branch's rewritten `decodeVector`:

```
--- FAIL: TestDecodeVectorMissingSample/only_metric
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40]
```

`make fmt`, `make imports`, `make static-check`, and `make test` (`-race -mod=vendor -tags netgo,builtinassets ./...`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCScW9ZoyzjdxKaKYQNQY4
